### PR TITLE
Fixed preservation of mixin types (fixes #617).

### DIFF
--- a/packages/uniforms-antd/src/AutoForm.tsx
+++ b/packages/uniforms-antd/src/AutoForm.tsx
@@ -2,7 +2,7 @@ import AutoForm from 'uniforms/AutoForm';
 
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-const Auto = (parent: any) =>
+const Auto = (parent: any): any =>
   class extends AutoForm.Auto(parent) {
     static Auto = Auto;
   };

--- a/packages/uniforms-antd/src/BaseForm.tsx
+++ b/packages/uniforms-antd/src/BaseForm.tsx
@@ -1,6 +1,6 @@
 import BaseForm from 'uniforms/BaseForm';
 
-const AntD = (parent: any) =>
+const AntD = (parent: any): any =>
   class extends parent {
     static AntD = AntD;
 

--- a/packages/uniforms-antd/src/QuickForm.tsx
+++ b/packages/uniforms-antd/src/QuickForm.tsx
@@ -5,7 +5,7 @@ import BaseForm from './BaseForm';
 import ErrorsField from './ErrorsField';
 import SubmitField from './SubmitField';
 
-const Quick = parent =>
+const Quick = (parent: any): any =>
   class extends QuickForm.Quick(parent) {
     static Quick = Quick;
 

--- a/packages/uniforms-antd/src/ValidatedForm.tsx
+++ b/packages/uniforms-antd/src/ValidatedForm.tsx
@@ -2,7 +2,7 @@ import ValidatedForm from 'uniforms/ValidatedForm';
 
 import BaseForm from './BaseForm';
 
-const Validated = parent =>
+const Validated = (parent: any): any =>
   class extends ValidatedForm.Validated(parent) {
     static Validated = Validated;
   };

--- a/packages/uniforms-bootstrap3/src/AutoForm.tsx
+++ b/packages/uniforms-bootstrap3/src/AutoForm.tsx
@@ -2,7 +2,7 @@ import AutoForm from 'uniforms/AutoForm';
 
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-const Auto = (parent: any) =>
+const Auto = (parent: any): any =>
   class extends AutoForm.Auto(parent) {
     static Auto = Auto;
   };

--- a/packages/uniforms-bootstrap3/src/BaseForm.tsx
+++ b/packages/uniforms-bootstrap3/src/BaseForm.tsx
@@ -2,7 +2,7 @@ import BaseForm from 'uniforms/BaseForm';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const Bootstrap3 = (parent: any) =>
+const Bootstrap3 = (parent: any): any =>
   class extends parent {
     static Bootstrap3 = Bootstrap3;
 

--- a/packages/uniforms-bootstrap3/src/QuickForm.tsx
+++ b/packages/uniforms-bootstrap3/src/QuickForm.tsx
@@ -5,7 +5,7 @@ import BaseForm from './BaseForm';
 import ErrorsField from './ErrorsField';
 import SubmitField from './SubmitField';
 
-const Quick = (parent: any) =>
+const Quick = (parent: any): any =>
   class extends QuickForm.Quick(parent) {
     static Quick = Quick;
 

--- a/packages/uniforms-bootstrap3/src/ValidatedForm.tsx
+++ b/packages/uniforms-bootstrap3/src/ValidatedForm.tsx
@@ -2,7 +2,7 @@ import ValidatedForm from 'uniforms/ValidatedForm';
 
 import BaseForm from './BaseForm';
 
-const Validated = parent =>
+const Validated = (parent: any): any =>
   class extends ValidatedForm.Validated(parent) {
     static Validated = Validated;
   };

--- a/packages/uniforms-bootstrap4/src/AutoForm.tsx
+++ b/packages/uniforms-bootstrap4/src/AutoForm.tsx
@@ -2,7 +2,7 @@ import AutoForm from 'uniforms/AutoForm';
 
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-const Auto = parent =>
+const Auto = (parent: any): any =>
   class extends AutoForm.Auto(parent) {
     static Auto = Auto;
   };

--- a/packages/uniforms-bootstrap4/src/BaseForm.tsx
+++ b/packages/uniforms-bootstrap4/src/BaseForm.tsx
@@ -2,7 +2,7 @@ import BaseForm from 'uniforms/BaseForm';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const Bootstrap4 = parent =>
+const Bootstrap4 = (parent: any): any =>
   class extends parent {
     static Bootstrap4 = Bootstrap4;
 

--- a/packages/uniforms-bootstrap4/src/QuickForm.tsx
+++ b/packages/uniforms-bootstrap4/src/QuickForm.tsx
@@ -5,7 +5,7 @@ import BaseForm from './BaseForm';
 import ErrorsField from './ErrorsField';
 import SubmitField from './SubmitField';
 
-const Quick = parent =>
+const Quick = (parent: any): any =>
   class extends QuickForm.Quick(parent) {
     static Quick = Quick;
 

--- a/packages/uniforms-bootstrap4/src/ValidatedForm.tsx
+++ b/packages/uniforms-bootstrap4/src/ValidatedForm.tsx
@@ -2,7 +2,7 @@ import ValidatedForm from 'uniforms/ValidatedForm';
 
 import BaseForm from './BaseForm';
 
-const Validated = parent =>
+const Validated = (parent: any): any =>
   class extends ValidatedForm.Validated(parent) {
     static Validated = Validated;
   };

--- a/packages/uniforms-material/src/AutoForm.tsx
+++ b/packages/uniforms-material/src/AutoForm.tsx
@@ -2,7 +2,7 @@ import AutoForm from 'uniforms/AutoForm';
 
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-const Auto = parent =>
+const Auto = (parent: any): any =>
   class extends AutoForm.Auto(parent) {
     static Auto = Auto;
   };

--- a/packages/uniforms-material/src/BaseForm.tsx
+++ b/packages/uniforms-material/src/BaseForm.tsx
@@ -1,6 +1,6 @@
 import BaseForm from 'uniforms/BaseForm';
 
-const Material = parent =>
+const Material = (parent: any): any =>
   class extends parent {
     static Material = Material;
 

--- a/packages/uniforms-material/src/QuickForm.tsx
+++ b/packages/uniforms-material/src/QuickForm.tsx
@@ -5,7 +5,7 @@ import BaseForm from './BaseForm';
 import ErrorsField from './ErrorsField';
 import SubmitField from './SubmitField';
 
-const Quick = parent =>
+const Quick = (parent: any): any =>
   class extends QuickForm.Quick(parent) {
     static Quick = Quick;
 

--- a/packages/uniforms-material/src/ValidatedForm.tsx
+++ b/packages/uniforms-material/src/ValidatedForm.tsx
@@ -2,7 +2,7 @@ import ValidatedForm from 'uniforms/ValidatedForm';
 
 import BaseForm from './BaseForm';
 
-const Validated = parent =>
+const Validated = (parent: any): any =>
   class extends ValidatedForm.Validated(parent) {
     static Validated = Validated;
   };

--- a/packages/uniforms-semantic/src/AutoForm.tsx
+++ b/packages/uniforms-semantic/src/AutoForm.tsx
@@ -2,7 +2,7 @@ import AutoForm from 'uniforms/AutoForm';
 
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-const Auto = parent =>
+const Auto = (parent: any): any =>
   class extends AutoForm.Auto(parent) {
     static Auto = Auto;
   };

--- a/packages/uniforms-semantic/src/BaseForm.tsx
+++ b/packages/uniforms-semantic/src/BaseForm.tsx
@@ -1,7 +1,7 @@
 import BaseForm from 'uniforms/BaseForm';
 import classnames from 'classnames';
 
-const Semantic = parent =>
+const Semantic = (parent: any): any =>
   class extends parent {
     static Semantic = Semantic;
 

--- a/packages/uniforms-semantic/src/QuickForm.tsx
+++ b/packages/uniforms-semantic/src/QuickForm.tsx
@@ -5,7 +5,7 @@ import BaseForm from './BaseForm';
 import ErrorsField from './ErrorsField';
 import SubmitField from './SubmitField';
 
-const Quick = parent =>
+const Quick = (parent: any): any =>
   class extends QuickForm.Quick(parent) {
     static Quick = Quick;
 

--- a/packages/uniforms-semantic/src/ValidatedForm.tsx
+++ b/packages/uniforms-semantic/src/ValidatedForm.tsx
@@ -2,7 +2,7 @@ import ValidatedForm from 'uniforms/ValidatedForm';
 
 import BaseForm from './BaseForm';
 
-const Validated = parent =>
+const Validated = (parent: any): any =>
   class extends ValidatedForm.Validated(parent) {
     static Validated = Validated;
   };

--- a/packages/uniforms-unstyled/src/AutoForm.tsx
+++ b/packages/uniforms-unstyled/src/AutoForm.tsx
@@ -2,7 +2,7 @@ import AutoForm from 'uniforms/AutoForm';
 
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-const Auto = parent =>
+const Auto = (parent: any): any =>
   class extends AutoForm.Auto(parent) {
     static Auto = Auto;
   };

--- a/packages/uniforms-unstyled/src/BaseForm.tsx
+++ b/packages/uniforms-unstyled/src/BaseForm.tsx
@@ -1,6 +1,6 @@
 import BaseForm from 'uniforms/BaseForm';
 
-const Unstyled = parent =>
+const Unstyled = (parent: any): any =>
   class extends parent {
     static Unstyled = Unstyled;
 

--- a/packages/uniforms-unstyled/src/QuickForm.tsx
+++ b/packages/uniforms-unstyled/src/QuickForm.tsx
@@ -5,7 +5,7 @@ import BaseForm from './BaseForm';
 import ErrorsField from './ErrorsField';
 import SubmitField from './SubmitField';
 
-const Quick = parent =>
+const Quick = (parent: any): any =>
   class extends QuickForm.Quick(parent) {
     static Quick = Quick;
 

--- a/packages/uniforms-unstyled/src/ValidatedForm.tsx
+++ b/packages/uniforms-unstyled/src/ValidatedForm.tsx
@@ -2,7 +2,7 @@ import ValidatedForm from 'uniforms/ValidatedForm';
 
 import BaseForm from './BaseForm';
 
-const Validated = parent =>
+const Validated = (parent: any): any =>
   class extends ValidatedForm.Validated(parent) {
     static Validated = Validated;
   };

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -4,10 +4,21 @@ import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import set from 'lodash/set';
 
+// FIXME: Fix configuration of ESLint in TypeScript files.
+// eslint-disable-next-line no-unused-vars
+import BaseForm from './BaseForm';
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-const Auto = (parent: any) =>
-  class extends parent {
+function Auto<
+  T extends {
+    new (...args: any[]): BaseForm;
+    childContextTypes?: {};
+    defaultProps?: {};
+    displayName?: string;
+    propTypes?: {};
+  }
+>(parent: T): T & { Auto: typeof Auto } {
+  return class extends parent {
     static Auto: any = Auto;
 
     static displayName: string = `Auto${parent.displayName}`;
@@ -18,11 +29,9 @@ const Auto = (parent: any) =>
       onChangeModel: PropTypes.func
     };
 
-    constructor() {
-      // @ts-ignore
-      super(...arguments);
+    constructor(...args: any[]) {
+      super(...args);
 
-      // @ts-ignore
       this.state = {
         ...this.state,
 
@@ -32,7 +41,8 @@ const Auto = (parent: any) =>
     }
 
     componentWillReceiveProps({ model }: { model: any }) {
-      super.componentWillReceiveProps(...((arguments as unknown) as any[]));
+      // @ts-ignore
+      super.componentWillReceiveProps(...arguments);
 
       if (!isEqual(this.props.model, model)) {
         this.setState(() => ({ model, modelSync: model }));
@@ -81,8 +91,10 @@ const Auto = (parent: any) =>
     }
 
     onValidate() {
+      // @ts-ignore
       return this.onValidateModel(this.getChildContextModel());
     }
   };
+}
 
 export default Auto(ValidatedQuickForm);

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -4,21 +4,10 @@ import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import set from 'lodash/set';
 
-// FIXME: Fix configuration of ESLint in TypeScript files.
-// eslint-disable-next-line no-unused-vars
-import BaseForm from './BaseForm';
 import ValidatedQuickForm from './ValidatedQuickForm';
 
-function Auto<
-  T extends {
-    new (...args: any[]): BaseForm;
-    childContextTypes?: {};
-    defaultProps?: {};
-    displayName?: string;
-    propTypes?: {};
-  }
->(parent: T): T & { Auto: typeof Auto } {
-  return class extends parent {
+const Auto = (parent: any): any =>
+  class extends parent {
     static Auto = Auto;
 
     static displayName: string = `Auto${parent.displayName}`;
@@ -32,6 +21,7 @@ function Auto<
     constructor(...args: any[]) {
       super(...args);
 
+      // @ts-ignore
       this.state = {
         ...this.state,
 
@@ -95,6 +85,5 @@ function Auto<
       return this.onValidateModel(this.getChildContextModel());
     }
   };
-}
 
 export default Auto(ValidatedQuickForm);

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -19,7 +19,7 @@ function Auto<
   }
 >(parent: T): T & { Auto: typeof Auto } {
   return class extends parent {
-    static Auto: any = Auto;
+    static Auto = Auto;
 
     static displayName: string = `Auto${parent.displayName}`;
 
@@ -49,7 +49,7 @@ function Auto<
       }
     }
 
-    getNativeFormProps() {
+    getNativeFormProps(): Record<string, unknown> {
       return omit(super.getNativeFormProps(), ['onChangeModel']);
     }
 

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -201,7 +201,7 @@ export default class BaseForm extends Component<any, any> {
     return changedKeys(root, valueA, valueB);
   }
 
-  getNativeFormProps() {
+  getNativeFormProps(): { [prop: string]: unknown } {
     const props = omit(this.props, [
       'autosave',
       'autosaveDelay',

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -201,7 +201,7 @@ export default class BaseForm extends Component<any, any> {
     return changedKeys(root, valueA, valueB);
   }
 
-  getNativeFormProps(): { [prop: string]: unknown } {
+  getNativeFormProps(): Record<string, unknown> {
     const props = omit(this.props, [
       'autosave',
       'autosaveDelay',

--- a/packages/uniforms/src/QuickForm.tsx
+++ b/packages/uniforms/src/QuickForm.tsx
@@ -4,8 +4,16 @@ import React from 'react';
 import BaseForm from './BaseForm';
 import nothing from './nothing';
 
-const Quick = (parent: any) =>
-  class extends parent {
+function Quick<
+  T extends {
+    new (...args: any[]): BaseForm;
+    childContextTypes?: {};
+    defaultProps?: {};
+    displayName?: string;
+    propTypes?: {};
+  }
+>(parent: T): T & { Quick: typeof Quick } {
+  return class extends parent {
     static Quick = Quick;
 
     static displayName = `Quick${parent.displayName}`;
@@ -51,5 +59,6 @@ const Quick = (parent: any) =>
       return () => nothing;
     }
   };
+}
 
 export default Quick(BaseForm);

--- a/packages/uniforms/src/QuickForm.tsx
+++ b/packages/uniforms/src/QuickForm.tsx
@@ -4,16 +4,8 @@ import React from 'react';
 import BaseForm from './BaseForm';
 import nothing from './nothing';
 
-function Quick<
-  T extends {
-    new (...args: any[]): BaseForm;
-    childContextTypes?: {};
-    defaultProps?: {};
-    displayName?: string;
-    propTypes?: {};
-  }
->(parent: T): T & { Quick: typeof Quick } {
-  return class extends parent {
+const Quick = (parent: any): any =>
+  class extends parent {
     static Quick = Quick;
 
     static displayName = `Quick${parent.displayName}`;
@@ -59,6 +51,5 @@ function Quick<
       return () => nothing;
     }
   };
-}
 
 export default Quick(BaseForm);

--- a/packages/uniforms/src/QuickForm.tsx
+++ b/packages/uniforms/src/QuickForm.tsx
@@ -26,7 +26,7 @@ function Quick<
       submitField: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
     };
 
-    getNativeFormProps() {
+    getNativeFormProps(): Record<string, unknown> {
       const {
         autoField: AutoField = this.getAutoField(),
         errorsField: ErrorsField = this.getErrorsField(),

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -18,16 +18,8 @@ const childContextTypes = __childContextTypesBuild(
   )
 );
 
-function Validated<
-  T extends {
-    new (...args: any[]): BaseForm;
-    childContextTypes?: {};
-    defaultProps?: {};
-    displayName?: string;
-    propTypes?: {};
-  }
->(parent: T): T & { Validated: typeof Validated } {
-  return class extends parent {
+const Validated = (parent: any): any =>
+  class extends parent {
     static Validated = Validated;
 
     static displayName = `Validated${parent.displayName}`;
@@ -63,6 +55,7 @@ function Validated<
     constructor(...args: any[]) {
       super(...args);
 
+      // @ts-ignore
       this.state = {
         ...this.state,
 
@@ -220,7 +213,6 @@ function Validated<
       });
     }
   };
-}
 
 function shouldRevalidate(inProps: any, inState: any) {
   return (

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -18,8 +18,16 @@ const childContextTypes = __childContextTypesBuild(
   )
 );
 
-const Validated = (parent: any) =>
-  class extends parent {
+function Validated<
+  T extends {
+    new (...args: any[]): BaseForm;
+    childContextTypes?: {};
+    defaultProps?: {};
+    displayName?: string;
+    propTypes?: {};
+  }
+>(parent: T): T & { Validated: typeof Validated } {
+  return class extends parent {
     static Validated = Validated;
 
     static displayName = `Validated${parent.displayName}`;
@@ -52,11 +60,9 @@ const Validated = (parent: any) =>
     validate: (key?: any, value?: any) => Promise<unknown>;
     validateModel: (model: any) => Promise<unknown>;
 
-    constructor() {
-      // @ts-ignore
-      super(...arguments);
+    constructor(...args: any[]) {
+      super(...args);
 
-      // @ts-ignore
       this.state = {
         ...this.state,
 
@@ -183,6 +189,7 @@ const Validated = (parent: any) =>
     }
 
     onValidateModel(model: any) {
+      // @ts-ignore
       model = this.getModel('validate', model);
 
       let catched = this.props.error || null;
@@ -213,6 +220,7 @@ const Validated = (parent: any) =>
       });
     }
   };
+}
 
 function shouldRevalidate(inProps: any, inState: any) {
   return (

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -92,7 +92,7 @@ function Validated<
       };
     }
 
-    getNativeFormProps() {
+    getNativeFormProps(): Record<string, unknown> {
       return omit(super.getNativeFormProps(), [
         'onValidate',
         'validate',


### PR DESCRIPTION
As reported in #617, `AutoForm` (other form components too) have non-JSX compatible types. With this change base class (`Component`) and mixin helpers are preserved. It's not an ideal solution but it'll do for now. In the future, we'd have to define `BaseForm` generic type and other forms should simply derive from it, reusing generics.