### PR TITLE
Added ES6 targets (closes #433).

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@
 /npm-debug.log*
 /packages/*/*.d.ts
 /packages/*/*.js
+/packages/*/es6
 /packages/*/node_modules
 /website/.cache-loader
 /website/.docusaurus

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /npm-debug.log*
 /packages/*/*.d.ts
 /packages/*/*.js
+/packages/*/es6
 /packages/*/node_modules
 /website/.cache-loader
 /website/.docusaurus

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@
 /npm-debug.log*
 /packages/*/*.d.ts
 /packages/*/*.js
+/packages/*/es6
 /packages/*/node_modules
 /website/.cache-loader
 /website/.docusaurus

--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "Ant Design UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-antd",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -19,6 +19,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-antd/tsconfig.es6.json
+++ b/packages/uniforms-antd/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-antd.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-bootstrap3/package.json
+++ b/packages/uniforms-bootstrap3/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "Bootstrap3 UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bootstrap3",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bootstrap3/package.json
+++ b/packages/uniforms-bootstrap3/package.json
@@ -19,6 +19,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-bootstrap3/tsconfig.es6.json
+++ b/packages/uniforms-bootstrap3/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bootstrap3.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-bootstrap4/package.json
+++ b/packages/uniforms-bootstrap4/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "Bootstrap4 UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bootstrap4",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bootstrap4/package.json
+++ b/packages/uniforms-bootstrap4/package.json
@@ -19,6 +19,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-bootstrap4/tsconfig.es6.json
+++ b/packages/uniforms-bootstrap4/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bootstrap4.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-bridge-graphql/package.json
+++ b/packages/uniforms-bridge-graphql/package.json
@@ -17,6 +17,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-bridge-graphql/package.json
+++ b/packages/uniforms-bridge-graphql/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "GraphQL schema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-graphql",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-graphql/tsconfig.es6.json
+++ b/packages/uniforms-bridge-graphql/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bridge-graphql.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-bridge-json-schema/package.json
+++ b/packages/uniforms-bridge-json-schema/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "JSONSchema schema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-json-schema",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-json-schema/package.json
+++ b/packages/uniforms-bridge-json-schema/package.json
@@ -17,6 +17,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-bridge-json-schema/tsconfig.es6.json
+++ b/packages/uniforms-bridge-json-schema/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bridge-json-schema.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-bridge-simple-schema-2/package.json
+++ b/packages/uniforms-bridge-simple-schema-2/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "SimpleSchema 2 bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-simple-schema-2",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-simple-schema-2/package.json
+++ b/packages/uniforms-bridge-simple-schema-2/package.json
@@ -17,6 +17,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-bridge-simple-schema-2/tsconfig.es6.json
+++ b/packages/uniforms-bridge-simple-schema-2/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bridge-simple-schema-2.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-bridge-simple-schema/package.json
+++ b/packages/uniforms-bridge-simple-schema/package.json
@@ -17,6 +17,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-bridge-simple-schema/package.json
+++ b/packages/uniforms-bridge-simple-schema/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "SimpleSchema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-simple-schema",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-simple-schema/tsconfig.es6.json
+++ b/packages/uniforms-bridge-simple-schema/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bridge-simple-schema.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-material/package.json
+++ b/packages/uniforms-material/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "Material UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-material",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-material/package.json
+++ b/packages/uniforms-material/package.json
@@ -19,6 +19,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-material/tsconfig.es6.json
+++ b/packages/uniforms-material/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-material.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-semantic/package.json
+++ b/packages/uniforms-semantic/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "Semantic UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-semantic",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-semantic/package.json
+++ b/packages/uniforms-semantic/package.json
@@ -19,6 +19,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-semantic/tsconfig.es6.json
+++ b/packages/uniforms-semantic/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-semantic.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms-unstyled/package.json
+++ b/packages/uniforms-unstyled/package.json
@@ -18,6 +18,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms-unstyled/package.json
+++ b/packages/uniforms-unstyled/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "Unstyled components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-unstyled",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-unstyled/tsconfig.es6.json
+++ b/packages/uniforms-unstyled/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-unstyled.es6.tsbuildinfo"
+  }
+}

