### PR TITLE
Split unhandled props into DatePicker or TimePicker

### DIFF
--- a/API.md
+++ b/API.md
@@ -354,13 +354,6 @@ import DateField from 'uniforms-unstyled/DateField'; // Choose your theme packag
     // Available in:
     //   material
     timeFormat="ampm"
-
-    // Callback function fired when the DatePicker or TimePicker dialog is dismissed.
-    // Signature:
-    // function(dateDismissed: bool, timeDismissed: bool, ...args) => void
-    // Available in:
-    //   material
-    onDismiss={(dateDismissed, timeDismissed, ...args) => {}}
 />
 ```
 

--- a/API.md
+++ b/API.md
@@ -354,6 +354,13 @@ import DateField from 'uniforms-unstyled/DateField'; // Choose your theme packag
     // Available in:
     //   material
     timeFormat="ampm"
+
+    // Callback function fired when the DatePicker or TimePicker dialog is dismissed.
+    // Signature:
+    // function(dateDismissed: bool, timeDismissed: bool, ...args) => void
+    // Available in:
+    //   material
+    onDismiss={(dateDismissed, timeDismissed, ...args) => {}}
 />
 ```
 

--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -55,6 +55,7 @@ class Date_ extends Component {
             disableYearSelection,
             errorMessage,
             firstDayOfWeek,
+            formatDate,
             id,
             inputRef,
             label,
@@ -92,6 +93,7 @@ class Date_ extends Component {
                     DateTimeFormat={DateTimeFormat}
                     disableYearSelection={disableYearSelection}
                     firstDayOfWeek={firstDayOfWeek}
+                    formatDate={formatDate}
                     id={`${id}-date`}
                     locale={locale}
                     maxDate={max}

--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -1,10 +1,10 @@
-import connectField                from 'uniforms/connectField';
-import DatePicker                  from 'material-ui/DatePicker';
-import filterDOMProps              from 'uniforms/filterDOMProps';
-import React                       from 'react';
-import TextField                   from 'material-ui/TextField';
-import TimePicker                  from 'material-ui/TimePicker';
-import {Component}                 from 'react';
+import DatePicker     from 'material-ui/DatePicker';
+import React          from 'react';
+import TextField      from 'material-ui/TextField';
+import TimePicker     from 'material-ui/TimePicker';
+import connectField   from 'uniforms/connectField';
+import filterDOMProps from 'uniforms/filterDOMProps';
+import {Component}    from 'react';
 
 class Date_ extends Component {
     static displayName = 'Date';
@@ -16,10 +16,9 @@ class Date_ extends Component {
 
         this._intermediate = null;
 
-        this.onFocus      = this.onFocus.bind(this);
-        this.onDismiss    = this.onDismiss.bind(this);
         this.onChangeDate = this.onChangeDate.bind(this);
         this.onChangeTime = this.onChangeTime.bind(this);
+        this.onFocus      = this.onFocus.bind(this);
     }
 
     onChangeDate (event, date) {
@@ -42,17 +41,13 @@ class Date_ extends Component {
         setTimeout(() => this.refs.datepicker.openDialog(), 100);
     }
 
-    onDismiss (...args) {
-        this.props.onDismiss(...args);
-    }
-
     render () {
         const {
+            DateTimeFormat,
             autoOk,
             cancelLabel,
-            DateTimeFormat,
-            disabled,
             disableYearSelection,
+            disabled,
             errorMessage,
             firstDayOfWeek,
             formatDate,
@@ -88,9 +83,9 @@ class Date_ extends Component {
                 />
 
                 <DatePicker
+                    DateTimeFormat={DateTimeFormat}
                     autoOk={autoOk}
                     cancelLabel={cancelLabel}
-                    DateTimeFormat={DateTimeFormat}
                     disableYearSelection={disableYearSelection}
                     firstDayOfWeek={firstDayOfWeek}
                     formatDate={formatDate}
@@ -100,7 +95,6 @@ class Date_ extends Component {
                     minDate={min}
                     okLabel={okLabel}
                     onChange={this.onChangeDate}
-                    onDismiss={(...args) => this.onDismiss(true, false, ...args)}
                     ref="datepicker"
                     textFieldStyle={{display: 'none'}}
                     value={value}
@@ -113,7 +107,6 @@ class Date_ extends Component {
                     id={`${id}-time`}
                     okLabel={okLabel}
                     onChange={this.onChangeTime}
-                    onDismiss={(...args) => this.onDismiss(false, true, ...args)}
                     pedantic={pedantic}
                     ref="timepicker"
                     textFieldStyle={{display: 'none'}}

--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -1,10 +1,10 @@
-import DatePicker     from 'material-ui/DatePicker';
-import React          from 'react';
-import TextField      from 'material-ui/TextField';
-import TimePicker     from 'material-ui/TimePicker';
-import connectField   from 'uniforms/connectField';
-import filterDOMProps from 'uniforms/filterDOMProps';
-import {Component}    from 'react';
+import connectField                from 'uniforms/connectField';
+import DatePicker                  from 'material-ui/DatePicker';
+import filterDOMProps              from 'uniforms/filterDOMProps';
+import React                       from 'react';
+import TextField                   from 'material-ui/TextField';
+import TimePicker                  from 'material-ui/TimePicker';
+import {Component}                 from 'react';
 
 class Date_ extends Component {
     static displayName = 'Date';
@@ -17,6 +17,7 @@ class Date_ extends Component {
         this._intermediate = null;
 
         this.onFocus      = this.onFocus.bind(this);
+        this.onDismiss    = this.onDismiss.bind(this);
         this.onChangeDate = this.onChangeDate.bind(this);
         this.onChangeTime = this.onChangeTime.bind(this);
     }
@@ -41,16 +42,28 @@ class Date_ extends Component {
         setTimeout(() => this.refs.datepicker.openDialog(), 100);
     }
 
+    onDismiss (...args) {
+        this.props.onDismiss(...args);
+    }
+
     render () {
         const {
+            autoOk,
+            cancelLabel,
+            DateTimeFormat,
             disabled,
+            disableYearSelection,
             errorMessage,
+            firstDayOfWeek,
             id,
             inputRef,
             label,
+            locale,
             max,
             min,
             name,
+            okLabel,
+            pedantic,
             placeholder,
             showInlineError,
             timeFormat,
@@ -74,19 +87,32 @@ class Date_ extends Component {
                 />
 
                 <DatePicker
+                    autoOk={autoOk}
+                    cancelLabel={cancelLabel}
+                    DateTimeFormat={DateTimeFormat}
+                    disableYearSelection={disableYearSelection}
+                    firstDayOfWeek={firstDayOfWeek}
                     id={`${id}-date`}
+                    locale={locale}
                     maxDate={max}
                     minDate={min}
+                    okLabel={okLabel}
                     onChange={this.onChangeDate}
+                    onDismiss={(...args) => this.onDismiss(true, false, ...args)}
                     ref="datepicker"
                     textFieldStyle={{display: 'none'}}
                     value={value}
                 />
 
                 <TimePicker
+                    autoOk={autoOk}
+                    cancelLabel={cancelLabel}
                     format={timeFormat}
                     id={`${id}-time`}
+                    okLabel={okLabel}
                     onChange={this.onChangeTime}
+                    onDismiss={(...args) => this.onDismiss(false, true, ...args)}
+                    pedantic={pedantic}
                     ref="timepicker"
                     textFieldStyle={{display: 'none'}}
                     value={value}


### PR DESCRIPTION
Solves #246 
Yet don't know what to do with the following: `DateTimeFormat`, `locale` and `formatDate`. Just passing them down to the right component so far. Formatting solution from DatePicker in material-ui doesn't support time at all so we probably can't use it. Shall we create own solution or leave it as it is right now, not allowing to format date string in DateField?