### PR TITLE
If the value is not found in the set of options(because it can be an …

### DIFF
--- a/packages/uniforms/src/SimpleSchemaBridge.js
+++ b/packages/uniforms/src/SimpleSchemaBridge.js
@@ -202,8 +202,11 @@ export default class SimpleSchemaBridge extends Bridge {
             } else {
                 field = {
                     ...field,
-                    transform: value => options.find(option => option.value === value).label,
-                    allowedValues: options.map(option => option.value)
+                    transform: value => {
+                        const option = options.find(option => option.value.toString() === value);
+                        return option ? option.label : '';
+                    },
+                    allowedValues: options.map(option => option.value.toString())
                 };
             }
         }


### PR DESCRIPTION
…old value) don't break, show empty