### PR TITLE
Support multiple on material ui SelectField

### DIFF
--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -90,7 +90,7 @@ const renderSelect = ({
         {allowedValues.map(value =>
             <MenuItem
                 insetChildren={props.fieldType === Array}
-                checked={props.fieldType === Array && props.value.includes(value)}
+                checked={props.fieldType === Array && props.value && props.value.includes(value)}
                 key={value}
                 primaryText={transform ? transform(value) : value}
                 value={value}

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -71,7 +71,6 @@ const renderSelect = ({
     onChange,
     placeholder,
     transform,
-    value,
     ...props
 }) =>
     <SelectField
@@ -81,26 +80,33 @@ const renderSelect = ({
         fullWidth={fullWidth}
         hintText={placeholder}
         id={id}
+        multiple={props.fieldType === Array}
         name={name}
         onChange={(event, index, value) => onChange(value)}
         ref={inputRef}
-        value={value}
+        value={props.value}
         {...filterDOMProps(props)}
     >
         {allowedValues.map(value =>
             <MenuItem
+                insetChildren={props.fieldType === Array}
+                checked={props.fieldType === Array && props.value.includes(value)}
                 key={value}
-                value={value}
                 primaryText={transform ? transform(value) : value}
+                value={value}
             />
         )}
     </SelectField>
 ;
 
 const Select = props =>
-    props.checkboxes || props.fieldType === Array
+    props.checkboxes
         ? renderCheckboxes(props)
         : renderSelect    (props)
 ;
 
 export default connectField(Select, {ensureValue: false});
+
+filterDOMProps.register(
+    'checkboxes'
+);

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -91,8 +91,8 @@ const renderSelect = ({
     >
         {allowedValues.map(allowedValue =>
             <MenuItem
-                insetChildren={fieldType === Array || null}
-                checked={fieldType === Array && value && value.includes(allowedValue) || null}
+                insetChildren={fieldType === Array || undefined}
+                checked={fieldType === Array && value && value.includes(allowedValue) || undefined}
                 key={allowedValue}
                 primaryText={transform ? transform(allowedValue) : allowedValue}
                 value={allowedValue}

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -63,6 +63,7 @@ const renderSelect = ({
     allowedValues,
     disabled,
     errorMessage,
+    fieldType,
     fullWidth = true,
     id,
     inputRef,
@@ -71,6 +72,7 @@ const renderSelect = ({
     onChange,
     placeholder,
     transform,
+    value,
     ...props
 }) =>
     <SelectField
@@ -80,33 +82,29 @@ const renderSelect = ({
         fullWidth={fullWidth}
         hintText={placeholder}
         id={id}
-        multiple={props.fieldType === Array}
+        multiple={fieldType === Array}
         name={name}
         onChange={(event, index, value) => onChange(value)}
         ref={inputRef}
-        value={props.value}
+        value={value}
         {...filterDOMProps(props)}
     >
-        {allowedValues.map(value =>
+        {allowedValues.map(allowedValue =>
             <MenuItem
-                insetChildren={props.fieldType === Array}
-                checked={props.fieldType === Array && props.value && props.value.includes(value)}
-                key={value}
-                primaryText={transform ? transform(value) : value}
-                value={value}
+                insetChildren={fieldType === Array || null}
+                checked={fieldType === Array && value && value.includes(allowedValue) || null}
+                key={allowedValue}
+                primaryText={transform ? transform(allowedValue) : allowedValue}
+                value={allowedValue}
             />
         )}
     </SelectField>
 ;
 
-const Select = props =>
-    props.checkboxes
+const Select = ({checkboxes, ...props}) =>
+    checkboxes
         ? renderCheckboxes(props)
         : renderSelect    (props)
 ;
 
 export default connectField(Select, {ensureValue: false});
-
-filterDOMProps.register(
-    'checkboxes'
-);


### PR DESCRIPTION
Solves #236 
Wondering if i may do something like this to avoid triple field type checking:
```js
const renderSelect = ({
    ...props
}, context, multiple = props.fieldType === Array) => {
/* Rendering */
}
```
What do you think about this?