### PR TITLE
Simplified QuickForm rendering

### DIFF
--- a/packages/uniforms/src/QuickForm.js
+++ b/packages/uniforms/src/QuickForm.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import omit from 'lodash/omit';
 
 import BaseForm from './BaseForm';
 import nothing from './nothing';
@@ -20,31 +19,21 @@ const Quick = parent =>
     };
 
     getNativeFormProps() {
-      return omit(super.getNativeFormProps(), ['autoField', 'errorsField', 'submitField']);
-    }
+      const {
+        autoField: AutoField = this.getAutoField(),
+        errorsField: ErrorsField = this.getErrorsField(),
+        submitField: SubmitField = this.getSubmitField(),
+        ...props
+      } = super.getNativeFormProps();
 
-    render() {
-      const nativeFormProps = this.getNativeFormProps();
-      if (nativeFormProps.children) {
-        return super.render();
+      if (!props.children) {
+        props.children = this.getChildContextSchema()
+          .getSubfields()
+          .map(key => <AutoField key={key} name={key} />)
+          .concat([<ErrorsField key="$ErrorsField" />, <SubmitField key="$SubmitField" />]);
       }
 
-      const AutoField = this.props.autoField || this.getAutoField();
-      const ErrorsField = this.props.errorsField || this.getErrorsField();
-      const SubmitField = this.props.submitField || this.getSubmitField();
-
-      return (
-        <form {...nativeFormProps}>
-          {this.getChildContextSchema()
-            .getSubfields()
-            .map(key => (
-              <AutoField key={key} name={key} />
-            ))}
-
-          <ErrorsField />
-          <SubmitField />
-        </form>
-      );
+      return props;
     }
 
     getAutoField() {


### PR DESCRIPTION
With this change, using a different form component can override only `BaseForm.render`, instead of both `BaseForm` and `QuickForm`.