### PR TITLE
Add material-ui to the list of npm keywords

### DIFF
--- a/packages/uniforms-material/package.json
+++ b/packages/uniforms-material/package.json
@@ -14,6 +14,7 @@
     "meteor",
     "react",
     "react-component",
+    "material-ui",
     "schema",
     "validation"
   ],


### PR DESCRIPTION
I would like to enable a third-party component search for Material-UI components like Gatsby is doing it with its plugins page: https://www.gatsbyjs.org/plugins/.

<!-- Before you open a pull request, please check if a similar one already exists or has been closed before. -->
