### PR TITLE
refactor TextField with state

### DIFF
--- a/packages/uniforms-unstyled/src/TextField.js
+++ b/packages/uniforms-unstyled/src/TextField.js
@@ -1,8 +1,20 @@
 import React from 'react';
 import connectField from 'uniforms/connectField';
 import filterDOMProps from 'uniforms/filterDOMProps';
+import {Component} from 'react';
 
-const Text = ({disabled, id, inputRef, label, name, onChange, placeholder, type, value, ...props}) => (
+const Text_ = ({
+  disabled,
+  id,
+  inputRef,
+  label,
+  name,
+  onChange,
+  placeholder,
+  type,
+  value,
+  ...props
+}) => (
   <div {...filterDOMProps(props)}>
     {label && <label htmlFor={id}>{label}</label>}
 
@@ -10,7 +22,7 @@ const Text = ({disabled, id, inputRef, label, name, onChange, placeholder, type,
       disabled={disabled}
       id={id}
       name={name}
-      onChange={event => onChange(event.target.value)}
+      onChange={onChange}
       placeholder={placeholder}
       ref={inputRef}
       type={type}
@@ -18,6 +30,31 @@ const Text = ({disabled, id, inputRef, label, name, onChange, placeholder, type,
     />
   </div>
 );
-Text.defaultProps = {type: 'text'};
+
+Text_.defaultProps = { type: 'text' };
+
+// NOTE: React < 16 workaround. Make it optional?
+class Text extends Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {value: '' + this.props.value};
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  componentWillReceiveProps({value}) {
+    this.setState({value: value === undefined || value === '' ? '' : '' + value});
+  }
+
+  onChange({target: {value}}) {
+    this.setState({value});
+    this.props.onChange(value);
+  }
+
+  render() {
+    return Text_({...this.props, onChange: this.onChange, value: this.state.value});
+  }
+}
 
 export default connectField(Text);


### PR DESCRIPTION
This fix issue #528 

It adds internal state to TextField so it updates even when wrapped inside Pose component (see issue for more details).