--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -18,6 +18,8 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "es6/*.d.ts",
+    "es6/*.js",
     "src/*.ts",
     "src/*.tsx"
   ],

--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "license": "MIT",
   "main": "index.js",
+  "module": "es6/index.js",
   "description": "Core package of uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms/tsconfig.es6.json
+++ b/packages/uniforms/tsconfig.es6.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "es6",
+    "target": "es6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms.es6.tsbuildinfo"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,16 +1,27 @@
 {
   "files": [],
   "references": [
-    { "path": "packages/uniforms" },
-    { "path": "packages/uniforms-antd" },
-    { "path": "packages/uniforms-bootstrap3" },
-    { "path": "packages/uniforms-bootstrap4" },
-    { "path": "packages/uniforms-bridge-graphql" },
-    { "path": "packages/uniforms-bridge-json-schema" },
-    { "path": "packages/uniforms-bridge-simple-schema" },
-    { "path": "packages/uniforms-bridge-simple-schema-2" },
-    { "path": "packages/uniforms-material" },
-    { "path": "packages/uniforms-semantic" },
-    { "path": "packages/uniforms-unstyled" }
+    { "path": "packages/uniforms/tsconfig.json" },
+    { "path": "packages/uniforms/tsconfig.es6.json" },
+    { "path": "packages/uniforms-antd/tsconfig.json" },
+    { "path": "packages/uniforms-antd/tsconfig.es6.json" },
+    { "path": "packages/uniforms-bootstrap3/tsconfig.json" },
+    { "path": "packages/uniforms-bootstrap3/tsconfig.es6.json" },
+    { "path": "packages/uniforms-bootstrap4/tsconfig.json" },
+    { "path": "packages/uniforms-bootstrap4/tsconfig.es6.json" },
+    { "path": "packages/uniforms-bridge-graphql/tsconfig.json" },
+    { "path": "packages/uniforms-bridge-graphql/tsconfig.es6.json" },
+    { "path": "packages/uniforms-bridge-json-schema/tsconfig.json" },
+    { "path": "packages/uniforms-bridge-json-schema/tsconfig.es6.json" },
+    { "path": "packages/uniforms-bridge-simple-schema/tsconfig.json" },
+    { "path": "packages/uniforms-bridge-simple-schema/tsconfig.es6.json" },
+    { "path": "packages/uniforms-bridge-simple-schema-2/tsconfig.json" },
+    { "path": "packages/uniforms-bridge-simple-schema-2/tsconfig.es6.json" },
+    { "path": "packages/uniforms-material/tsconfig.json" },
+    { "path": "packages/uniforms-material/tsconfig.es6.json" },
+    { "path": "packages/uniforms-semantic/tsconfig.json" },
+    { "path": "packages/uniforms-semantic/tsconfig.es6.json" },
+    { "path": "packages/uniforms-unstyled/tsconfig.json" },
+    { "path": "packages/uniforms-unstyled/tsconfig.es6.json" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "importHelpers": true,
     "jsx": "react",
+    "moduleResolution": "node",
     "noImplicitAny": false,
     "paths": {
       "uniforms": ["uniforms/src"],
@@ -37,6 +38,7 @@
       "uniforms-unstyled": ["uniforms-unstyled/src"],
       "uniforms-unstyled/*": ["uniforms-unstyled/src/*"]
     },
-    "strict": true
+    "strict": true,
+    "target": "es5"
   }
 }


### PR DESCRIPTION
We've added separate compilation target for ES6 standard which enables classes.

We would like to ask @macrozone @refactorized to check if everything works fine.
1. Clone this branch.
2. Run `npm ci`.
3. Copy built files directly into `node_modules` to check if it works.