### PR TITLE
Uses the common JSON Schema "title" property as the default field label when it exists

### DIFF
--- a/packages/uniforms/__tests__/JSONSchemaBridge.js
+++ b/packages/uniforms/__tests__/JSONSchemaBridge.js
@@ -58,7 +58,7 @@ describe('JSONSchemaBridge', () => {
                     $ref: '#/definitions/personalData'
                 }
             },
-            hasAJob: {type: 'boolean'},
+            hasAJob: {type: 'boolean', title: 'Currently Employed'},
             invalid: {type: 'null'},
             personalData: {$ref: '#/definitions/personalData'},
             salary: {
@@ -256,6 +256,16 @@ describe('JSONSchemaBridge', () => {
             expect(bridge.getProps('dateOfBirth', {label: true})).toEqual({
                 label: 'Date of birth',
                 required: true
+            });
+        });
+
+        it('works with property title as default label', () => {
+            expect(bridge.getProps('hasAJob', {label: true})).toEqual({
+                allowedValues: undefined,
+                label: 'Currently Employed',
+                options: undefined,
+                placeholder: undefined,
+                required: false
             });
         });
 

--- a/packages/uniforms/src/JSONSchemaBridge.js
+++ b/packages/uniforms/src/JSONSchemaBridge.js
@@ -145,7 +145,7 @@ export default class JSONSchemaBridge extends Bridge {
     }
 
     getProps (name, {label = true, options: opts, placeholder, ...props} = {}) {
-        const {enum: _enum, type: _type, options: _options, uniforms} = this.getField(name);
+        const {title: _title, enum: _enum, type: _type, options: _options, uniforms} = this.getField(name);
         const {
             enum: allowedValues = _enum, options = _options,type: fieldType = _type, isRequired
         } = this._compiledSchema[name];
@@ -153,13 +153,14 @@ export default class JSONSchemaBridge extends Bridge {
         const [fieldName] = joinName(null, name).slice(-1).map(str => str.replace(/([A-Z])/g, ' $1'));
 
         const fieldNameCapitalized = fieldName.charAt(0).toUpperCase() + fieldName.slice(1).toLowerCase();
+        const labelContent = _title ? _title : fieldNameCapitalized;
 
         const ready = {
             allowedValues,
             ...(fieldType === 'number' ? {decimal: true} : {}),
             options: opts || options,
-            label: label === true ? fieldNameCapitalized : label || '',
-            placeholder: placeholder === true ? fieldNameCapitalized : placeholder,
+            label: label === true ? labelContent : label || '',
+            placeholder: placeholder === true ? labelContent : placeholder,
             required: isRequired
         };
 


### PR DESCRIPTION
<!-- Before you open a pull request, please check if a similar one already exists or has been closed before. -->

JSON schema convention uses "title": on a property to specify a human-friendly label.  

This PR tries to use this title when label:true, before falling back to fieldNameCapitalized()