### PR TITLE
custom addIcon and removeIcon for ListFields for bootstrap-4

### DIFF
--- a/packages/uniforms-bootstrap4/src/components/fields/ListAddField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListAddField.js
@@ -4,11 +4,11 @@ import {connectField}   from 'uniforms';
 import {filterDOMProps} from 'uniforms';
 
 const ListAdd = ({
+    addIcon,
     className,
     disabled,
     parent,
     value,
-    addIcon = (<i className="octicon octicon-plus" />),
     ...props
 }) => {
     const limitNotReached = !disabled && !(parent.maxCount <= parent.value.length);
@@ -22,6 +22,10 @@ const ListAdd = ({
             {addIcon}
         </section>
     );
+};
+
+ListAdd.defaultProps = {
+    addIcon: (<i className="octicon octicon-plus" />),
 };
 
 export default connectField(ListAdd, {includeParent: true, initialValue: false});

--- a/packages/uniforms-bootstrap4/src/components/fields/ListAddField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListAddField.js
@@ -8,6 +8,7 @@ const ListAdd = ({
     disabled,
     parent,
     value,
+    addIcon = (<i className="octicon octicon-plus" />),
     ...props
 }) => {
     const limitNotReached = !disabled && !(parent.maxCount <= parent.value.length);
@@ -18,8 +19,7 @@ const ListAdd = ({
             onClick={() => limitNotReached && parent.onChange(parent.value.concat([value]))}
             {...filterDOMProps(props)}
         >
-            {/* TODO: configure to alternate icon */}
-            <i className="octicon octicon-plus" />
+            {addIcon}
         </section>
     );
 };

--- a/packages/uniforms-bootstrap4/src/components/fields/ListAddField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListAddField.js
@@ -25,7 +25,7 @@ const ListAdd = ({
 };
 
 ListAdd.defaultProps = {
-    addIcon: (<i className="octicon octicon-plus" />),
+    addIcon: <i className="octicon octicon-plus" />
 };
 
 export default connectField(ListAdd, {includeParent: true, initialValue: false});

--- a/packages/uniforms-bootstrap4/src/components/fields/ListDelField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListDelField.js
@@ -8,7 +8,7 @@ const ListDel = ({
     disabled,
     name,
     parent,
-    removeIcon = (<i className="octicon octicon-dash" />),
+    removeIcon,
     ...props
 }) => {
     const fieldIndex      = +name.slice(1 + name.lastIndexOf('.'));
@@ -26,6 +26,10 @@ const ListDel = ({
             {removeIcon}
         </span>
    );
+};
+
+ListDel.defaultProps = {
+    removeIcon: (<i className="octicon octicon-dash" />),
 };
 
 export default connectField(ListDel, {includeParent: true, initialValue: false});

--- a/packages/uniforms-bootstrap4/src/components/fields/ListDelField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListDelField.js
@@ -8,6 +8,7 @@ const ListDel = ({
     disabled,
     name,
     parent,
+    removeIcon = (<i className="octicon octicon-dash" />),
     ...props
 }) => {
     const fieldIndex      = +name.slice(1 + name.lastIndexOf('.'));
@@ -22,8 +23,7 @@ const ListDel = ({
             )}
             {...filterDOMProps(props)}
         >
-            {/* TODO: configure to alternate icon */}
-            <i className="octicon octicon-dash" />
+            {removeIcon}
         </span>
    );
 };

--- a/packages/uniforms-bootstrap4/src/components/fields/ListDelField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListDelField.js
@@ -29,7 +29,7 @@ const ListDel = ({
 };
 
 ListDel.defaultProps = {
-    removeIcon: (<i className="octicon octicon-dash" />),
+    removeIcon: <i className="octicon octicon-dash" />
 };
 
 export default connectField(ListDel, {includeParent: true, initialValue: false});

--- a/packages/uniforms-bootstrap4/src/components/fields/ListField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListField.js
@@ -9,15 +9,15 @@ import ListAddField  from './ListAddField';
 import ListItemField from './ListItemField';
 
 const List = ({
+    addIcon,
     children,
     className,
     initialCount,
     itemProps,
     label,
     name,
-    value,
-    addIcon,
     removeIcon,
+    value,
     ...props
 }) =>
     <section className={classnames('card', className)} {...filterDOMProps(props)}>

--- a/packages/uniforms-bootstrap4/src/components/fields/ListField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListField.js
@@ -16,6 +16,8 @@ const List = ({
     label,
     name,
     value,
+    addIcon,
+    removeIcon,
     ...props
 }) =>
     <section className={classnames('card', className)} {...filterDOMProps(props)}>
@@ -26,7 +28,7 @@ const List = ({
                         {label}&nbsp;
                     </label>
 
-                    <ListAddField name={`${name}.$`} initialCount={initialCount} />
+                    <ListAddField name={`${name}.$`} initialCount={initialCount} addIcon={addIcon} />
                 </section>
             )}
 
@@ -36,13 +38,21 @@ const List = ({
                            React.cloneElement(child, {
                                key: index,
                                label: null,
-                               name: joinName(name, child.props.name && child.props.name.replace('$', index))
+                               name: joinName(name, child.props.name && child.props.name.replace('$', index)),
+                               removeIcon
                            })
                       )
                  )
             ) : (
                 value.map((item, index) =>
-                    <ListItemField key={index} label={null} name={joinName(name, index)} {...itemProps} />
+
+                    <ListItemField
+                        key={index}
+                        label={null}
+                        name={joinName(name, index)}
+                        removeIcon={removeIcon}
+                        {...itemProps}
+                    />
                 )
             )}
         </section>

--- a/packages/uniforms-bootstrap4/src/components/fields/ListItemField.js
+++ b/packages/uniforms-bootstrap4/src/components/fields/ListItemField.js
@@ -9,7 +9,7 @@ import ListDelField from './ListDelField';
 const ListItem = props =>
     <section className="row">
         <section className="col-xs-1">
-            <ListDelField name={props.name} />
+            <ListDelField name={props.name} removeIcon={props.removeIcon} />
         </section>
 
         {props.children ? (


### PR DESCRIPTION
Add ability to include custom add / remove icons for ListFields.

This can be implemented in either AutoField or by using ListField.

Example AutoField:
```
<AutoField
  name="athletics.otherSports"
  addIcon={(<i className="fa fa-add-circle" />)}
  removeIcon={(<i className="fa fa-close-circle" />)}
/>
```

Example ListField:
```
<ListField
  name="athletics.otherSports"
  addIcon={(<i className="fa fa-add-circle" />)}
  removeIcon={(<i className="fa fa-close-circle" />)}
>
  <ListItemField name="$">
    <NestField>
      <TextField name="sportName" className="col-md-6" />
      <TextField name="yearsParticipated" className="col-md-6" />
    </NestField>
  </ListItemField>
</ListField>
```