### PR TITLE
peerDependencies to allow for newer versions

### DIFF
--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -22,10 +22,10 @@
     "src/"
   ],
   "peerDependencies": {
-    "graphql": "^0.8.2 || ^0.9.1",
+    "graphql": ">=0.8.2 < 1.0.0",
     "react": "^15.0.0 || ^0.14.0",
     "react-dom": "^15.0.0 || ^0.14.0",
-    "simpl-schema": "^0.2.0 || ^0.1.0 || ^0.0.4"
+    "simpl-schema": ">=0.0.4 < 1.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.20.0",


### PR DESCRIPTION
Fixes the below warnings when using `graphql@0.10.1` and `simpl-schema@0.3.0`.

Will allow others to use the latest version of `graphql` or `simpl-schema` up to `v1.0.0` without incurring the below warnings.

```
npm WARN uniforms@1.18.1 requires a peer of graphql@^0.8.2 || ^0.9.1 but none was installed.
npm WARN uniforms@1.18.1 requires a peer of simpl-schema@^0.2.0 || ^0.1.0 || ^0.0.4 but none was installed.
```