### PR TITLE
Made NumField adaptive to React version

### DIFF
--- a/packages/uniforms-bootstrap3/__tests__/NumField.js
+++ b/packages/uniforms-bootstrap3/__tests__/NumField.js
@@ -5,6 +5,11 @@ import NumField from 'uniforms-bootstrap3/NumField';
 
 import createContext from './_createContext';
 
+const expectedValueTransform =
+  parseInt(React.version, 10) < 16
+    ? x => (x === undefined ? '' : '' + x)
+    : x => x;
+
 test('<NumField> - renders an input', () => {
   const element = <NumField name="x" />;
   const wrapper = mount(element, createContext({ x: { type: Number } }));
@@ -110,7 +115,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
   );
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('1');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(1));
 
   // NOTE: All following tests are here to cover hacky NumField implementation.
   const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {});
@@ -124,7 +129,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
     { value: 1, decimal: false },
     { value: 1, decimal: false }
   ].forEach(({ decimal = true, value }) => {
-    const valueInput = value === undefined ? '' : '' + value;
+    const valueInput = expectedValueTransform(value);
 
     wrapper.setProps({ decimal });
 
@@ -151,7 +156,7 @@ test('<NumField> - renders an input with correct value (specified)', () => {
   const wrapper = mount(element, createContext({ x: { type: Number } }));
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('2');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(2));
 });
 
 test('<NumField> - renders an input which correctly reacts on change', () => {

--- a/packages/uniforms-bootstrap3/src/NumField.js
+++ b/packages/uniforms-bootstrap3/src/NumField.js
@@ -5,6 +5,7 @@ import connectField from 'uniforms/connectField';
 import wrapField from './wrapField';
 
 const noneIfNaN = x => (isNaN(x) ? undefined : x);
+const parse = (decimal, x) => noneIfNaN((decimal ? parseFloat : parseInt)(x));
 
 const Num_ = props =>
   wrapField(
@@ -27,45 +28,46 @@ const Num_ = props =>
     />
   );
 
-// NOTE: React < 16 workaround. Make it optional?
-class Num extends Component {
-  constructor() {
-    super(...arguments);
+let Num;
+// istanbul ignore next
+if (parseInt(React.version, 10) < 16) {
+  Num = class Num extends Component {
+    state = { value: '' + this.props.value };
 
-    this.state = { value: '' + this.props.value };
+    componentWillReceiveProps({ decimal, value }) {
+      if (
+        parse(decimal, value) !==
+        parse(decimal, this.state.value.replace(/[.,]+$/, ''))
+      ) {
+        this.setState({
+          value: value === undefined || value === '' ? '' : '' + value
+        });
+      }
+    }
 
-    this.onChange = this.onChange.bind(this);
-  }
+    onChange = event => {
+      const value = event.target.value.replace(/[^\d.,-]/g, '');
 
-  componentWillReceiveProps({ decimal, value }) {
-    const parse = decimal ? parseFloat : parseInt;
+      this.setState({ value });
+      this.props.onChange(parse(this.props.decimal, value));
+    };
 
-    if (
-      noneIfNaN(parse(value)) !==
-      noneIfNaN(parse(this.state.value.replace(/[.,]+$/, '')))
-    ) {
-      this.setState({
-        value: value === undefined || value === '' ? '' : '' + value
+    render() {
+      return Num_({
+        ...this.props,
+        onChange: this.onChange,
+        value: this.state.value
       });
     }
-  }
-
-  onChange({ target: { value } }) {
-    const change = value.replace(/[^\d.,-]/g, '');
-
-    this.setState({ value: change });
-    this.props.onChange(
-      noneIfNaN((this.props.decimal ? parseFloat : parseInt)(change))
-    );
-  }
-
-  render() {
-    return Num_({
-      ...this.props,
-      onChange: this.onChange,
-      value: this.state.value
+  };
+} else {
+  Num = props =>
+    Num_({
+      ...props,
+      onChange(event) {
+        props.onChange(parse(props.decimal, event.target.value));
+      }
     });
-  }
 }
 
 export default connectField(Num);

--- a/packages/uniforms-bootstrap4/__tests__/NumField.js
+++ b/packages/uniforms-bootstrap4/__tests__/NumField.js
@@ -5,6 +5,11 @@ import NumField from 'uniforms-bootstrap4/NumField';
 
 import createContext from './_createContext';
 
+const expectedValueTransform =
+  parseInt(React.version, 10) < 16
+    ? x => (x === undefined ? '' : '' + x)
+    : x => x;
+
 test('<NumField> - renders an input', () => {
   const element = <NumField name="x" />;
   const wrapper = mount(element, createContext({ x: { type: Number } }));
@@ -110,7 +115,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
   );
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('1');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(1));
 
   // NOTE: All following tests are here to cover hacky NumField implementation.
   const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {});
@@ -124,7 +129,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
     { value: 1, decimal: false },
     { value: 1, decimal: false }
   ].forEach(({ decimal = true, value }) => {
-    const valueInput = value === undefined ? '' : '' + value;
+    const valueInput = expectedValueTransform(value);
 
     wrapper.setProps({ decimal });
 
@@ -151,7 +156,7 @@ test('<NumField> - renders an input with correct value (specified)', () => {
   const wrapper = mount(element, createContext({ x: { type: Number } }));
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('2');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(2));
 });
 
 test('<NumField> - renders an input which correctly reacts on change', () => {

--- a/packages/uniforms-bootstrap4/src/NumField.js
+++ b/packages/uniforms-bootstrap4/src/NumField.js
@@ -5,6 +5,7 @@ import connectField from 'uniforms/connectField';
 import wrapField from './wrapField';
 
 const noneIfNaN = x => (isNaN(x) ? undefined : x);
+const parse = (decimal, x) => noneIfNaN((decimal ? parseFloat : parseInt)(x));
 
 const Num_ = props =>
   wrapField(
@@ -27,45 +28,46 @@ const Num_ = props =>
     />
   );
 
-// NOTE: React < 16 workaround. Make it optional?
-class Num extends Component {
-  constructor() {
-    super(...arguments);
+let Num;
+// istanbul ignore next
+if (parseInt(React.version, 10) < 16) {
+  Num = class Num extends Component {
+    state = { value: '' + this.props.value };
 
-    this.state = { value: '' + this.props.value };
+    componentWillReceiveProps({ decimal, value }) {
+      if (
+        parse(decimal, value) !==
+        parse(decimal, this.state.value.replace(/[.,]+$/, ''))
+      ) {
+        this.setState({
+          value: value === undefined || value === '' ? '' : '' + value
+        });
+      }
+    }
 
-    this.onChange = this.onChange.bind(this);
-  }
+    onChange = event => {
+      const value = event.target.value.replace(/[^\d.,-]/g, '');
 
-  componentWillReceiveProps({ decimal, value }) {
-    const parse = decimal ? parseFloat : parseInt;
+      this.setState({ value });
+      this.props.onChange(parse(this.props.decimal, value));
+    };
 
-    if (
-      noneIfNaN(parse(value)) !==
-      noneIfNaN(parse(this.state.value.replace(/[.,]+$/, '')))
-    ) {
-      this.setState({
-        value: value === undefined || value === '' ? '' : '' + value
+    render() {
+      return Num_({
+        ...this.props,
+        onChange: this.onChange,
+        value: this.state.value
       });
     }
-  }
-
-  onChange({ target: { value } }) {
-    const change = value.replace(/[^\d.,-]/g, '');
-
-    this.setState({ value: change });
-    this.props.onChange(
-      noneIfNaN((this.props.decimal ? parseFloat : parseInt)(change))
-    );
-  }
-
-  render() {
-    return Num_({
-      ...this.props,
-      onChange: this.onChange,
-      value: this.state.value
+  };
+} else {
+  Num = props =>
+    Num_({
+      ...props,
+      onChange(event) {
+        props.onChange(parse(props.decimal, event.target.value));
+      }
     });
-  }
 }
 
 export default connectField(Num);

--- a/packages/uniforms-material/__tests__/NumField.js
+++ b/packages/uniforms-material/__tests__/NumField.js
@@ -6,6 +6,11 @@ import NumField from 'uniforms-material/NumField';
 
 import createContext from './_createContext';
 
+const expectedValueTransform =
+  parseInt(React.version, 10) < 16
+    ? x => (x === undefined ? '' : '' + x)
+    : x => x;
+
 test('<NumField> - renders a TextField', () => {
   const element = <NumField name="x" />;
   const wrapper = mount(element, createContext({ x: { type: Number } }));
@@ -111,7 +116,7 @@ test('<NumField> - renders a TextField with correct value (model)', () => {
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  expect(wrapper.find(TextField).prop('value')).toBe('1');
+  expect(wrapper.find(TextField).prop('value')).toBe(expectedValueTransform(1));
 
   // NOTE: All following tests are here to cover hacky NumField implementation.
   const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {});
@@ -125,7 +130,7 @@ test('<NumField> - renders a TextField with correct value (model)', () => {
     { value: 1, decimal: false },
     { value: 1, decimal: false }
   ].forEach(({ decimal = true, value }) => {
-    const valueInput = value === undefined ? '' : '' + value;
+    const valueInput = expectedValueTransform(value);
 
     wrapper.setProps({ decimal });
 
@@ -152,7 +157,7 @@ test('<NumField> - renders a TextField with correct value (specified)', () => {
   const wrapper = mount(element, createContext({ x: { type: Number } }));
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  expect(wrapper.find(TextField).prop('value')).toBe('2');
+  expect(wrapper.find(TextField).prop('value')).toBe(expectedValueTransform(2));
 });
 
 test('<NumField> - renders a TextField which correctly reacts on change', () => {

--- a/packages/uniforms-material/src/NumField.js
+++ b/packages/uniforms-material/src/NumField.js
@@ -4,6 +4,7 @@ import connectField from 'uniforms/connectField';
 import filterDOMProps from 'uniforms/filterDOMProps';
 
 const noneIfNaN = x => (isNaN(x) ? undefined : x);
+const parse = (decimal, x) => noneIfNaN((decimal ? parseFloat : parseInt)(x));
 
 const Num_ = ({
   decimal,
@@ -44,45 +45,46 @@ Num_.defaultProps = {
   margin: 'dense'
 };
 
-// NOTE: React < 16 workaround. Make it optional?
-class Num extends Component {
-  constructor() {
-    super(...arguments);
+let Num;
+// istanbul ignore next
+if (parseInt(React.version, 10) < 16) {
+  Num = class Num extends Component {
+    state = { value: '' + this.props.value };
 
-    this.state = { value: '' + this.props.value };
+    componentWillReceiveProps({ decimal, value }) {
+      if (
+        parse(decimal, value) !==
+        parse(decimal, this.state.value.replace(/[.,]+$/, ''))
+      ) {
+        this.setState({
+          value: value === undefined || value === '' ? '' : '' + value
+        });
+      }
+    }
 
-    this.onChange = this.onChange.bind(this);
-  }
+    onChange = event => {
+      const value = event.target.value.replace(/[^\d.,-]/g, '');
 
-  componentWillReceiveProps({ decimal, value }) {
-    const parse = decimal ? parseFloat : parseInt;
+      this.setState({ value });
+      this.props.onChange(parse(this.props.decimal, value));
+    };
 
-    if (
-      noneIfNaN(parse(value)) !==
-      noneIfNaN(parse(this.state.value.replace(/[.,]+$/, '')))
-    ) {
-      this.setState({
-        value: value === undefined || value === '' ? '' : '' + value
+    render() {
+      return Num_({
+        ...this.props,
+        onChange: this.onChange,
+        value: this.state.value
       });
     }
-  }
-
-  onChange({ target: { value } }) {
-    const change = value.replace(/[^\d.,-]/g, '');
-
-    this.setState({ value: change });
-    this.props.onChange(
-      noneIfNaN((this.props.decimal ? parseFloat : parseInt)(change))
-    );
-  }
-
-  render() {
-    return Num_({
-      ...this.props,
-      onChange: this.onChange,
-      value: this.state.value
+  };
+} else {
+  Num = props =>
+    Num_({
+      ...props,
+      onChange(event) {
+        props.onChange(parse(props.decimal, event.target.value));
+      }
     });
-  }
 }
 
 export default connectField(Num);

--- a/packages/uniforms-semantic/__tests__/NumField.js
+++ b/packages/uniforms-semantic/__tests__/NumField.js
@@ -5,6 +5,11 @@ import NumField from 'uniforms-semantic/NumField';
 
 import createContext from './_createContext';
 
+const expectedValueTransform =
+  parseInt(React.version, 10) < 16
+    ? x => (x === undefined ? '' : '' + x)
+    : x => x;
+
 test('<NumField> - renders an input', () => {
   const element = <NumField name="x" />;
   const wrapper = mount(element, createContext({ x: { type: Number } }));
@@ -110,7 +115,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
   );
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('1');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(1));
 
   // NOTE: All following tests are here to cover hacky NumField implementation.
   const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {});
@@ -124,7 +129,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
     { value: 1, decimal: false },
     { value: 1, decimal: false }
   ].forEach(({ decimal = true, value }) => {
-    const valueInput = value === undefined ? '' : '' + value;
+    const valueInput = expectedValueTransform(value);
 
     wrapper.setProps({ decimal });
 
@@ -151,7 +156,7 @@ test('<NumField> - renders an input with correct value (specified)', () => {
   const wrapper = mount(element, createContext({ x: { type: Number } }));
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('2');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(2));
 });
 
 test('<NumField> - renders an input which correctly reacts on change', () => {

--- a/packages/uniforms-semantic/src/NumField.js
+++ b/packages/uniforms-semantic/src/NumField.js
@@ -4,6 +4,7 @@ import connectField from 'uniforms/connectField';
 import filterDOMProps from 'uniforms/filterDOMProps';
 
 const noneIfNaN = x => (isNaN(x) ? undefined : x);
+const parse = (decimal, x) => noneIfNaN((decimal ? parseFloat : parseInt)(x));
 
 const Num_ = ({
   className,
@@ -68,45 +69,46 @@ const Num_ = ({
   </div>
 );
 
-// NOTE: React < 16 workaround. Make it optional?
-class Num extends Component {
-  constructor() {
-    super(...arguments);
+let Num;
+// istanbul ignore next
+if (parseInt(React.version, 10) < 16) {
+  Num = class Num extends Component {
+    state = { value: '' + this.props.value };
 
-    this.state = { value: '' + this.props.value };
+    componentWillReceiveProps({ decimal, value }) {
+      if (
+        parse(decimal, value) !==
+        parse(decimal, this.state.value.replace(/[.,]+$/, ''))
+      ) {
+        this.setState({
+          value: value === undefined || value === '' ? '' : '' + value
+        });
+      }
+    }
 
-    this.onChange = this.onChange.bind(this);
-  }
+    onChange = event => {
+      const value = event.target.value.replace(/[^\d.,-]/g, '');
 
-  componentWillReceiveProps({ decimal, value }) {
-    const parse = decimal ? parseFloat : parseInt;
+      this.setState({ value });
+      this.props.onChange(parse(this.props.decimal, value));
+    };
 
-    if (
-      noneIfNaN(parse(value)) !==
-      noneIfNaN(parse(this.state.value.replace(/[.,]+$/, '')))
-    ) {
-      this.setState({
-        value: value === undefined || value === '' ? '' : '' + value
+    render() {
+      return Num_({
+        ...this.props,
+        onChange: this.onChange,
+        value: this.state.value
       });
     }
-  }
-
-  onChange({ target: { value } }) {
-    const change = value.replace(/[^\d.,-]/g, '');
-
-    this.setState({ value: change });
-    this.props.onChange(
-      noneIfNaN((this.props.decimal ? parseFloat : parseInt)(change))
-    );
-  }
-
-  render() {
-    return Num_({
-      ...this.props,
-      onChange: this.onChange,
-      value: this.state.value
+  };
+} else {
+  Num = props =>
+    Num_({
+      ...props,
+      onChange(event) {
+        props.onChange(parse(props.decimal, event.target.value));
+      }
     });
-  }
 }
 
 export default connectField(Num);

--- a/packages/uniforms-unstyled/__tests__/NumField.js
+++ b/packages/uniforms-unstyled/__tests__/NumField.js
@@ -5,6 +5,11 @@ import NumField from 'uniforms-unstyled/NumField';
 
 import createContext from './_createContext';
 
+const expectedValueTransform =
+  parseInt(React.version, 10) < 16
+    ? x => (x === undefined ? '' : '' + x)
+    : x => x;
+
 test('<NumField> - renders an input', () => {
   const element = <NumField name="x" />;
   const wrapper = mount(element, createContext({ x: { type: Number } }));
@@ -110,7 +115,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
   );
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('1');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(1));
 
   // NOTE: All following tests are here to cover hacky NumField implementation.
   const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {});
@@ -124,7 +129,7 @@ test('<NumField> - renders an input with correct value (model)', () => {
     { value: 1, decimal: false },
     { value: 1, decimal: false }
   ].forEach(({ decimal = true, value }) => {
-    const valueInput = value === undefined ? '' : '' + value;
+    const valueInput = expectedValueTransform(value);
 
     wrapper.setProps({ decimal });
 
@@ -151,7 +156,7 @@ test('<NumField> - renders an input with correct value (specified)', () => {
   const wrapper = mount(element, createContext({ x: { type: Number } }));
 
   expect(wrapper.find('input')).toHaveLength(1);
-  expect(wrapper.find('input').prop('value')).toBe('2');
+  expect(wrapper.find('input').prop('value')).toBe(expectedValueTransform(2));
 });
 
 test('<NumField> - renders an input which correctly reacts on change', () => {

--- a/packages/uniforms/__tests__/connectField.js
+++ b/packages/uniforms/__tests__/connectField.js
@@ -76,7 +76,7 @@ describe('connectField', () => {
 
   describe('when called with `baseField`', () => {
     it('inherits from `baseField`', () => {
-      /* istanbul ignore next */
+      // istanbul ignore next
       class Class {}
 
       Class.property1 = 1;


### PR DESCRIPTION
A long time ago, back in #167, I had implemented special handling of numeric inputs in `NumField` because it behaved weirdly in most browsers (it was crazy in Safari). It got fixed by React in version 16, but the mechanism stayed as it was, because of backward compatibility. Now, it stung back in #558. I've decided to make it logic conditional, to enable it only in React versions which needs them.