### PR TITLE
Update bootstrap to v4.0.0

### DIFF
--- a/demo/imports/lib/styles.js
+++ b/demo/imports/lib/styles.js
@@ -12,7 +12,7 @@ const styles = {
 
     bootstrap4: style([
         'https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css',
-        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.5/css/bootstrap.min.css'
+        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.6/css/bootstrap.min.css'
     ]),
 
     material: style([]),

--- a/demo/imports/lib/styles.js
+++ b/demo/imports/lib/styles.js
@@ -12,7 +12,7 @@ const styles = {
 
     bootstrap4: style([
         'https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css',
-        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.6/css/bootstrap.min.css'
+        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-beta/css/bootstrap.min.css'
     ]),
 
     material: style([]),

--- a/demo/imports/lib/styles.js
+++ b/demo/imports/lib/styles.js
@@ -12,7 +12,7 @@ const styles = {
 
     bootstrap4: style([
         'https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css',
-        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-beta.3/css/bootstrap.min.css'
+        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.min.css'
     ]),
 
     material: style([]),

--- a/demo/imports/lib/styles.js
+++ b/demo/imports/lib/styles.js
@@ -12,7 +12,7 @@ const styles = {
 
     bootstrap4: style([
         'https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css',
-        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-beta/css/bootstrap.min.css'
+        'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-beta.3/css/bootstrap.min.css'
     ]),
 
     material: style([]),

--- a/packages/uniforms-bootstrap4/__tests__/BoolField.js
+++ b/packages/uniforms-bootstrap4/__tests__/BoolField.js
@@ -17,7 +17,8 @@ test('<BoolField> - renders an inline input', () => {
     const wrapper = mount(element, createContext({x: {type: Boolean}}));
 
     expect(wrapper.find('input')).toHaveLength(1);
-    expect(wrapper.find('.checkbox-inline')).toHaveLength(1);
+    expect(wrapper.find('.checkbox')).toHaveLength(1);
+    expect(wrapper.find('.custom-control-inline')).toHaveLength(1);
 });
 
 test('<BoolField> - renders a input with correct id (inherited)', () => {

--- a/packages/uniforms-bootstrap4/__tests__/ErrorsField.js
+++ b/packages/uniforms-bootstrap4/__tests__/ErrorsField.js
@@ -27,10 +27,10 @@ test('<ErrorsField> - renders list of correct error messages (context)', () => {
     const element = <ErrorsField name="x" />;
     const wrapper = mount(element, createContext({x: {type: String}, y: {type: String}, z: {type: String}}, {error}));
 
-    expect(wrapper.find('.card-block > div')).toHaveLength(3);
-    expect(wrapper.find('.card-block > div').at(0).text()).toBe('X is required');
-    expect(wrapper.find('.card-block > div').at(1).text()).toBe('Y is required');
-    expect(wrapper.find('.card-block > div').at(2).text()).toBe('Z is required');
+    expect(wrapper.find('.card-body > div')).toHaveLength(3);
+    expect(wrapper.find('.card-body > div').at(0).text()).toBe('X is required');
+    expect(wrapper.find('.card-body > div').at(1).text()).toBe('Y is required');
+    expect(wrapper.find('.card-body > div').at(2).text()).toBe('Z is required');
 });
 
 test('<ErrorsField> - renders children (specified)', () => {

--- a/packages/uniforms-bootstrap4/__tests__/RadioField.js
+++ b/packages/uniforms-bootstrap4/__tests__/RadioField.js
@@ -17,7 +17,8 @@ test('<RadioField> - renders a set of inline checkboxes', () => {
     const wrapper = mount(element, createContext({x: {type: String, allowedValues: ['a', 'b']}}));
 
     expect(wrapper.find('input')).toHaveLength(2);
-    expect(wrapper.find('.radio-inline')).toHaveLength(2);
+    expect(wrapper.find('.radio')).toHaveLength(2);
+    expect(wrapper.find('.custom-control-inline')).toHaveLength(2);
 });
 
 test('<RadioField> - renders a set of checkboxes with correct disabled state', () => {

--- a/packages/uniforms-bootstrap4/__tests__/gridClassName.js
+++ b/packages/uniforms-bootstrap4/__tests__/gridClassName.js
@@ -5,33 +5,33 @@ test('gridClassName - object', () => {
     expect(gridClassName({md: 5}, 'input')).toBe('col-7 col-md-7');
     expect(gridClassName({md: 7}, 'input')).toBe('col-5 col-md-5');
     expect(gridClassName({md: 9}, 'input')).toBe('col-3 col-md-3');
-    expect(gridClassName({md: 3, xs: 2}, 'input')).toBe('col-9 col-md-9 col-10 col-xs-10');
-    expect(gridClassName({md: 5, xs: 4}, 'input')).toBe('col-7 col-md-7 col-8 col-xs-8');
-    expect(gridClassName({md: 7, xs: 6}, 'input')).toBe('col-5 col-md-5 col-6 col-xs-6');
-    expect(gridClassName({md: 9, xs: 8}, 'input')).toBe('col-3 col-md-3 col-4 col-xs-4');
+    expect(gridClassName({md: 3, xs: 2}, 'input')).toBe('col-10 col-md-9');
+    expect(gridClassName({md: 5, xs: 4}, 'input')).toBe('col-8 col-md-7');
+    expect(gridClassName({md: 7, xs: 6}, 'input')).toBe('col-6 col-md-5');
+    expect(gridClassName({md: 9, xs: 8}, 'input')).toBe('col-4 col-md-3');
 
     expect(gridClassName({md: 3}, 'label')).toBe('col-3 col-md-3');
     expect(gridClassName({md: 5}, 'label')).toBe('col-5 col-md-5');
     expect(gridClassName({md: 7}, 'label')).toBe('col-7 col-md-7');
     expect(gridClassName({md: 9}, 'label')).toBe('col-9 col-md-9');
-    expect(gridClassName({md: 3, xs: 2}, 'label')).toBe('col-3 col-md-3 col-2 col-xs-2');
-    expect(gridClassName({md: 5, xs: 4}, 'label')).toBe('col-5 col-md-5 col-4 col-xs-4');
-    expect(gridClassName({md: 7, xs: 6}, 'label')).toBe('col-7 col-md-7 col-6 col-xs-6');
-    expect(gridClassName({md: 9, xs: 8}, 'label')).toBe('col-9 col-md-9 col-8 col-xs-8');
+    expect(gridClassName({md: 3, xs: 2}, 'label')).toBe('col-2 col-md-3');
+    expect(gridClassName({md: 5, xs: 4}, 'label')).toBe('col-4 col-md-5');
+    expect(gridClassName({md: 7, xs: 6}, 'label')).toBe('col-6 col-md-7');
+    expect(gridClassName({md: 9, xs: 8}, 'label')).toBe('col-8 col-md-9');
 });
 
 test('gridClassName - number', () => {
-    expect(gridClassName(3, 'input')).toBe('col-9 col-sm-9');
-    expect(gridClassName(3, 'label')).toBe('col-3 col-sm-3');
-    expect(gridClassName(5, 'input')).toBe('col-7 col-sm-7');
-    expect(gridClassName(5, 'label')).toBe('col-5 col-sm-5');
+    expect(gridClassName(3, 'input')).toBe('col-9');
+    expect(gridClassName(3, 'label')).toBe('col-3');
+    expect(gridClassName(5, 'input')).toBe('col-7');
+    expect(gridClassName(5, 'label')).toBe('col-5');
 });
 
 test('gridClassName - number (string)', () => {
-    expect(gridClassName('3', 'input')).toBe('col-9 col-sm-9');
-    expect(gridClassName('3', 'label')).toBe('col-3 col-sm-3');
-    expect(gridClassName('5', 'input')).toBe('col-7 col-sm-7');
-    expect(gridClassName('5', 'label')).toBe('col-5 col-sm-5');
+    expect(gridClassName('3', 'input')).toBe('col-9');
+    expect(gridClassName('3', 'label')).toBe('col-3');
+    expect(gridClassName('5', 'input')).toBe('col-7');
+    expect(gridClassName('5', 'label')).toBe('col-5');
 });
 
 test('gridClassName - string', () => {

--- a/packages/uniforms-bootstrap4/__tests__/gridClassName.js
+++ b/packages/uniforms-bootstrap4/__tests__/gridClassName.js
@@ -9,6 +9,12 @@ test('gridClassName - object', () => {
     expect(gridClassName({md: 5, xs: 4}, 'input')).toBe('col-8 col-md-7');
     expect(gridClassName({md: 7, xs: 6}, 'input')).toBe('col-6 col-md-5');
     expect(gridClassName({md: 9, xs: 8}, 'input')).toBe('col-4 col-md-3');
+    expect(gridClassName({sm: 11, md: 9, xs: 8, xl: 2, lg: 5}, 'input'))
+        .toBe('col-4 col-sm-1 col-md-3 col-lg-7 col-xl-10');
+    expect(gridClassName({xl: 2, lg: 5, md: 9, sm: 11, xs: 8}, 'input'))
+        .toBe('col-4 col-sm-1 col-md-3 col-lg-7 col-xl-10');
+    expect(gridClassName({lg: 9, xs: 8, md: 2, xl: 5}, 'input')).toBe('col-4 col-md-10 col-lg-3 col-xl-7');
+    expect(gridClassName({xl: 9, lg: 2, md: 5}, 'input')).toBe('col-7 col-md-7 col-lg-10 col-xl-3');
 
     expect(gridClassName({md: 3}, 'label')).toBe('col-3 col-md-3');
     expect(gridClassName({md: 5}, 'label')).toBe('col-5 col-md-5');
@@ -18,6 +24,12 @@ test('gridClassName - object', () => {
     expect(gridClassName({md: 5, xs: 4}, 'label')).toBe('col-4 col-md-5');
     expect(gridClassName({md: 7, xs: 6}, 'label')).toBe('col-6 col-md-7');
     expect(gridClassName({md: 9, xs: 8}, 'label')).toBe('col-8 col-md-9');
+    expect(gridClassName({sm: 11, md: 9, xs: 8, xl: 2, lg: 5}, 'label'))
+        .toBe('col-8 col-sm-11 col-md-9 col-lg-5 col-xl-2');
+    expect(gridClassName({xl: 2, lg: 5, md: 9, sm: 11, xs: 8}, 'label'))
+        .toBe('col-8 col-sm-11 col-md-9 col-lg-5 col-xl-2');
+    expect(gridClassName({lg: 9, xs: 8, md: 2, xl: 5}, 'label')).toBe('col-8 col-md-2 col-lg-9 col-xl-5');
+    expect(gridClassName({xl: 9, lg: 2, md: 5}, 'label')).toBe('col-5 col-md-5 col-lg-2 col-xl-9');
 });
 
 test('gridClassName - number', () => {

--- a/packages/uniforms-bootstrap4/src/BoolField.js
+++ b/packages/uniforms-bootstrap4/src/BoolField.js
@@ -11,6 +11,7 @@ const Bool = ({label, labelBefore, ...props}) =>
                 props.inputClassName,
                 'form-check',
                 `checkbox${props.inline ? '-inline' : ''}`, // bootstrap4 < alpha.6
+                {'text-danger': props.error}
             )}
         >
             <label htmlFor={props.id} className="form-check-label">

--- a/packages/uniforms-bootstrap4/src/BoolField.js
+++ b/packages/uniforms-bootstrap4/src/BoolField.js
@@ -10,7 +10,7 @@ const Bool = ({label, labelBefore, ...props}) =>
             className={classnames(
                 props.inputClassName,
                 'form-check',
-                `checkbox${props.inline ? '-inline' : ''}`, // bootstrap4 < alpha.6
+                `checkbox${props.inline ? ' custom-control-inline' : ''}`,
                 {'text-danger': props.error}
             )}
         >

--- a/packages/uniforms-bootstrap4/src/BoolField.js
+++ b/packages/uniforms-bootstrap4/src/BoolField.js
@@ -10,8 +10,11 @@ const Bool = ({label, labelBefore, ...props}) =>
             className={classnames(
                 props.inputClassName,
                 'form-check',
-                `checkbox${props.inline ? ' custom-control-inline' : ''}`,
-                {'text-danger': props.error}
+                'checkbox',
+                {
+                    'text-danger': props.error,
+                    'custom-control-inline': props.inline
+                }
             )}
         >
             <label htmlFor={props.id} className="form-check-label">

--- a/packages/uniforms-bootstrap4/src/DateField.js
+++ b/packages/uniforms-bootstrap4/src/DateField.js
@@ -17,7 +17,7 @@ const dateParse = (timestamp, onChange) => {
 const Date_ = props =>
     wrapField(props, (
         <input
-            className={classnames(props.inputClassName, 'form-control', {'form-control-danger': props.error})}
+            className={classnames(props.inputClassName, 'form-control', {'is-invalid': props.error})}
             disabled={props.disabled}
             id={props.id}
             max={dateFormat(props.max)}

--- a/packages/uniforms-bootstrap4/src/ErrorField.js
+++ b/packages/uniforms-bootstrap4/src/ErrorField.js
@@ -6,7 +6,7 @@ import nothing        from 'uniforms/nothing';
 
 const Error = ({children, className, error, errorMessage, ...props}) =>
     !error ? nothing : (
-        <div className={classnames('card', className)} {...filterDOMProps(props)}>
+        <div className={classnames('card', 'mb-3', className)} {...filterDOMProps(props)}>
             <div className="card-body">
                 {children ? (
                     children

--- a/packages/uniforms-bootstrap4/src/ErrorField.js
+++ b/packages/uniforms-bootstrap4/src/ErrorField.js
@@ -7,7 +7,7 @@ import nothing        from 'uniforms/nothing';
 const Error = ({children, className, error, errorMessage, ...props}) =>
     !error ? nothing : (
         <div className={classnames('card', className)} {...filterDOMProps(props)}>
-            <div className="card-block">
+            <div className="card-body">
                 {children ? (
                     children
                 ) : (

--- a/packages/uniforms-bootstrap4/src/ErrorsField.js
+++ b/packages/uniforms-bootstrap4/src/ErrorsField.js
@@ -6,7 +6,7 @@ import nothing        from 'uniforms/nothing';
 
 const ErrorsField = ({className, children, ...props}, {uniforms: {error, schema}}) =>
     (!error && !children) ? nothing : (
-        <div className={classnames('card card-outline-danger text-danger', className)} {...filterDOMProps(props)}>
+        <div className={classnames('card card-outline-danger mb-3 text-danger', className)} {...filterDOMProps(props)}>
             <div className="card-body">
                 {children}
 

--- a/packages/uniforms-bootstrap4/src/ErrorsField.js
+++ b/packages/uniforms-bootstrap4/src/ErrorsField.js
@@ -7,7 +7,7 @@ import nothing        from 'uniforms/nothing';
 const ErrorsField = ({className, children, ...props}, {uniforms: {error, schema}}) =>
     (!error && !children) ? nothing : (
         <div className={classnames('card card-outline-danger text-danger', className)} {...filterDOMProps(props)}>
-            <div className="card-block">
+            <div className="card-body">
                 {children}
 
                 {schema.getErrorMessages(error).map((message, index) =>

--- a/packages/uniforms-bootstrap4/src/ErrorsField.js
+++ b/packages/uniforms-bootstrap4/src/ErrorsField.js
@@ -6,7 +6,7 @@ import nothing        from 'uniforms/nothing';
 
 const ErrorsField = ({className, children, ...props}, {uniforms: {error, schema}}) =>
     (!error && !children) ? nothing : (
-        <div className={classnames('card card-outline-danger mb-3 text-danger', className)} {...filterDOMProps(props)}>
+        <div className={classnames('card border-danger mb-3 text-danger', className)} {...filterDOMProps(props)}>
             <div className="card-body">
                 {children}
 

--- a/packages/uniforms-bootstrap4/src/ListAddField.js
+++ b/packages/uniforms-bootstrap4/src/ListAddField.js
@@ -15,7 +15,7 @@ const ListAdd = ({
 
     return (
         <div
-            className={classnames('label label-default label-pill float-xs-right', className)}
+            className={classnames('label label-default label-pill float-right', className)}
             onClick={() => limitNotReached && parent.onChange(parent.value.concat([value]))}
             {...filterDOMProps(props)}
         >

--- a/packages/uniforms-bootstrap4/src/ListField.js
+++ b/packages/uniforms-bootstrap4/src/ListField.js
@@ -23,7 +23,7 @@ const List = ({
     value,
     ...props
 }) =>
-    <div className={classnames('card', className)} {...filterDOMProps(props)}>
+    <div className={classnames('card mb-3', className)} {...filterDOMProps(props)}>
         <div className="card-block">
             {label && (
                 <div className="card-title">

--- a/packages/uniforms-bootstrap4/src/ListField.js
+++ b/packages/uniforms-bootstrap4/src/ListField.js
@@ -24,7 +24,7 @@ const List = ({
     ...props
 }) =>
     <div className={classnames('card mb-3', className)} {...filterDOMProps(props)}>
-        <div className="card-block">
+        <div className="card-body">
             {label && (
                 <div className="card-title">
                     <label className="control-label">

--- a/packages/uniforms-bootstrap4/src/ListField.js
+++ b/packages/uniforms-bootstrap4/src/ListField.js
@@ -27,7 +27,7 @@ const List = ({
         <div className="card-body">
             {label && (
                 <div className="card-title">
-                    <label className="control-label">
+                    <label className="col-form-label">
                         {label}&nbsp;
                     </label>
 

--- a/packages/uniforms-bootstrap4/src/ListItemField.js
+++ b/packages/uniforms-bootstrap4/src/ListItemField.js
@@ -8,20 +8,20 @@ import ListDelField from './ListDelField';
 
 const ListItem = ({removeIcon, ...props}) =>
     <div className="row">
-        <div className="col-xs-1">
+        <div className="col-1">
             <ListDelField name={props.name} removeIcon={removeIcon} />
         </div>
 
         {props.children ? (
             Children.map(props.children, child =>
                 React.cloneElement(child, {
-                    className: 'col-xs-11',
+                    className: 'col-11',
                     name: joinName(props.name, child.props.name),
                     label: null
                 })
             )
         ) : (
-            <AutoField {...props} className="col-xs-11" />
+            <AutoField {...props} className="col-11" />
         )}
     </div>
 ;

--- a/packages/uniforms-bootstrap4/src/LongTextField.js
+++ b/packages/uniforms-bootstrap4/src/LongTextField.js
@@ -7,7 +7,7 @@ import wrapField from './wrapField';
 const LongText = props =>
     wrapField(props, (
         <textarea
-            className={classnames(props.inputClassName, 'form-control', {'form-control-danger': props.error})}
+            className={classnames(props.inputClassName, 'form-control', {'is-invalid': props.error})}
             disabled={props.disabled}
             id={props.id}
             name={props.name}

--- a/packages/uniforms-bootstrap4/src/NumField.js
+++ b/packages/uniforms-bootstrap4/src/NumField.js
@@ -10,7 +10,7 @@ const noneIfNaN = x => isNaN(x) ? undefined : x;
 const Num_ = props =>
     wrapField(props, (
         <input
-            className={classnames(props.inputClassName, 'form-control', {'form-control-danger': props.error})}
+            className={classnames(props.inputClassName, 'form-control', {'is-invalid': props.error})}
             disabled={props.disabled}
             id={props.id}
             max={props.max}

--- a/packages/uniforms-bootstrap4/src/RadioField.js
+++ b/packages/uniforms-bootstrap4/src/RadioField.js
@@ -12,7 +12,7 @@ const Radio = props =>
                 className={classnames(
                     props.inputClassName,
                     'form-check',
-                    `radio${props.inline ? '-inline' : ''}`, // bootstrap4 < alpha.6
+                    `radio ${props.inline ? ' custom-control-inline' : ''}`,
                     {'text-danger': props.error}
                 )}
             >

--- a/packages/uniforms-bootstrap4/src/RadioField.js
+++ b/packages/uniforms-bootstrap4/src/RadioField.js
@@ -12,7 +12,8 @@ const Radio = props =>
                 className={classnames(
                     props.inputClassName,
                     'form-check',
-                    `radio${props.inline ? '-inline' : ''}` // bootstrap4 < alpha.6
+                    `radio${props.inline ? '-inline' : ''}`, // bootstrap4 < alpha.6
+                    {'text-danger': props.error}
                 )}
             >
                 <label htmlFor={`${props.id}-${item}`} className="form-check-label">

--- a/packages/uniforms-bootstrap4/src/RadioField.js
+++ b/packages/uniforms-bootstrap4/src/RadioField.js
@@ -12,8 +12,11 @@ const Radio = props =>
                 className={classnames(
                     props.inputClassName,
                     'form-check',
-                    `radio ${props.inline ? ' custom-control-inline' : ''}`,
-                    {'text-danger': props.error}
+                    'radio',
+                    {
+                        'text-danger': props.error,
+                        'custom-control-inline': props.inline
+                    }
                 )}
             >
                 <label htmlFor={`${props.id}-${item}`} className="form-check-label">

--- a/packages/uniforms-bootstrap4/src/SelectField.js
+++ b/packages/uniforms-bootstrap4/src/SelectField.js
@@ -33,7 +33,7 @@ const renderCheckboxes = props =>
 
 const renderSelect = props =>
     <select
-        className={classnames(props.inputClassName, 'c-select form-control', {'form-control-danger': props.error})}
+        className={classnames(props.inputClassName, 'c-select form-control', {'is-invalid': props.error})}
         disabled={props.disabled}
         id={props.id}
         name={props.name}

--- a/packages/uniforms-bootstrap4/src/SubmitField.js
+++ b/packages/uniforms-bootstrap4/src/SubmitField.js
@@ -32,9 +32,9 @@ const SubmitField = ({
     );
 
     return (
-        <div className={classnames(className, {'has-danger': error, row: state.grid})} {...filterDOMProps(props)}>
+        <div className={classnames(className, {'is-invalid': error, row: state.grid})} {...filterDOMProps(props)}>
             {hasWrap && (
-                <label className={classnames('form-control-label', gridClassName(state.grid, 'label'))}>
+                <label className={classnames('col-form-label', gridClassName(state.grid, 'label'))}>
                     &nbsp;
                 </label>
             )}

--- a/packages/uniforms-bootstrap4/src/TextField.js
+++ b/packages/uniforms-bootstrap4/src/TextField.js
@@ -7,7 +7,7 @@ import wrapField from './wrapField';
 const Text = props =>
     wrapField(props, (
         <input
-            className={classnames(props.inputClassName, 'form-control', {'form-control-danger': props.error})}
+            className={classnames(props.inputClassName, 'form-control', {'is-invalid': props.error})}
             disabled={props.disabled}
             id={props.id}
             name={props.name}

--- a/packages/uniforms-bootstrap4/src/gridClassName.js
+++ b/packages/uniforms-bootstrap4/src/gridClassName.js
@@ -39,13 +39,13 @@ export default function gridClassName (grid, side) {
 
     // Example: {xs: 6, sm: 4, md: 3}
     if (typeof grid === 'object') {
-        const completeGrid = grid.xs
-            ? grid
-            : {xs: grid.sm || grid.md || grid.lg || grid.xl, ...grid};
+        if (!grid.xs) {
+            grid = {xs: grid.sm || grid.md || grid.lg || grid.xl, ...grid};
+        }
 
-        return Object.keys(completeGrid)
+        return Object.keys(grid)
             .sort(compareSizeClass)
-            .map(size => gridClassNamePart(size, completeGrid[size], side)).join(' ');
+            .map(size => gridClassNamePart(size, grid[size], side)).join(' ');
     }
 
     return '';

--- a/packages/uniforms-bootstrap4/src/gridClassName.js
+++ b/packages/uniforms-bootstrap4/src/gridClassName.js
@@ -39,13 +39,10 @@ export default function gridClassName (grid, side) {
 
     // Example: {xs: 6, sm: 4, md: 3}
     if (typeof grid === 'object') {
-        if (!grid.xs) {
-            grid.xs = grid.sm || grid.md || grid.lg || grid.xl;
-        }
-
-        return Object.keys(grid)
+        const completeGrid = {xs: grid.sm || grid.md || grid.lg || grid.xl, ...grid};
+        return Object.keys(completeGrid)
             .sort(compareSizeClass)
-            .map(size => gridClassNamePart(size, grid[size], side)).join(' ');
+            .map(size => gridClassNamePart(size, completeGrid[size], side)).join(' ');
     }
 
     return '';

--- a/packages/uniforms-bootstrap4/src/gridClassName.js
+++ b/packages/uniforms-bootstrap4/src/gridClassName.js
@@ -3,32 +3,59 @@ import filterDOMProps from 'uniforms/filterDOMProps';
 filterDOMProps.register('grid');
 
 function gridClassNamePart (size, value, side) {
-    return `${gridClassNamePartNew(value, side)} ${gridClassNamePartOld(size, value, side)}`;
+    const sizeInfix = size === 'xs' ? '' : `${size}-`;
+    return side === 'label'
+        ? `col-${sizeInfix}${value}`
+        : `col-${sizeInfix}${(12 - value)}`;
 }
 
-// bootstrap alpha > 5 now uses flexbox columns
-function gridClassNamePartNew (value, side) {
-    return side === 'label'
-        ? `col-${value}`
-        : `col-${(12 - value)}`;
-}
+function compareSizeClass (a, b) {
+    if (a === 'xs') {
+        return -1;
+    }
 
-// bootstrap alpha < 6 requires col-size
-function gridClassNamePartOld (size, value, side) {
-    return side === 'label'
-        ? `col-${size}-${value}`
-        : `col-${size}-${(12 - value)}`;
+    if (a === 'sm') {
+        if (b === 'md') {
+            return -1;
+        }
+
+        if (b === 'lg') {
+            return -1;
+        }
+
+        if (b === 'xl') {
+            return -1;
+        }
+    }
+
+    if (a === 'md') {
+        if (b === 'lg') {
+            return -1;
+        }
+
+        if (b === 'xl') {
+            return -1;
+        }
+    }
+
+    if (a === 'lg') {
+        if (b === 'xl') {
+            return -1;
+        }
+    }
+
+    return 1;
 }
 
 export default function gridClassName (grid, side) {
     // Example: 6
     if (typeof grid === 'number') {
-        return gridClassNamePart('sm', grid, side);
+        return gridClassNamePart('xs', grid, side);
     }
 
     // Example: '6'
     if (typeof grid === 'string' && !isNaN(parseInt(grid))) {
-        return gridClassNamePart('sm', parseInt(grid), side);
+        return gridClassNamePart('xs', parseInt(grid), side);
     }
 
     // Example: 'col-md-6'
@@ -38,7 +65,14 @@ export default function gridClassName (grid, side) {
 
     // Example: {xs: 6, sm: 4, md: 3}
     if (typeof grid === 'object') {
-        return Object.keys(grid).map(size => gridClassNamePart(size, grid[size], side)).join(' ');
+
+        if (!grid['xs']) {
+            grid['xs'] = grid['sm'] || grid['md'] || grid['lg'] || grid['xl'];
+        }
+
+        return Object.keys(grid)
+            .sort(compareSizeClass)
+            .map(size => gridClassNamePart(size, grid[size], side)).join(' ');
     }
 
     return '';

--- a/packages/uniforms-bootstrap4/src/gridClassName.js
+++ b/packages/uniforms-bootstrap4/src/gridClassName.js
@@ -9,42 +9,16 @@ function gridClassNamePart (size, value, side) {
         : `col-${sizeInfix}${(12 - value)}`;
 }
 
+const gridOrder = {
+    xs: 1,
+    sm: 2,
+    md: 3,
+    lg: 4,
+    xl: 5
+};
+
 function compareSizeClass (a, b) {
-    if (a === 'xs') {
-        return -1;
-    }
-
-    if (a === 'sm') {
-        if (b === 'md') {
-            return -1;
-        }
-
-        if (b === 'lg') {
-            return -1;
-        }
-
-        if (b === 'xl') {
-            return -1;
-        }
-    }
-
-    if (a === 'md') {
-        if (b === 'lg') {
-            return -1;
-        }
-
-        if (b === 'xl') {
-            return -1;
-        }
-    }
-
-    if (a === 'lg') {
-        if (b === 'xl') {
-            return -1;
-        }
-    }
-
-    return 1;
+    return gridOrder[a] - gridOrder[b];
 }
 
 export default function gridClassName (grid, side) {
@@ -65,9 +39,8 @@ export default function gridClassName (grid, side) {
 
     // Example: {xs: 6, sm: 4, md: 3}
     if (typeof grid === 'object') {
-
-        if (!grid['xs']) {
-            grid['xs'] = grid['sm'] || grid['md'] || grid['lg'] || grid['xl'];
+        if (!grid.xs) {
+            grid.xs = grid.sm || grid.md || grid.lg || grid.xl;
         }
 
         return Object.keys(grid)

--- a/packages/uniforms-bootstrap4/src/gridClassName.js
+++ b/packages/uniforms-bootstrap4/src/gridClassName.js
@@ -39,7 +39,10 @@ export default function gridClassName (grid, side) {
 
     // Example: {xs: 6, sm: 4, md: 3}
     if (typeof grid === 'object') {
-        const completeGrid = {xs: grid.sm || grid.md || grid.lg || grid.xl, ...grid};
+        const completeGrid = grid.xs
+            ? grid
+            : {xs: grid.sm || grid.md || grid.lg || grid.xl, ...grid};
+
         return Object.keys(completeGrid)
             .sort(compareSizeClass)
             .map(size => gridClassNamePart(size, completeGrid[size], side)).join(' ');

--- a/packages/uniforms-bootstrap4/src/wrapField.js
+++ b/packages/uniforms-bootstrap4/src/wrapField.js
@@ -58,7 +58,10 @@ export default function wrapField ({
                     htmlFor={id}
                     className={classnames(
                         'form-control-label', // bootstrap4 < alpha6
-                        {'col-form-label': grid}, // bootstrap4 > alpha5
+                        {
+                            'col-form-label': grid, // bootstrap4 > alpha5
+                            'text-danger': error
+                        },
                         gridClassName(grid, 'label')
                     )}
                 >

--- a/packages/uniforms-bootstrap4/src/wrapField.js
+++ b/packages/uniforms-bootstrap4/src/wrapField.js
@@ -57,9 +57,8 @@ export default function wrapField ({
                 <label
                     htmlFor={id}
                     className={classnames(
-                        'form-control-label', // bootstrap4 < alpha6
                         {
-                            'col-form-label': grid, // bootstrap4 > alpha5
+                            'col-form-label': grid,
                             'text-danger': error
                         },
                         gridClassName(grid, 'label')

--- a/packages/uniforms-bootstrap4/src/wrapField.js
+++ b/packages/uniforms-bootstrap4/src/wrapField.js
@@ -45,7 +45,7 @@ export default function wrapField ({
                 className,
                 'form-group',
                 {
-                    'has-danger': error,
+                    'is-invalid': error,
                     disabled,
                     required,
                     row: grid


### PR DESCRIPTION
Becouse the bootstrap released the final stable 4 version i decided to update `uniforms-bootstrap4` from alpha-5 to version 4.0.0. I tested mostly on `demo` app and tried to keep similar appearance and behaviour like with alpha version. I tested also with some more complicated schemas  and imho looks good, but maybe something i missed so i will be happy on every review or remark. 