### PR TITLE
Antd help prop

### DIFF
--- a/docs/api-fields.md
+++ b/docs/api-fields.md
@@ -130,7 +130,7 @@ import BoolField from 'uniforms-unstyled/BoolField'; // Choose your theme packag
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
-  //   antd (alias of "extra")
+  //   antd
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -233,7 +233,7 @@ import DateField from 'uniforms-unstyled/DateField'; // Choose your theme packag
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
-  //   antd (alias of "extra")
+  //   antd
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -492,7 +492,7 @@ import LongTextField from 'uniforms-unstyled/LongTextField'; // Choose your them
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
-  //   antd (alias of "extra")
+  //   antd
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -627,7 +627,7 @@ import NumField from 'uniforms-unstyled/NumField'; // Choose your theme package.
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
-  //   antd (alias of "extra")
+  //   antd
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -792,7 +792,7 @@ import SelectField from 'uniforms-unstyled/SelectField'; // Choose your theme pa
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
-  //   antd (alias of "extra")
+  //   antd
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -909,7 +909,7 @@ import TextField from 'uniforms-unstyled/TextField'; // Choose your theme packag
     // Help text.
   //   *Some description would be great, huh?*
   // Available in:
-  //   antd (alias of "extra")
+  //   antd
   //   bootstrap3
   //   bootstrap4
   help="Need help?"

--- a/docs/api-fields.md
+++ b/docs/api-fields.md
@@ -136,6 +136,7 @@ import BoolField from 'uniforms-unstyled/BoolField'; // Choose your theme packag
   // Help block className.
   //   *Some description would be great, huh?*
   // Available in:
+  //   antd
   //   bootstrap3
   //   bootstrap4
   helpClassName="a b c"

--- a/docs/api-fields.md
+++ b/docs/api-fields.md
@@ -130,16 +130,21 @@ import BoolField from 'uniforms-unstyled/BoolField'; // Choose your theme packag
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
+  //   antd (alias of "extra")
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
   // Help block className.
   //   *Some description would be great, huh?*
   // Available in:
-  //   antd
   //   bootstrap3
   //   bootstrap4
   helpClassName="a b c"
+  // Extra feedback text.
+  //   In the antd theme, this renders addtional help text below any validation messages.
+  // Available in:
+  //   antd
+  extra="Extra Feedback or Help"
   // Checkbox inline state.
   //   In bootstrap themes, a label is rendered as a text but in inline mode,
   //   it's treated as a field label.
@@ -228,6 +233,7 @@ import DateField from 'uniforms-unstyled/DateField'; // Choose your theme packag
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
+  //   antd (alias of "extra")
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -237,6 +243,11 @@ import DateField from 'uniforms-unstyled/DateField'; // Choose your theme packag
   //   bootstrap3
   //   bootstrap4
   helpClassName="a b c"
+  // Extra feedback text.
+  //   In the antd theme, this renders addtional help text below any validation messages.
+  // Available in:
+  //   antd
+  extra="Extra Feedback or Help"
   // Input icon.
   //   Semantic inputs can have an icon. By default, it's placed on the right
   //   side - to place it on the left, use iconLeft prop instead.
@@ -459,12 +470,6 @@ import LongTextField from 'uniforms-unstyled/LongTextField'; // Choose your them
   grid="4" // 'col-4-sm' on label, 'col-8-sm' on input
   grid={{md: 5}} // 'col-5-md' on label, 'col-7-md' on input
   grid="col-6-xl" // 'col-6-xl' on label, 'col-6-xl' on input
-  // Help text.
-  //   *Some description would be great, huh?*
-  // Available in:
-  //   bootstrap3
-  //   bootstrap4
-  help="Need help?"
   // label className.
   //   A custom className for the field's label
   // Available in:
@@ -484,12 +489,24 @@ import LongTextField from 'uniforms-unstyled/LongTextField'; // Choose your them
   //   antd
   wrapperCol={{span: 4}} // 'ant-col-4' on field
   wrapperCol={{offset: 2}} // 'ant-col-offset-2' on field
+  // Help text.
+  //   *Some description would be great, huh?*
+  // Available in:
+  //   antd (alias of "extra")
+  //   bootstrap3
+  //   bootstrap4
+  help="Need help?"
   // Help block className.
   //   *Some description would be great, huh?*
   // Available in:
   //   bootstrap3
   //   bootstrap4
   helpClassName="a b c"
+  // Extra feedback text.
+  //   In the antd theme, this renders addtional help text below any validation messages.
+  // Available in:
+  //   antd
+  extra="Extra Feedback or Help"
   // Input icon.
   //   Semantic inputs can have an icon. By default, it's placed on the right
   //   side - to place it on the left, use iconLeft prop instead.
@@ -610,6 +627,7 @@ import NumField from 'uniforms-unstyled/NumField'; // Choose your theme package.
   // Help text.
   //   *Some description would be great, huh?*
   // Available in:
+  //   antd (alias of "extra")
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -619,6 +637,11 @@ import NumField from 'uniforms-unstyled/NumField'; // Choose your theme package.
   //   bootstrap3
   //   bootstrap4
   helpClassName="a b c"
+  // Extra feedback text.
+  //   In the antd theme, this renders addtional help text below any validation messages.
+  // Available in:
+  //   antd
+  extra="Extra Feedback or Help"
   // Input icon.
   //   Semantic inputs can have an icon. By default, it's placed on the right
   //   side - to place it on the left, use iconLeft prop instead.
