### PR TITLE
Made "Use this address for payment details?" field in form example on the landing page optional

### DIFF
--- a/docs/examples/CommonForms/ShippingSchema.js
+++ b/docs/examples/CommonForms/ShippingSchema.js
@@ -17,7 +17,8 @@ export default new SimpleSchema({
     optional: true
   },
   useThisAddressForPaymentDetails: {
-    type: Boolean
+    type: Boolean,
+    defaultValue: false
   },
   addressLine: {
     type: String

--- a/website/components/LandingPage/Header.js
+++ b/website/components/LandingPage/Header.js
@@ -63,7 +63,8 @@ function Showcase() {
     optional: true
   },
   useThisAddressForPaymentDetails: {
-    type: Boolean
+    type: Boolean,
+    defaultValue: false
   },
   addressLine: {
     type: String


### PR DESCRIPTION
Added `defaultValue: false` to `useThisAddressForPaymentDetails` field