### PR TITLE
Restore default SubmitField labels

### DIFF
--- a/packages/uniforms-bootstrap3/src/SubmitField.js
+++ b/packages/uniforms-bootstrap3/src/SubmitField.js
@@ -51,6 +51,6 @@ const SubmitField = ({
 };
 
 SubmitField.contextTypes = BaseField.contextTypes;
-SubmitField.defaultProps = {inputClassName: 'btn btn-primary'};
+SubmitField.defaultProps = {inputClassName: 'btn btn-primary', value: 'Submit'};
 
 export default SubmitField;

--- a/packages/uniforms-bootstrap4/src/SubmitField.js
+++ b/packages/uniforms-bootstrap4/src/SubmitField.js
@@ -51,6 +51,6 @@ const SubmitField = ({
 };
 
 SubmitField.contextTypes = BaseField.contextTypes;
-SubmitField.defaultProps = {inputClassName: 'btn btn-primary'};
+SubmitField.defaultProps = {inputClassName: 'btn btn-primary', value: 'Submit'};
 
 export default SubmitField;

--- a/packages/uniforms-semantic/src/SubmitField.js
+++ b/packages/uniforms-semantic/src/SubmitField.js
@@ -15,5 +15,6 @@ const SubmitField = ({className, disabled, inputRef, value, ...props}, {uniforms
 ;
 
 SubmitField.contextTypes = BaseField.contextTypes;
+SubmitField.defaultProps = {value: 'Submit'};
 
 export default SubmitField;

--- a/packages/uniforms-unstyled/src/SubmitField.js
+++ b/packages/uniforms-unstyled/src/SubmitField.js
@@ -13,5 +13,6 @@ const SubmitField = ({disabled, inputRef, value, ...props}, {uniforms: {error, s
 ;
 
 SubmitField.contextTypes = BaseField.contextTypes;
+SubmitField.defaultProps = {value: 'Submit'};
 
 export default SubmitField;


### PR DESCRIPTION
Restores missing default labels on SubmitField. The issue was raised [here](https://github.com/vazco/uniforms/issues/420#issuecomment-387356250)