@@ -766,6 +789,24 @@ import SelectField from 'uniforms-unstyled/SelectField'; // Choose your theme pa
   //   antd
   wrapperCol={{span: 4}} // 'ant-col-4' on field
   wrapperCol={{offset: 2}} // 'ant-col-offset-2' on field
+  // Help text.
+  //   *Some description would be great, huh?*
+  // Available in:
+  //   antd (alias of "extra")
+  //   bootstrap3
+  //   bootstrap4
+  help="Need help?"
+  // Help block className.
+  //   *Some description would be great, huh?*
+  // Available in:
+  //   bootstrap3
+  //   bootstrap4
+  helpClassName="a b c"
+  // Extra feedback text.
+  //   In the antd theme, this renders addtional help text below any validation messages.
+  // Available in:
+  //   antd
+  extra="Extra Feedback or Help"
   // Checkbox inline state.
   //   In bootstrap themes, label is rendered as a text, but in inline mode,
   //   it's treated as a field label.
@@ -865,9 +906,10 @@ import TextField from 'uniforms-unstyled/TextField'; // Choose your theme packag
   //   antd
   wrapperCol={{span: 4}} // 'ant-col-4' on field
   wrapperCol={{offset: 2}} // 'ant-col-offset-2' on field
-  // Help text.
+    // Help text.
   //   *Some description would be great, huh?*
   // Available in:
+  //   antd (alias of "extra")
   //   bootstrap3
   //   bootstrap4
   help="Need help?"
@@ -877,6 +919,11 @@ import TextField from 'uniforms-unstyled/TextField'; // Choose your theme packag
   //   bootstrap3
   //   bootstrap4
   helpClassName="a b c"
+  // Extra feedback text.
+  //   In the antd theme, this renders addtional help text below any validation messages.
+  // Available in:
+  //   antd
+  extra="Extra Feedback or Help"
   // Input icon.
   //   Semantic inputs can have an icon. By default, it's placed on the right
   //   side - to place it on the left, use iconLeft prop instead.

--- a/packages/uniforms-antd/__tests__/wrapField.js
+++ b/packages/uniforms-antd/__tests__/wrapField.js
@@ -49,7 +49,7 @@ test('<wrapField> - renders wrapper with help text', () => {
   const element = wrapField({ help: 'Help' }, <div />);
   const wrapper = mount(element);
 
-  expect(wrapper.find(Form.Item).prop('extra')).toBe('Help');
+  expect(wrapper.find(Form.Item).prop('help')).toBe('Help');
 });
 
 test('<wrapField> - renders wrapper with extra text', () => {

--- a/packages/uniforms-antd/__tests__/wrapField.js
+++ b/packages/uniforms-antd/__tests__/wrapField.js
@@ -44,3 +44,10 @@ test('<wrapField> - renders wrapper with an error status (error)', () => {
 
   expect(wrapper.find(Form.Item).prop('validateStatus')).toBe('error');
 });
+
+test('<wrapField> - renders wrapper with help text', () => {
+  const element = wrapField({ help: 'Help' }, <div />);
+  const wrapper = mount(element);
+
+  expect(wrapper.find(Form.Item).prop('extra')).toBe('Help');
+});

--- a/packages/uniforms-antd/__tests__/wrapField.js
+++ b/packages/uniforms-antd/__tests__/wrapField.js
@@ -51,3 +51,10 @@ test('<wrapField> - renders wrapper with help text', () => {
 
   expect(wrapper.find(Form.Item).prop('extra')).toBe('Help');
 });
+
+test('<wrapField> - renders wrapper with extra text', () => {
+  const element = wrapField({ extra: 'Extra' }, <div />);
+  const wrapper = mount(element);
+
+  expect(wrapper.find(Form.Item).prop('extra')).toBe('Extra');
+});

--- a/packages/uniforms-antd/src/wrapField.js
+++ b/packages/uniforms-antd/src/wrapField.js
@@ -9,6 +9,7 @@ export default function wrapField(
     colon,
     error,
     errorMessage,
+    extra,
     id,
     info,
     help,
@@ -40,7 +41,7 @@ export default function wrapField(
       colon={colon}
       hasFeedback
       help={showInlineError && error && errorMessage}
-      extra={help}
+      extra={extra || help}
       htmlFor={id}
       label={labelNode}
       labelCol={labelCol}

--- a/packages/uniforms-antd/src/wrapField.js
+++ b/packages/uniforms-antd/src/wrapField.js
@@ -11,6 +11,7 @@ export default function wrapField(
     errorMessage,
     id,
     info,
+    help,
     label,
     labelCol,
     required,
@@ -39,6 +40,7 @@ export default function wrapField(
       colon={colon}
       hasFeedback
       help={showInlineError && error && errorMessage}
+      extra={help}
       htmlFor={id}
       label={labelNode}
       labelCol={labelCol}

--- a/packages/uniforms-antd/src/wrapField.js
+++ b/packages/uniforms-antd/src/wrapField.js
@@ -40,8 +40,8 @@ export default function wrapField(
     <Form.Item
       colon={colon}
       hasFeedback
-      help={showInlineError && error && errorMessage}
-      extra={extra || help}
+      help={help || (showInlineError && error && errorMessage)}
+      extra={extra}
       htmlFor={id}
       label={labelNode}
       labelCol={labelCol}


### PR DESCRIPTION
Here's a quick pull request to add support for the "help" prop on a field when using the antd theme. 

I'm switching a project from bootstrap to antd and discovered this feature was missing for antd.  Seemed like the best fix was to map the help prop to the "extra" prop on the antd Form.Item component.
