### PR TITLE
Fixed Material-UI NumField defaultProps handling (fixes #631).

### DIFF
--- a/packages/uniforms-material/src/NumField.tsx
+++ b/packages/uniforms-material/src/NumField.tsx
@@ -40,11 +40,6 @@ const Num_ = ({
   />
 );
 
-Num_.defaultProps = {
-  fullWidth: true,
-  margin: 'dense'
-};
-
 let Num;
 // istanbul ignore next
 if (parseInt(React.version, 10) < 16) {
@@ -86,5 +81,10 @@ if (parseInt(React.version, 10) < 16) {
       }
     });
 }
+
+Num.defaultProps = {
+  fullWidth: true,
+  margin: 'dense'
+};
 
 export default connectField(Num);


### PR DESCRIPTION
This change fixes #631 - how default props are assigned to `NumField`. There was a bug that the `defaultProps` were set on a helper function, not the component itself.