### PR TITLE
Stop using deprecated "raised" variant, use "contained" instead

### DIFF
--- a/packages/uniforms-material/package.json
+++ b/packages/uniforms-material/package.json
@@ -22,7 +22,7 @@
     "src/"
   ],
   "peerDependencies": {
-    "@material-ui/core": "^3.0.0 || ^1.0.0",
+    "@material-ui/core": "^3.0.0 || ^1.2.0",
     "react": "^16.0.0 || ^15.0.0 || ^0.14.0",
     "uniforms": "^1.29.0"
   },

--- a/packages/uniforms-material/src/SubmitField.js
+++ b/packages/uniforms-material/src/SubmitField.js
@@ -16,6 +16,6 @@ const SubmitField = ({children, disabled, inputRef, label, value, ...props}, {un
 );
 SubmitField.contextTypes = BaseField.contextTypes;
 
-SubmitField.defaultProps = {label: 'Submit', variant: 'raised'};
+SubmitField.defaultProps = {label: 'Submit', variant: 'contained'};
 
 export default SubmitField;


### PR DESCRIPTION
Material-ui has started throwing warnings when using the old `raised` variant.