### PR TITLE
Fix deprecated icon warning in antd theme

### DIFF
--- a/packages/uniforms-antd/src/BoolField.js
+++ b/packages/uniforms-antd/src/BoolField.js
@@ -23,7 +23,7 @@ const Bool = ({ checkbox, ...props }) =>
 Bool.defaultProps = {
   checkbox: false,
   checkedChildren: <Icon type="check" />,
-  unCheckedChildren: <Icon type="cross" />
+  unCheckedChildren: <Icon type="close" />
 };
 
 export default connectField(Bool, { ensureValue: false });


### PR DESCRIPTION
Fix deprecated icon warning in the antd theme: "Warning: [antd: Icon] Icon 'cross' is typo and depracated, please use 'close' instead."