### PR TITLE
bootstrap 4 alpha.6 changed classes

### DIFF
--- a/packages/uniforms-bootstrap4/src/BoolField.js
+++ b/packages/uniforms-bootstrap4/src/BoolField.js
@@ -6,10 +6,17 @@ import wrapField from './wrapField';
 
 const Bool = ({label, labelBefore, ...props}) =>
     wrapField({label: labelBefore, ...props}, (
-        <section className={classnames(props.inputClassName, `checkbox${props.inline ? '-inline' : ''}`)}>
-            <label htmlFor={props.id}>
+        <section
+            className={classnames(
+                props.inputClassName,
+                'form-check',
+                `checkbox${props.inline ? '-inline' : ''}`, // bootstrap4 < alpha.6
+            )}
+        >
+            <label htmlFor={props.id} className="form-check-label">
                 <input
                     checked={props.value}
+                    className="form-check-input"
                     disabled={props.disabled}
                     id={props.id}
                     name={props.name}

--- a/packages/uniforms-bootstrap4/src/RadioField.js
+++ b/packages/uniforms-bootstrap4/src/RadioField.js
@@ -7,10 +7,18 @@ import wrapField from './wrapField';
 const Radio = props =>
     wrapField(props, (
         props.allowedValues.map(item =>
-            <section key={item} className={classnames(props.inputClassName, `radio${props.inline ? '-inline' : ''}`)}>
-                <label htmlFor={`${props.id}-${item}`}>
+            <section
+                key={item}
+                className={classnames(
+                    props.inputClassName,
+                    'form-check',
+                    `radio${props.inline ? '-inline' : ''}` // bootstrap4 < alpha.6
+                )}
+            >
+                <label htmlFor={`${props.id}-${item}`} className="form-check-label">
                     <input
                         checked={item === props.value}
+                        className="form-check-input"
                         disabled={props.disabled}
                         id={`${props.id}-${item}`}
                         name={props.name}

--- a/packages/uniforms-bootstrap4/src/gridClassName.js
+++ b/packages/uniforms-bootstrap4/src/gridClassName.js
@@ -3,6 +3,16 @@ import filterDOMProps from 'uniforms/filterDOMProps';
 filterDOMProps.register('grid');
 
 function gridClassNamePart (size, value, side) {
+    return `${gridClassNamePartNew(value, side)} ${gridClassNamePartOld(size, value, side)}`;
+}
+// bootstrap alpha > 5 now uses flexbox columns
+function gridClassNamePartNew (value, side) {
+    return side === 'label'
+        ? `col-${value}`
+        : `col-${(12 - value)}`;
+}
+// bootstrap alpha < 6 requires col-size
+function gridClassNamePartOld (size, value, side) {
     return side === 'label'
         ? `col-${size}-${value}`
         : `col-${size}-${(12 - value)}`;

--- a/packages/uniforms-bootstrap4/src/wrapField.js
+++ b/packages/uniforms-bootstrap4/src/wrapField.js
@@ -45,7 +45,14 @@ export default function wrapField ({
             )}
         >
             {label && (
-                <label htmlFor={id} className={classnames('form-control-label', gridClassName(grid, 'label'))}>
+                <label
+                    htmlFor={id}
+                    className={classnames(
+                        'form-control-label', // bootstrap4 < alpha6
+                        {'col-form-label': grid}, // bootstrap4 > alpha5
+                        gridClassName(grid, 'label')
+                    )}
+                >
                     {label}
                 </label>
             )}


### PR DESCRIPTION
Bootstrap has changed a few classes to support flexbox

    form-control-label  --> col-form-label (required)
    col-{size}-{number} --> col-{number}  (optional)

I have maintained backwards compatibility
But should eventually clean it up and remove later.

Bootstrap has changed a few classes on check/radio 

    radio & radio-inline --> form-check
    <label>              --> form-check-label
    <input>              --> form-check-input

    checkbox & checkbox-inline --> form-check
    <label>                    --> form-check-label
    <input>                    --> form-check-input