### PR TITLE
Fixed typo in the landing page.

### DIFF
--- a/website/components/LandingPage/ExampleSimpleYetPowerful.js
+++ b/website/components/LandingPage/ExampleSimpleYetPowerful.js
@@ -111,7 +111,7 @@ export default new JSONSchemaBridge(schema, schemaValidator);`
               yet powerful
             </Heading>
             <ul>
-              <li>Abbrevates from code by 51%</li>
+              <li>Abbreviates form code by 51%</li>
               <li>
                 Out-of-the box built-in fields capable of rendering every schema
               </li>


### PR DESCRIPTION
This PR fixes a typo in the landing page - it changes `Abbrevates from code by 51%` to `Abbreviates form code by 51%`.