### PR TITLE
Fixed RatingField example in docs

### DIFF
--- a/docs/examples/CustomFields/RatingField.js
+++ b/docs/examples/CustomFields/RatingField.js
@@ -14,11 +14,10 @@ const Rating = ({
   onChange
 }) => (
   <section className={classnames('ui', { disabled, required }, className)}>
-    {[...Array(max)]
-      .map((_, index) => index + 1)
+    {Array.from({length: max}, (_, index) => index + 1)
       .map(index => (
         <span
-          style={{ fontSize: 40 }}
+          style={{ fontSize: 40, cursor: 'pointer' }}
           key={index}
           onClick={() =>
             disabled || onChange(!required && value === index ? null : index)


### PR DESCRIPTION
Fixes a problem with `RatingField` example in the documentation (the field isn't rendered).

![image](https://user-images.githubusercontent.com/18295488/68684067-2264f200-0568-11ea-95f4-2f315dcfd9fa.png)
