### PR TITLE
wrapperStyle prop not filtered out in uniforms antd

### DIFF
--- a/packages/uniforms-antd/src/wrapField.js
+++ b/packages/uniforms-antd/src/wrapField.js
@@ -52,5 +52,6 @@ export default function wrapField ({
 filterDOMProps.register(
     'colon',
     'labelCol',
-    'wrapperCol'
+    'wrapperCol',
+    'wrapperStyle'
 );


### PR DESCRIPTION
When using uniforms-and, The prop wrapperStyle is not being recognized, due to the fact that is not filtered out, in wrapField.js file.