### PR TITLE
Fix TextField type prop for antd  (closes #345)

### DIFF
--- a/packages/uniforms-antd/__tests__/TextField.js
+++ b/packages/uniforms-antd/__tests__/TextField.js
@@ -134,3 +134,10 @@ test('<TextField> - renders a wrapper with unknown props', () => {
     expect(wrapper.find(Input).prop('data-y')).toBe('y');
     expect(wrapper.find(Input).prop('data-z')).toBe('z');
 });
+
+test('<TextField> - renders a input with correct type prop', () => {
+    const element = <TextField name="x" type="password" />;
+    const wrapper = mount(element, createContext({x: {type: String}}));
+
+    expect(wrapper.find(Input).prop('type')).toBe('password');
+});

--- a/packages/uniforms-antd/src/TextField.js
+++ b/packages/uniforms-antd/src/TextField.js
@@ -15,6 +15,7 @@ const Text = props =>
             placeholder={props.placeholder}
             ref={props.inputRef}
             value={props.value}
+            type={props.type}
             {...filterDOMProps(props)}
         />
     ))

--- a/packages/uniforms-antd/src/TextField.js
+++ b/packages/uniforms-antd/src/TextField.js
@@ -14,8 +14,8 @@ const Text = props =>
             onChange={event => props.onChange(event.target.value)}
             placeholder={props.placeholder}
             ref={props.inputRef}
-            value={props.value}
             type={props.type}
+            value={props.value}
             {...filterDOMProps(props)}
         />
     ))


### PR DESCRIPTION
Should fix #345 

@radekmie Let me know if this PR is okay.

I didn't see a need to touch `filterDOMProps` especially since its being used by all other style versions. It seems it was just a missed prop.