### PR TITLE
Use material-ui icons to make IconButtons have a square aspect-ratio

### DIFF
--- a/packages/uniforms-material/package-lock.json
+++ b/packages/uniforms-material/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "uniforms-material",
-	"version": "1.30.0",
+	"version": "1.31.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9,85 +9,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
 			"integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
 			"requires": {
-				"regenerator-runtime": "^0.12.0"
-			}
-		},
-		"@material-ui/icons": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.1.tgz",
-			"integrity": "sha512-1kNcxYiIT1x8iDPEAlgmKrfRTIV8UyK6fLVcZ9kMHIKGWft9I451V5mvSrbCjbf7MX1TbLWzZjph0aVCRf9MqQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "7.0.0",
-				"recompose": "^0.29.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-					"integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.12.0"
-					}
-				}
-			}
-		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
-		},
-		"change-emitter": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
-			"dev": true
-		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"dev": true,
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			}
-		},
-		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-			"dev": true
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"regenerator-runtime": "0.12.1"
 			}
 		},
 		"invariant": {
@@ -95,23 +17,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
+				"loose-envify": "1.4.0"
 			}
 		},
 		"js-tokens": {
@@ -129,17 +35,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"dev": true,
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"js-tokens": "4.0.0"
 			}
 		},
 		"object-assign": {
@@ -147,78 +43,19 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
-			"requires": {
-				"asap": "~2.0.3"
-			}
-		},
 		"prop-types": {
 			"version": "15.6.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
 			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
 			"requires": {
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
-			}
-		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-			"dev": true
-		},
-		"recompose": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.29.0.tgz",
-			"integrity": "sha512-J/qLXNU4W+AeHCDR70ajW8eMd1uroqZaECTj6qqDLPMILz3y0EzpYlvrnxKB9DnqcngWrtGwjXY9JeXaW9kS1A==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"change-emitter": "^0.1.2",
-				"fbjs": "^0.8.1",
-				"hoist-non-react-statics": "^2.3.1",
-				"react-lifecycles-compat": "^3.0.2",
-				"symbol-observable": "^1.0.4"
+				"loose-envify": "1.4.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"regenerator-runtime": {
 			"version": "0.12.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
 			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-			"dev": true
-		},
-		"ua-parser-js": {
-			"version": "0.7.19",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
-			"dev": true
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-			"dev": true
 		}
 	}
 }

--- a/packages/uniforms-material/package.json
+++ b/packages/uniforms-material/package.json
@@ -23,11 +23,9 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "^3.0.0 || ^1.2.0",
+    "@material-ui/icons": "3.0.1",
     "react": "^16.0.0 || ^15.0.0 || ^0.14.0",
     "uniforms": "^1.30.0"
-  },
-  "devDependencies": {
-    "@material-ui/icons": "3.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",

--- a/packages/uniforms-material/src/ListAddField.js
+++ b/packages/uniforms-material/src/ListAddField.js
@@ -1,5 +1,6 @@
 import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
+import Add from '@material-ui/icons/Add';
 import PropTypes from 'prop-types';
 import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
@@ -28,7 +29,7 @@ ListAdd.propTypes = {
 
 ListAdd.defaultProps = {
   fullWidth: true,
-  icon: '+',
+  icon: <Add />,
   margin: 'dense'
 };
 

--- a/packages/uniforms-material/src/ListDelField.js
+++ b/packages/uniforms-material/src/ListDelField.js
@@ -1,4 +1,5 @@
 import IconButton from '@material-ui/core/IconButton';
+import Remove from '@material-ui/icons/Remove';
 import PropTypes from 'prop-types';
 import React from 'react';
 import connectField from 'uniforms/connectField';
@@ -27,7 +28,7 @@ ListDel.propTypes = {
 };
 
 ListDel.defaultProps = {
-  icon: '-'
+  icon: <Remove />
 };
 
 export default connectField(ListDel, {includeParent: true, initialValue: false});


### PR DESCRIPTION
I've always been annoyed by the list add-del fields in uniforms-material, because they aren't perfectly circular.

Using the real material-ui icons solves this issue.

We're actually using other icons, which I believe are even cleaner, but maybe that's going too far:

<img width="601" alt="screenshot 2019-02-01 at 14 19 56" src="https://user-images.githubusercontent.com/10428082/52125369-8bf4bf00-262c-11e9-8363-942647aa1571.png">
