### PR TITLE
Add `allowedValues` to `filterDOMProps`

### DIFF
--- a/packages/uniforms/src/filterDOMProps.js
+++ b/packages/uniforms/src/filterDOMProps.js
@@ -23,7 +23,8 @@ const unwantedProps = [
     'transform',
     'value',
 
-    // This is used by AutoField
+    // These are used by AutoField
+    'allowedValues',
     'component'
 ];
 


### PR DESCRIPTION
When using the `AutoField` (and this can be done indirectly
via `AutoFields`), it is possible for `allowedValues` to be
passed from the `props` to the underlying DOM element.
In such a case, a runtime warning will be triggered:

	React does not recognize the `allowedValues` prop on a DOM element

A summary of the component stack:

	in input (created by Input)
	in Input (created by Text)
	...
	in Text (created by TextField)
	in TextField (created by AutoField)

To silence this warning, `filterDOMProps` has been updated to
exclude `allowedValues` from being passed to the underlying
DOM element.

This commit does not deal with package versioning.

Resolves #389

---

Small example to replicate the warning: https://codesandbox.io/s/xwy15nn0o


<!-- Before you open a pull request, please check if a similar one already exists or has been closed before. -->
