### PR TITLE
Fixed JSON schema type conflict.

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.js
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.js
@@ -108,7 +108,9 @@ describe('JSONSchemaBridge', () => {
             }
           }
         }
-      }
+      },
+      password: { type: 'string', uniforms: { type: 'password' } },
+      passwordNumeric: { type: 'number', uniforms: { type: 'password' } }
     },
     required: ['dateOfBirth']
   };
@@ -530,6 +532,21 @@ describe('JSONSchemaBridge', () => {
       expect(bridge.getProps('salary', props).allowedValues[1]).toBe('avarage');
     });
 
+    it('works with type', () => {
+      expect(bridge.getProps('password')).toEqual({
+        label: 'Password',
+        required: false,
+        type: 'password'
+      });
+
+      expect(bridge.getProps('passwordNumeric')).toEqual({
+        label: 'Password numeric',
+        required: false,
+        decimal: true,
+        type: 'password'
+      });
+    });
+
     it('works with other props', () => {
       expect(bridge.getProps('personalData.firstName', { x: 1, y: 1 })).toEqual(
         {
@@ -555,7 +572,9 @@ describe('JSONSchemaBridge', () => {
         'personalData',
         'salary',
         'shippingAddress',
-        'complexNames'
+        'complexNames',
+        'password',
+        'passwordNumeric'
       ]);
     });
 

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.js
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.js
@@ -225,13 +225,14 @@ export default class JSONSchemaBridge extends Bridge {
 
   getProps(name, props = {}) {
     const { uniforms, ...field } = this.getField(name);
-    const { enum: enum_, isRequired, title, type, ...ready } = omit(
+    const { enum: enum_, isRequired, title, ...ready } = omit(
       { ...field, ...uniforms, ...this._compiledSchema[name] },
-      ['default', 'format']
+      ['default', 'format', 'type']
     );
 
     if (enum_) ready.allowedValues = enum_;
-    if (type === 'number') ready.decimal = true;
+    if (field.type === 'number') ready.decimal = true;
+    if (uniforms && uniforms.type !== undefined) ready.type = uniforms.type;
     if (ready.required === undefined) ready.required = isRequired;
     ready.label = extractValue(
       ready.label,


### PR DESCRIPTION
[As @ziedmahdi noticed](https://github.com/vazco/uniforms/issues/345#issuecomment-535979999), using `uniforms: { type: 'password' }` in JSON schema had no effect.