### PR TITLE
Pass labelProps to DateField and SelectField

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Fields](#fields)
     - [`AutoField`](#autofield)
     - [`AutoFields`](#autofields)
@@ -325,6 +326,11 @@ import DateField from 'uniforms-unstyled/DateField'; // Choose your theme packag
     //   receive a field component rather than an HTML input. If you need an input ref,
     //   use this prop instead.
     inputRef={ref => {}}
+
+    // Props for the FormLabel
+    // Available in:
+    //   material-ui
+    labelProps={{ shrink: true, disableAnimation: true }}
 
     // Maximum value.
     //   Date object.
@@ -858,6 +864,11 @@ import SelectField from 'uniforms-unstyled/SelectField'; // Choose your theme pa
     //   receive a field component rather than a HTML input. If you need an input ref,
     //   use this prop instead.
     inputRef={ref => {}}
+
+    // Props for the FormLabel
+    // Available in:
+    //   material-ui
+    labelProps={{ shrink: true, disableAnimation: true }}
 
     // Field inline error.
     //   *Some description would be great, huh?*

--- a/API.md
+++ b/API.md
@@ -327,7 +327,7 @@ import DateField from 'uniforms-unstyled/DateField'; // Choose your theme packag
     //   use this prop instead.
     inputRef={ref => {}}
 
-    // Props for the FormLabel
+    // Props for the InputLabel
     // Available in:
     //   material-ui
     labelProps={{ shrink: true, disableAnimation: true }}
@@ -865,7 +865,7 @@ import SelectField from 'uniforms-unstyled/SelectField'; // Choose your theme pa
     //   use this prop instead.
     inputRef={ref => {}}
 
-    // Props for the FormLabel
+    // Props for the InputLabel
     // Available in:
     //   material-ui
     labelProps={{ shrink: true, disableAnimation: true }}

--- a/API.md
+++ b/API.md
@@ -1,6 +1,5 @@
 # Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Fields](#fields)
     - [`AutoField`](#autofield)
     - [`AutoFields`](#autofields)

--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -1,7 +1,7 @@
 import FormControl    from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import InputLabel     from '@material-ui/core/InputLabel';
 import Input          from '@material-ui/core/Input';
+import InputLabel     from '@material-ui/core/InputLabel';
 import React          from 'react';
 import connectField   from 'uniforms/connectField';
 import filterDOMProps from 'uniforms/filterDOMProps';
@@ -25,6 +25,7 @@ const Date = ({
     helperText,
     inputRef,
     label,
+    labelProps,
     margin,
     name,
     onChange,
@@ -32,7 +33,6 @@ const Date = ({
     required,
     showInlineError,
     value,
-    labelProps,
     ...props
 }) => (
     <FormControl

--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -1,6 +1,6 @@
 import FormControl    from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import FormLabel      from '@material-ui/core/FormLabel';
+import InputLabel     from '@material-ui/core/InputLabel';
 import Input          from '@material-ui/core/Input';
 import React          from 'react';
 import connectField   from 'uniforms/connectField';
@@ -32,6 +32,7 @@ const Date = ({
     required,
     showInlineError,
     value,
+    labelProps,
     ...props
 }) => (
     <FormControl
@@ -41,7 +42,7 @@ const Date = ({
         margin={margin}
         required={required}
     >
-        {label && <FormLabel component="legend" htmlFor={name}>{label}</FormLabel>}
+        {label && <InputLabel htmlFor={name} {...labelProps}>{label}</InputLabel>}
         <Input
             name={name}
             onChange={event => dateParse(event.target.valueAsNumber, onChange)}

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -43,6 +43,7 @@ const renderSelect = ({
     showInlineError,
     transform,
     value,
+    labelProps,
     ...props
 }) => {
     const Item = native ? 'option' : MenuItem;
@@ -55,7 +56,7 @@ const renderSelect = ({
             margin={margin}
             required={required}
         >
-            {label && <InputLabel htmlFor={name}>{label}</InputLabel>}
+            {label && <InputLabel htmlFor={name} {...labelProps}>{label}</InputLabel>}
             <SelectMaterial
                 inputProps={{name, id, ...inputProps}}
                 multiple={fieldType === Array || undefined}

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -34,6 +34,7 @@ const renderSelect = ({
     id,
     inputProps,
     label,
+    labelProps,
     margin,
     name,
     native,
@@ -43,7 +44,6 @@ const renderSelect = ({
     showInlineError,
     transform,
     value,
-    labelProps,
     ...props
 }) => {
     const Item = native ? 'option' : MenuItem;


### PR DESCRIPTION
Addresses #481. 

It turns out there was only `DateField` and `SelectField` that can use the extra `labelProps`. The `TextField` component, used in most places, can already get a `InputLabelProps` prop that will be passed to its `InputLabel`.

For the sake of consistency, I changed the `FormLabel` to `InputLabel` on `DateField`, as I don't think it is required. I'll revert it if there was a specific reason behind it.