### PR TITLE
Add extra check on Match

### DIFF
--- a/packages/uniforms/src/SimpleSchemaBridge.js
+++ b/packages/uniforms/src/SimpleSchemaBridge.js
@@ -33,7 +33,7 @@ try {
     }
 } catch (_) { /* Ignore it. */ }
 
-if (SimpleSchema) {
+if (SimpleSchema && Match) {
     SimpleSchema.extendOptions({
         uniforms: Match.Optional(
             Match.OneOf(


### PR DESCRIPTION
When using uniforms in a Meteor/React project and testing with Jest, in the Jest environment Meteor is not defined. This results in an error being raised `Cannot read property 'Match' of undefined`. Even if you use `simpl-schema`, the file is being imported and fails on `SimpleSchemaBridge.js:38`.