### PR TITLE
Enable SimpleSchema2Bridge with simpl-schema package

### DIFF
--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -100,6 +100,7 @@
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.4.0",
     "lodash.set": "^4.3.2",
-    "lodash.xorwith": "^4.5.0"
+    "lodash.xorwith": "^4.5.0",
+    "simpl-schema": "0.0.3"
   }
 }

--- a/packages/uniforms/src/bridges/SimpleSchema2Bridge.js
+++ b/packages/uniforms/src/bridges/SimpleSchema2Bridge.js
@@ -31,8 +31,7 @@ try {
     );
 } catch (_) { /* Ignore it. */ }
 
-// export default class SimpleSchema2Bridge extends Bridge {
-export class SimpleSchema2Bridge extends Bridge {
+export default class SimpleSchema2Bridge extends Bridge {
     static check (schema) {
         return SimpleSchema && (
             schema &&


### PR DESCRIPTION
Some fixes required to get the new SimpleSchema2 bridge working after updating to [v1.1.1](https://github.com/vazco/uniforms/tree/v1.1.1)