### PR TITLE
An idea for `showInlineError` Boolean

### DIFF
--- a/packages/uniforms-bootstrap3/src/components/fields/FormGroup.js
+++ b/packages/uniforms-bootstrap3/src/components/fields/FormGroup.js
@@ -4,7 +4,10 @@ import classnames from 'classnames';
 import gridClassName from '../../lib/gridClassName';
 
 const makeHelp = (help, helpClassName) => help && (
-    <span className={helpClassName || 'text-muted'}>
+    <span className={classnames(
+        'help-block',
+        helpClassName || 'text-muted'
+    )}>
         {help}
     </span>
 );
@@ -21,7 +24,8 @@ const FormGroup = ({
     id,
     label,             // string label (or false)
     required,
-    wrapClassName      // class name for the section wrapping the input(s)
+    wrapClassName,     // class name for the section wrapping the input(s)
+    showInlineError    // boolean, if true, show <span.help-text> with error message
 }) =>
     <section
         className={classnames(
@@ -46,11 +50,13 @@ const FormGroup = ({
             <section className={classnames(wrapClassName, gridClassName(grid, 'input'))}>
                 {children}
                 {makeHelp(help, helpClassName)}
+                {error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
             </section>
         )}
 
         {!grid && !wrapClassName && children}
         {!grid && !wrapClassName && makeHelp(help, helpClassName)}
+        {!grid && !wrapClassName && error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
     </section>
 ;
 

--- a/packages/uniforms-bootstrap3/src/components/fields/FormGroup.js
+++ b/packages/uniforms-bootstrap3/src/components/fields/FormGroup.js
@@ -17,6 +17,7 @@ const FormGroup = ({
     className,         // class name for the whole .form-group
     disabled,          // boolean, if true, show fields as disabled
     error,             // error validation response
+    errorMessage,      // errorMessage string of error
     feedbackable,      // only some input types support feedback icons
     grid,              // grid is either a int [1-11] or object {xs:6,sm:4,md:2}
     help,              // help text
@@ -50,13 +51,13 @@ const FormGroup = ({
             <section className={classnames(wrapClassName, gridClassName(grid, 'input'))}>
                 {children}
                 {makeHelp(help, helpClassName)}
-                {error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
+                {errorMessage && showInlineError ? makeHelp(errorMessage, 'text-help-error') : ''}
             </section>
         )}
 
         {!grid && !wrapClassName && children}
         {!grid && !wrapClassName && makeHelp(help, helpClassName)}
-        {!grid && !wrapClassName && error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
+        {!grid && !wrapClassName && errorMessage && showInlineError ? makeHelp(errorMessage, 'text-help-error') : ''}
     </section>
 ;
 

--- a/packages/uniforms-bootstrap4/src/components/fields/FormGroup.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/FormGroup.js
@@ -17,6 +17,7 @@ const FormGroup = ({
     className,         // class name for the whole .form-group
     disabled,          // boolean, if true, show fields as disabled
     error,             // error validation response
+    errorMessage,      // errorMessage string of error
     grid,              // grid is either a int [1-11] or object {xs:6,sm:4,md:2}
     help,              // help text
     helpClassName,     // class name for the help text (default: 'text-muted')
@@ -45,13 +46,13 @@ const FormGroup = ({
             <section className={classnames(wrapClassName, gridClassName(grid, 'input'))}>
                 {children}
                 {makeHelp(help, helpClassName)}
-                {error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
+                {errorMessage && showInlineError ? makeHelp(errorMessage, 'text-help-error') : ''}
             </section>
         )}
 
         {!grid && !wrapClassName && children}
         {!grid && !wrapClassName && makeHelp(help, helpClassName)}
-        {!grid && !wrapClassName && error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
+        {!grid && !wrapClassName && errorMessage && showInlineError ? makeHelp(errorMessage, 'text-help-error') : ''}
     </section>
 ;
 

--- a/packages/uniforms-bootstrap4/src/components/fields/FormGroup.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/FormGroup.js
@@ -20,7 +20,8 @@ const FormGroup = ({
     id,
     label,             // string label (or false)
     required,
-    wrapClassName      // class name for the section wrapping the input(s)
+    wrapClassName,     // class name for the section wrapping the input(s)
+    showError          // boolean, if true, show <span.help-text> with error message
 }) =>
     <section
         className={classnames({
@@ -41,11 +42,13 @@ const FormGroup = ({
             <section className={classnames(wrapClassName, gridClassName(grid, 'input'))}>
                 {children}
                 {makeHelp(help, helpClassName)}
+                {error && showError ? makeHelp(error, 'text-help') : ''}
             </section>
         )}
 
         {!grid && !wrapClassName && children}
         {!grid && !wrapClassName && makeHelp(help, helpClassName)}
+        {!grid && !wrapClassName && error && showError ? makeHelp(error, 'text-help') : ''}
     </section>
 ;
 

--- a/packages/uniforms-bootstrap4/src/components/fields/FormGroup.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/FormGroup.js
@@ -4,7 +4,10 @@ import classnames from 'classnames';
 import gridClassName from '../../lib/gridClassName';
 
 const makeHelp = (help, helpClassName) => help && (
-    <span className={helpClassName || 'text-muted'}>
+    <span className={classnames(
+        'text-help',
+        helpClassName || 'text-muted'
+    )}>
         {help}
     </span>
 );
@@ -21,7 +24,7 @@ const FormGroup = ({
     label,             // string label (or false)
     required,
     wrapClassName,     // class name for the section wrapping the input(s)
-    showError          // boolean, if true, show <span.help-text> with error message
+    showInlineError    // boolean, if true, show <span.help-text> with error message
 }) =>
     <section
         className={classnames({
@@ -42,13 +45,13 @@ const FormGroup = ({
             <section className={classnames(wrapClassName, gridClassName(grid, 'input'))}>
                 {children}
                 {makeHelp(help, helpClassName)}
-                {error && showError ? makeHelp(error, 'text-help') : ''}
+                {error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
             </section>
         )}
 
         {!grid && !wrapClassName && children}
         {!grid && !wrapClassName && makeHelp(help, helpClassName)}
-        {!grid && !wrapClassName && error && showError ? makeHelp(error, 'text-help') : ''}
+        {!grid && !wrapClassName && error && showInlineError ? makeHelp(error, 'text-help-error') : ''}
     </section>
 ;
 


### PR DESCRIPTION
If true, we could include the error message as a text block with the input form.

This seems like a very useful option,
especially for forms where the errors are not rendered.