### PR TITLE
Add proptype support for JSX, react node, as label

### DIFF
--- a/packages/uniforms/src/components/fields/BaseField.js
+++ b/packages/uniforms/src/components/fields/BaseField.js
@@ -12,7 +12,7 @@ export default class BaseField extends Component {
         name:     PropTypes.string,
         disabled: PropTypes.bool,
 
-        label:       PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+        label:       PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.node]),
         placeholder: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
     };
 


### PR DESCRIPTION
I split this off of PR #38 - so it was easier to merge (seems like a super-simple upstream)

(In my case, I'm using an icon in a label)