### PR TITLE
use transform for keys in material view

### DIFF
--- a/packages/uniforms-material/src/RadioField.js
+++ b/packages/uniforms-material/src/RadioField.js
@@ -40,7 +40,7 @@ const Radio = ({
       {allowedValues.map(item => (
         <FormControlLabel
           control={<RadioMaterial {...filteredProps} />}
-          key={item}
+          key={transform ? transform(item) : item}
           label={transform ? transform(item) : item}
           value={`${item}`}
         />

--- a/packages/uniforms-material/src/SelectField.js
+++ b/packages/uniforms-material/src/SelectField.js
@@ -120,7 +120,7 @@ const renderCheckboxes = ({
         {allowedValues.map(item => (
           <FormControlLabel
             control={<Radio id={`${id}-${item}`} {...filteredProps} />}
-            key={item}
+            key={transform ? transform(item) : item}
             label={transform ? transform(item) : item}
             value={item}
           />
@@ -146,7 +146,7 @@ const renderCheckboxes = ({
                 {...filteredProps}
               />
             }
-            key={item}
+            key={transform ? transform(item) : item}
             label={transform ? transform(item) : item}
           />
         ))}


### PR DESCRIPTION
If you pass Objects as options, you'll get this error. This is because of `key={item}` which assigns an Object to the key which translates to `[object Object]`.

``Warning: Encountered two children with the same key, `.$.1=2$[object Object]`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.``