### PR TITLE
Fix initialValue check

### DIFF
--- a/packages/uniforms/src/connectField.js
+++ b/packages/uniforms/src/connectField.js
@@ -44,7 +44,10 @@ export default function connectField (component, {
                     return;
                 }
 
-                if (props.value === undefined && props.required) {
+                if (
+                    props.required
+                    && (this.options.ensureValue ? props.value === '' : props.value === undefined)
+                ) {
                     props.onChange(props.initialValue);
                 }
             }


### PR DESCRIPTION
Currently there is no way set default value for SelectField, because its value by default is `''` (empty string) which is not equal to `undefined`.