### PR TITLE
Changed onSubmit rejection meaning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next:
+- **Changed:** If `onSubmit` rejects, it's treated as a form error.
+- **Fixed:** `form.submit` correctly rejects on validation error.
+
 ## [v1.23.0-rc.1](https://github.com/vazco/uniforms/tree/v1.23.0-rc.1) (2017-12-29)
 - **Added:** Support for `antd@3.0.0`. [\#372](https://github.com/vazco/uniforms/issues/372)
 

--- a/packages/uniforms/__tests__/ValidatedForm.js
+++ b/packages/uniforms/__tests__/ValidatedForm.js
@@ -286,6 +286,20 @@ describe('ValidatedForm', () => {
             expect(onValidate).toHaveBeenLastCalledWith({a: 2, b: 1}, null, expect.any(Function));
         });
 
+        it('works with async errors from `onSubmit`', async () => {
+            onSubmit.mockImplementationOnce(() => Promise.reject(new Error()));
+
+            const wrapper = mount(
+                <ValidatedForm model={model} schema={schema} onSubmit={onSubmit} />
+            );
+
+            wrapper.find('form').simulate('submit');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(wrapper.instance().getChildContext()).toHaveProperty('uniforms.error', error);
+        });
+
         it('works with async errors from `onValidate`', () => {
             const wrapper = mount(
                 <ValidatedForm model={model} schema={schema} onValidate={onValidate} validate="onChange" />

--- a/packages/uniforms/src/BaseForm.js
+++ b/packages/uniforms/src/BaseForm.js
@@ -234,12 +234,10 @@ export default class BaseForm extends Component {
             event.stopPropagation();
         }
 
-        const promise = Promise.resolve(
+        return Promise.resolve(
             this.props.onSubmit &&
             this.props.onSubmit(this.getModel('submit'))
-        );
-
-        return promise.then(
+        ).then(
             this.props.onSubmitSuccess,
             this.props.onSubmitFailure
         );

--- a/packages/uniforms/src/ValidatedForm.js
+++ b/packages/uniforms/src/ValidatedForm.js
@@ -109,11 +109,27 @@ const Validated = parent => class extends parent {
             event.stopPropagation();
         }
 
-        return new Promise(resolve => {
+        const promise = new Promise((resolve, reject) => {
             this.setState(() => ({validate: true}), () => {
-                this.onValidate().then(() => resolve(super.onSubmit()), () => {});
+                this.onValidate().then(
+                    () => {
+                        super.onSubmit().then(
+                            resolve,
+                            error => {
+                                this.setState({error});
+                                reject(error);
+                            }
+                        );
+                    },
+                    reject
+                );
             });
         });
+
+        // NOTE: It's okay for this Promise to reject.
+        promise.catch(() => {});
+
+        return promise;
     }
 
     onValidate (key, value) {


### PR DESCRIPTION
This PR aims to do two things:
- **Change:** If `onSubmit` rejects, it's treated as a form error.

    This is an old-standing idea, for few months on roadmap already. Also reported in #341. The goal is to change this code:

    ```js
    <ValidatedForm
        error={this.state.error}
        schema={schema}
        onSubmit={model => db.submitThatReturnsPromise(model)}
        onSubmitFailure={error => this.setState({error})}
        onSubmitSuccess={() => this.setState({error: null})}
    />
    ```

    Into to this code:

    ```js
    <ValidatedForm
        schema={schema}
        onSubmit={model => db.submitThatReturnsPromise(model)}
    />
    ```

    Nice, huh?

- **Fix:** `form.submit` correctly rejects on validation error.

    It's an important fix; it was mentioned already in #331.