### PR TITLE
Fixed dataPath parsing (fixes #593).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Fixed:** Parsing of `dataPath` in `JSONSchemaBridge`. [\#593](https://github.com/vazco/uniforms/issues/593)
+
 ## [v2.4.0](https://github.com/vazco/uniforms/tree/v2.4.0) (2019-08-28)
 
 - **Added:** Default labels in `GraphQLSchemaBridge`. [\#577](https://github.com/vazco/uniforms/issues/577)

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.js
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.js
@@ -46,6 +46,21 @@ const extractValue = (...xs) =>
     x === false || x === null ? '' : x !== true && x !== undefined ? x : y
   );
 
+const pathToName = path => {
+  if (path[0] === '.')
+    path = path
+      .replace(/\['(.+?)'\]/g, '.$1')
+      .replace(/\[(.+?)\]/g, '.$1')
+      .replace(/\\'/g, "'");
+  else
+    path = path
+      .replace(/\//g, '.')
+      .replace(/~0/g, '~')
+      .replace(/~1/g, '/');
+
+  return path.slice(1);
+};
+
 const toHumanLabel = label => upperFirst(lowerCase(label));
 
 export default class JSONSchemaBridge extends Bridge {
@@ -71,7 +86,8 @@ export default class JSONSchemaBridge extends Bridge {
       error.details &&
       error.details.find &&
       error.details.find(detail => {
-        const path = detail.dataPath.substring(1);
+        const path = pathToName(detail.dataPath);
+
         return (
           name === path ||
           (rootName === path && baseName === detail.params.missingProperty)


### PR DESCRIPTION
The previous implementation was not able to parse `dataPaths` with array indexes (`.a[0]`) and escapes (`.a['b-c']`). Now it works correctly, even when the `jsonPointers` flag is enabled (`/a/0` and `/a/b-c`).