### PR TITLE
Allow to override button classes

### DIFF
--- a/packages/uniforms-bootstrap3/src/ListAddField.js
+++ b/packages/uniforms-bootstrap3/src/ListAddField.js
@@ -15,7 +15,7 @@ const ListAdd = ({
 
     return (
         <div
-            className={classnames('badge pull-right', className)}
+            className={classnames({ badge: true, 'pull-right': true}, className)}
             onClick={() => limitNotReached && parent.onChange(parent.value.concat([value]))}
             {...filterDOMProps(props)}
         >


### PR DESCRIPTION
Using this method we can pass this options to override the value of the badge class correctly

```
let classNameAddField = { 'badge': false, btn: true};

<ListAddField className={classNameAddField} name={`${name}.$`} initialCount={initialCount} addIcon={addIcon} />
```

This way is more correct than doing 

```
let classNameAddField = { 'badge pull-right': false, btn: true, 'pull-right': true};
<ListAddField className={classNameAddField} name={`${name}.$`} initialCount={initialCount} addIcon={addIcon} />
```