### PR TITLE
SemanticUI: Add support for input icons

### DIFF
--- a/packages/uniforms-semantic/src/components/fields/DateField.js
+++ b/packages/uniforms-semantic/src/components/fields/DateField.js
@@ -23,6 +23,9 @@ const Date_ = ({
     findError,    // eslint-disable-line no-unused-vars
     findField,    // eslint-disable-line no-unused-vars
     findValue,    // eslint-disable-line no-unused-vars
+    icon,
+    iconLeft,
+    iconProps,
     id,
     label,
     max,
@@ -42,16 +45,22 @@ const Date_ = ({
             </label>
         )}
 
-        <input
-            disabled={disabled}
-            id={id}
-            max={dateFormat(max)}
-            min={dateFormat(min)}
-            name={name}
-            onChange={event => dateParse(event.target.valueAsNumber, onChange)}
-            type="datetime-local"
-            value={dateFormat(value)}
-        />
+        <section className={classnames('ui', {left: iconLeft, icon: icon || iconLeft}, 'input')}>
+            <input
+                disabled={disabled}
+                id={id}
+                max={dateFormat(max)}
+                min={dateFormat(min)}
+                name={name}
+                onChange={event => dateParse(event.target.valueAsNumber, onChange)}
+                type="datetime-local"
+                value={dateFormat(value)}
+            />
+
+            {(icon || iconLeft) && (
+                <i className={`${icon || iconLeft} icon`} {...iconProps} />
+            )}
+        </section>
     </section>
 ;
 

--- a/packages/uniforms-semantic/src/components/fields/NumField.js
+++ b/packages/uniforms-semantic/src/components/fields/NumField.js
@@ -16,6 +16,9 @@ const Num = ({
     findError,    // eslint-disable-line no-unused-vars
     findField,    // eslint-disable-line no-unused-vars
     findValue,    // eslint-disable-line no-unused-vars
+    icon,
+    iconLeft,
+    iconProps,
     id,
     label,
     max,
@@ -35,18 +38,24 @@ const Num = ({
             </label>
         )}
 
-        <input
-            disabled={disabled}
-            id={id}
-            max={max}
-            min={min}
-            name={name}
-            onChange={event => onChange((decimal ? parseFloat : parseInt)(event.target.value) || undefined)}
-            placeholder={placeholder}
-            step={decimal ? 0.01 : 1}
-            type="number"
-            value={value === undefined ? null : value}
-        />
+        <section className={classnames('ui', {left: iconLeft, icon: icon || iconLeft}, 'input')}>
+            <input
+                disabled={disabled}
+                id={id}
+                max={max}
+                min={min}
+                name={name}
+                onChange={event => onChange((decimal ? parseFloat : parseInt)(event.target.value) || undefined)}
+                placeholder={placeholder}
+                step={decimal ? 0.01 : 1}
+                type="number"
+                value={value === undefined ? null : value}
+            />
+
+            {(icon || iconLeft) && (
+                <i className={`${icon || iconLeft} icon`} {...iconProps} />
+            )}
+        </section>
     </section>
 ;
 

--- a/packages/uniforms-semantic/src/components/fields/TextField.js
+++ b/packages/uniforms-semantic/src/components/fields/TextField.js
@@ -17,6 +17,7 @@ const Text = ({
     findValue,    // eslint-disable-line no-unused-vars
     icon,
     iconLeft,
+    iconProps,
     id,
     label,
     name,
@@ -28,36 +29,29 @@ const Text = ({
     value,
     ...props
 }) =>
-    <section
-        className={classnames(className, {
-            ui: icon || iconLeft,
-            disabled,
-            error,
-            required,
-            left: iconLeft,
-            'icon input': icon || iconLeft
-        }, 'field')}
-        {...props}
-    >
+    <section className={classnames(className, {disabled, error, required}, 'field')} {...props}>
         {label && (
             <label htmlFor={id}>
                 {label}
             </label>
         )}
 
-        <input
-            disabled={disabled}
-            id={id}
-            name={name}
-            onChange={event => onChange(event.target.value)}
-            placeholder={placeholder}
-            type={type || 'text'}
-            value={value}
-        />
+        <section className={classnames('ui', {left: iconLeft, icon: icon || iconLeft}, 'input')}>
 
-        {(icon || iconLeft) && (
-            <i className={`${icon || iconLeft} icon`} />
-        )}
+            <input
+                disabled={disabled}
+                id={id}
+                name={name}
+                onChange={event => onChange(event.target.value)}
+                placeholder={placeholder}
+                type={type || 'text'}
+                value={value}
+            />
+
+            {(icon || iconLeft) && (
+                <i className={`${icon || iconLeft} icon`} {...(iconProps || {})} />
+            )}
+        </section>
     </section>
 ;
 

--- a/packages/uniforms-semantic/src/components/fields/TextField.js
+++ b/packages/uniforms-semantic/src/components/fields/TextField.js
@@ -37,7 +37,6 @@ const Text = ({
         )}
 
         <section className={classnames('ui', {left: iconLeft, icon: icon || iconLeft}, 'input')}>
-
             <input
                 disabled={disabled}
                 id={id}

--- a/packages/uniforms-semantic/src/components/fields/TextField.js
+++ b/packages/uniforms-semantic/src/components/fields/TextField.js
@@ -49,7 +49,7 @@ const Text = ({
             />
 
             {(icon || iconLeft) && (
-                <i className={`${icon || iconLeft} icon`} {...(iconProps || {})} />
+                <i className={`${icon || iconLeft} icon`} {...iconProps} />
             )}
         </section>
     </section>

--- a/packages/uniforms-semantic/src/components/fields/TextField.js
+++ b/packages/uniforms-semantic/src/components/fields/TextField.js
@@ -15,6 +15,8 @@ const Text = ({
     findError,    // eslint-disable-line no-unused-vars
     findField,    // eslint-disable-line no-unused-vars
     findValue,    // eslint-disable-line no-unused-vars
+    icon,
+    iconLeft,
     id,
     label,
     name,
@@ -26,7 +28,17 @@ const Text = ({
     value,
     ...props
 }) =>
-    <section className={classnames(className, {disabled, error, required}, 'field')} {...props}>
+    <section
+        className={classnames(className, {
+            ui: icon || iconLeft,
+            disabled,
+            error,
+            required,
+            left: iconLeft,
+            'icon input': icon || iconLeft
+        }, 'field')}
+        {...props}
+    >
         {label && (
             <label htmlFor={id}>
                 {label}
@@ -42,6 +54,10 @@ const Text = ({
             type={type || 'text'}
             value={value}
         />
+
+        {(icon || iconLeft) && (
+            <i className={`${icon || iconLeft} icon`} />
+        )}
     </section>
 ;
 

--- a/packages/uniforms-semantic/test/combined.js
+++ b/packages/uniforms-semantic/test/combined.js
@@ -59,7 +59,9 @@ describe('Everything', () => {
         'x28':     {...base,               __type__: String, component: ErrorField},
         'x31':     {...base,               __type__: String, allowedValues, checkboxes, component: SelectField},
         'x32':     {...base, id: 'x32',    __type__: String, component: HiddenField},
-        'x33':     {...base, id: 'x33',    __type__: String, component: HiddenField, value: undefined}
+        'x33':     {...base, id: 'x33',    __type__: String, component: HiddenField, value: undefined},
+        'x34':     {...base, id: 'x34',    __type__: String, icon: 'user'},
+        'x35':     {...base, id: 'x35',    __type__: String, iconLeft: 'search'}
     };
 
     const bridge = {

--- a/packages/uniforms-semantic/test/combined.js
+++ b/packages/uniforms-semantic/test/combined.js
@@ -61,7 +61,11 @@ describe('Everything', () => {
         'x32':     {...base, id: 'x32',    __type__: String, component: HiddenField},
         'x33':     {...base, id: 'x33',    __type__: String, component: HiddenField, value: undefined},
         'x34':     {...base, id: 'x34',    __type__: String, icon: 'user'},
-        'x35':     {...base, id: 'x35',    __type__: String, iconLeft: 'search'}
+        'x35':     {...base, id: 'x35',    __type__: String, iconLeft: 'user'},
+        'x36':     {...base, id: 'x36',    __type__: Date, icon: 'user'},
+        'x37':     {...base, id: 'x37',    __type__: Date, iconLeft: 'user'},
+        'x38':     {...base, id: 'x38',    __type__: Number, icon: 'user'},
+        'x39':     {...base, id: 'x39',    __type__: Number, iconLeft: 'user'}
     };
 
     const bridge = {


### PR DESCRIPTION
Adds ability to use icons in `TextField` component.

Example usage:
```javascript
<TextField name="username" icon="user" />
<TextField name="query" iconLeft="search" />
```
There could be only one icon, and `icon` take precedence before `iconLeft`.

I could also add support for [pointer events](http://semantic-ui.com/elements/input.html#icon) if you think it would useful:
```javascript
<TextField name="username" icon="add user" onIconClick={() => {}} />
```

One problem I'm aware of is that adding `ui icon input` classes change the input width.
This could be solved by adding `fluid` class either by `TextField` itself (IMHO bad idea) or end user:
```javascript
<TextField name="username" className="fluid" icon="user" />
```