### PR TITLE
Added wrapField.filterDOMProps in uniforms-material (fixed #501).

### DIFF
--- a/packages/uniforms-material/src/BoolField.js
+++ b/packages/uniforms-material/src/BoolField.js
@@ -12,7 +12,7 @@ import wrapField from './wrapField';
 
 const Bool = ({appearance, disabled, inputRef, label, legend, name, onChange, transform, value, ...props}) => {
   const SelectionControl = appearance === 'checkbox' ? Checkbox : Switch;
-  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
+  const filteredProps = wrapField._filterDOMProps(filterDOMProps(props));
 
   return wrapField(
     {...props, component: 'fieldset', disabled},

--- a/packages/uniforms-material/src/BoolField.js
+++ b/packages/uniforms-material/src/BoolField.js
@@ -12,6 +12,7 @@ import wrapField from './wrapField';
 
 const Bool = ({appearance, disabled, inputRef, label, legend, name, onChange, transform, value, ...props}) => {
   const SelectionControl = appearance === 'checkbox' ? Checkbox : Switch;
+  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
 
   return wrapField(
     {...props, component: 'fieldset', disabled},
@@ -29,7 +30,7 @@ const Bool = ({appearance, disabled, inputRef, label, legend, name, onChange, tr
             onChange={event => disabled || onChange(event.target.checked)}
             ref={inputRef}
             value={name}
-            {...filterDOMProps(props)}
+            {...filteredProps}
           />
         }
         label={transform ? transform(label) : label}

--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -17,8 +17,10 @@ const dateParse = (timestamp, onChange) => {
   }
 };
 
-const Date = ({inputRef, label, labelProps, name, onChange, placeholder, value, ...props}) =>
-  wrapField(
+const Date = ({inputRef, label, labelProps, name, onChange, placeholder, value, ...props}) => {
+  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
+
+  return wrapField(
     {...props, component: undefined},
     label && (
       <InputLabel htmlFor={name} {...labelProps}>
@@ -32,9 +34,10 @@ const Date = ({inputRef, label, labelProps, name, onChange, placeholder, value, 
       ref={inputRef}
       type="datetime-local"
       value={dateFormat(value)}
-      {...filterDOMProps(props)}
+      {...filteredProps}
     />
   );
+};
 
 Date.defaultProps = {
   fullWidth: true,

--- a/packages/uniforms-material/src/DateField.js
+++ b/packages/uniforms-material/src/DateField.js
@@ -18,7 +18,7 @@ const dateParse = (timestamp, onChange) => {
 };
 
 const Date = ({inputRef, label, labelProps, name, onChange, placeholder, value, ...props}) => {
-  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
+  const filteredProps = wrapField._filterDOMProps(filterDOMProps(props));
 
   return wrapField(
     {...props, component: undefined},

--- a/packages/uniforms-material/src/RadioField.js
+++ b/packages/uniforms-material/src/RadioField.js
@@ -20,8 +20,10 @@ const Radio = ({
   transform,
   value,
   ...props
-}) =>
-  wrapField(
+}) => {
+  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
+
+  return wrapField(
     {...props, disabled, component: 'fieldset'},
     label && (
       <FormLabel component="legend" htmlFor={name}>
@@ -37,7 +39,7 @@ const Radio = ({
     >
       {allowedValues.map(item => (
         <FormControlLabel
-          control={<RadioMaterial {...filterDOMProps(props)} />}
+          control={<RadioMaterial {...filteredProps} />}
           key={item}
           label={transform ? transform(item) : item}
           value={`${item}`}
@@ -45,6 +47,7 @@ const Radio = ({
       ))}
     </RadioGroup>
   );
+};
 
 Radio.defaultProps = {
   fullWidth: true,

--- a/packages/uniforms-material/src/RadioField.js
+++ b/packages/uniforms-material/src/RadioField.js
@@ -21,7 +21,7 @@ const Radio = ({
   value,
   ...props
 }) => {
-  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
+  const filteredProps = wrapField._filterDOMProps(filterDOMProps(props));
 
   return wrapField(
     {...props, disabled, component: 'fieldset'},

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -42,7 +42,7 @@ const renderSelect = ({
   ...props
 }) => {
   const Item = native ? 'option' : MenuItem;
-  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
+  const filteredProps = wrapField._filterDOMProps(filterDOMProps(props));
 
   return wrapField(
     {...props, component: undefined, disabled, required},
@@ -93,7 +93,7 @@ const renderCheckboxes = ({
   ...props
 }) => {
   let children;
-  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
+  const filteredProps = wrapField._filterDOMProps(filterDOMProps(props));
 
   if (fieldType !== Array) {
     children = (

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -42,6 +42,7 @@ const renderSelect = ({
   ...props
 }) => {
   const Item = native ? 'option' : MenuItem;
+  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
 
   return wrapField(
     {...props, component: undefined, disabled, required},
@@ -57,7 +58,7 @@ const renderSelect = ({
       native={native}
       onChange={event => disabled || onChange(event.target.value)}
       value={native && !value ? '' : value}
-      {...filterDOMProps(props)}
+      {...filteredProps}
     >
       {!!placeholder && (
         <Item value="" disabled={!!required}>
@@ -92,6 +93,7 @@ const renderCheckboxes = ({
   ...props
 }) => {
   let children;
+  const filteredProps = filterDOMProps(wrapField.filterDOMProps(props));
 
   if (fieldType !== Array) {
     children = (
@@ -104,7 +106,7 @@ const renderCheckboxes = ({
       >
         {allowedValues.map(item => (
           <FormControlLabel
-            control={<Radio id={`${id}-${item}`} {...filterDOMProps(props)} />}
+            control={<Radio id={`${id}-${item}`} {...filteredProps} />}
             key={item}
             label={transform ? transform(item) : item}
             value={item}
@@ -128,7 +130,7 @@ const renderCheckboxes = ({
                 onChange={() => disabled || onChange(xor(item, value))}
                 ref={inputRef}
                 value={props.name}
-                {...filterDOMProps(props)}
+                {...filteredProps}
               />
             }
             key={item}

--- a/packages/uniforms-material/src/wrapField.js
+++ b/packages/uniforms-material/src/wrapField.js
@@ -26,5 +26,5 @@ export default function wrapField(
   );
 }
 
-wrapField.filterDOMPropsList = ['fullWidth', 'helperText', 'margin', 'variant'];
-wrapField.filterDOMProps = props => omit(props, wrapField.filterDOMPropsList);
+wrapField._filterDOMPropsList = ['fullWidth', 'helperText', 'margin', 'variant'];
+wrapField._filterDOMProps = props => omit(props, wrapField._filterDOMPropsList);

--- a/packages/uniforms-material/src/wrapField.js
+++ b/packages/uniforms-material/src/wrapField.js
@@ -1,6 +1,7 @@
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import React from 'react';
+import omit from 'lodash/omit';
 
 export default function wrapField(
   {component, disabled, error, errorMessage, fullWidth, helperText, margin, required, showInlineError, variant},
@@ -24,3 +25,6 @@ export default function wrapField(
     !!formHelperText && <FormHelperText>{formHelperText}</FormHelperText>
   );
 }
+
+wrapField.filterDOMPropsList = ['fullWidth', 'helperText', 'margin', 'variant'];
+wrapField.filterDOMProps = props => omit(props, wrapField.filterDOMPropsList);


### PR DESCRIPTION
This PR introduces `wrapField.filterDOMProps` and `wrapField.filterDOMPropsList` in `uniforms-material` theme. Usage is the same as for `filterDOMProps` - if you use `wrapField`, then filter your props to get rid of these used in that helper.

Questions:
* Is the name OK? I'm especially concerned about the `filterDOMPropsList`.
* Should we make it public or prefix it with an underscore and treat it as an implementation detail?
* Should we introduce such logic in other themes for compatibility?