### PR TITLE
Nesting Arrays breaks props from schemaMetadata

### DIFF
--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.js
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.js
@@ -100,7 +100,7 @@ export default class GraphQLBridge extends Bridge {
 
   // eslint-disable-next-line complexity
   getProps(nameNormal, props = {}) {
-    const nameGeneric = nameNormal.replace(/\.\d+/, '.$');
+    const nameGeneric = nameNormal.replace(/\.\d+/g, '.$');
 
     const field = this.getField(nameGeneric, false);
     const fieldType = extractFromNonNull(field).type;


### PR DESCRIPTION
Hi,

when you try to create labels for nested arrays in a schema the replacement code broke. Setting the regex replacement to global fixes it. 

This did not work prior to the fix since only the first index, in this case, the `0` is replaced - the second `3` is not touched.
` .getProps("arrayFieldA.0.innerArray.3.description")`
but works after the fix.

<!-- Before you open a pull request, please check if a similar one already exists or has been closed before. -->
