### PR TITLE
Fixed branch test coverage reporting.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Test
         run: npm run coverage -- --no-cache --runInBand
       - name: Report coverage
-        uses: codecov/codecov-action@v1.0.3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Build docs
         run: npm --prefix website run build
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.node-version == '12.x'


### PR DESCRIPTION
Codecov Action has a bug that results in incorrect reporting of non-`master` coverage. This change uses [codecov/codecov-bash](https://github.com/codecov/codecov-bash) directly, which is easier to maintain and significantly faster (no docker image is being built at the beginning of each run).

The bash script has the same bug _now_, as the code is already merged but wasn't released yet: https://github.com/codecov/codecov-bash/issues/169