### PR TITLE
Support date and datetime-local inputs

### DIFF
--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -7,7 +7,8 @@ import connectField   from 'uniforms/connectField';
 import filterDOMProps from 'uniforms/filterDOMProps';
 
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = value => value && value.toISOString().slice(0, -8);
+const dateFormat = value => value && value.toISOString().slice(0, -14);
+const dateTimeFormat = value => value && value.toISOString().slice(0, -8);
 const dateParse = (timestamp, onChange) => {
     const date = new DateConstructor(timestamp);
     if (date.getFullYear() < 10000) {
@@ -48,7 +49,7 @@ const Date = ({
             placeholder={placeholder}
             ref={inputRef}
             type="datetime-local"
-            value={dateFormat(value)}
+            value={props.inputProps && props.inputProps.type === 'date' ? dateFormat(value) : dateTimeFormat(value)}
             {...filterDOMProps(props)}
         />
         {showInlineError && error ? (


### PR DESCRIPTION
It'd be helpful for DateField to also support `type: 'date'` inputs, instead of only `datefield-local`. Currently, you can change the type, but the data does not appear, as it has to be formatted properly: `YYYY-MM-DD`.
 
I propose a working, though not very elegant solution, that checks for `inputProps` being passed to the material-ui `Input` component. [(source)](https://stackoverflow.com/questions/14647290/html-5-date-field-shows-as-mm-dd-yyyy-in-chrome-even-when-valid-date-is-set)

So to use this you have to do (with simple schema):

```js
new SimpleSchema({
  dateField: { type: Date, uniforms: { inputProps: { type: 'date' } } },
  dateTimeField: { type: Date },
})
```

It works in chrome, haven't tested it in other browsers yet.