### PR TITLE
reset sets model back to initial model

### DIFF
--- a/packages/uniforms/src/components/forms/AutoForm.js
+++ b/packages/uniforms/src/components/forms/AutoForm.js
@@ -62,7 +62,7 @@ const Auto = parent => class extends parent {
 
     onReset () {
         super.onReset();
-        this.setState(() => ({model: {}, modelSync: {}}));
+        this.setState(() => ({model: this.props.model, modelSync: this.props.model}));
     }
 
     onValidate () {


### PR DESCRIPTION
fixes https://github.com/vazco/uniforms/issues/140


however, something is odd:

In the demo, the form already contains default-values. not from the mode, but from the bridge/schema.

reset does not seem to restore these default-values and i am unsure whether this should be the case. 
