### PR TITLE
Update semantic BoolField (fixes #680, #681).

### DIFF
--- a/packages/uniforms-semantic/__tests__/BoolField.tsx
+++ b/packages/uniforms-semantic/__tests__/BoolField.tsx
@@ -175,3 +175,10 @@ test('<BoolField> - renders correct error text (showInlineError=false)', () => {
       .text(),
   ).not.toBe('Error');
 });
+
+test('<BoolField> - renders with a custom wrapClassName', () => {
+  const element = <BoolField name="x" wrapClassName="test-class-name" />;
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.find('.ui.test-class-name')).toHaveLength(1);
+});

--- a/packages/uniforms-semantic/__tests__/BoolField.tsx
+++ b/packages/uniforms-semantic/__tests__/BoolField.tsx
@@ -183,55 +183,18 @@ test('<BoolField> - renders with a custom wrapClassName', () => {
   expect(wrapper.find('.ui.test-class-name')).toHaveLength(1);
 });
 
-test('<BoolField> - renders with a `fitted` className when no `label` prop is passed', () => {
+test('<BoolField> - renders with a `fitted` className when `label` is disabled', () => {
   const element = <BoolField name="x" />;
   const wrapper = mount(element, createContext({ x: { type: String } }));
 
   const found = wrapper.find('.ui');
-  expect(wrapper.props().label).not.toBeDefined();
   expect(found.hasClass('fitted')).toEqual(true);
 });
 
-test('<BoolField> - renders with a `fitted` className when `label` prop is falsy', () => {
-  /**
-   * NOTE: According to https://react.semantic-ui.com/modules/checkbox/#variations-fitted
-   * `fitted` should only be passed if `label` is undefined:
-   * > The fitted class is automatically applied if there is no label prop.
-   * This test takes into account uniforms behaviour of putting empty string into label
-   */
-  const labels = [false, '', undefined, null];
-
-  labels.forEach(label => {
-    const element = <BoolField name="x" label={label} />;
-    const wrapper = mount(element, createContext({ x: { type: String } }));
-
-    const found = wrapper.find('.ui');
-    expect(wrapper.props().label).not.toBeTruthy();
-    expect(found.hasClass('fitted')).toEqual(true);
-  });
-});
-
-test('<BoolField> - renders with a `fitted` className when `label` prop equals true', () => {
-  /**
-   * NOTE: According to https://react.semantic-ui.com/modules/checkbox/#variations-fitted
-   * `fitted` should only be passed if `label` is undefined:
-   * > The fitted class is automatically applied if there is no label prop.
-   * This test takes into account uniforms behaviour of putting empty string into label
-   */
-
+test('<BoolField> - renders without a `fitted` className when `label` is enabled', () => {
   const element = <BoolField name="x" label />;
   const wrapper = mount(element, createContext({ x: { type: String } }));
 
   const found = wrapper.find('.ui');
-  expect(wrapper.props().label).toEqual(true);
-  expect(found.hasClass('fitted')).toEqual(false);
-});
-
-test('<BoolField> - renders without a `fitted` className when `label` prop is passed', () => {
-  const element = <BoolField name="x" label="test label" />;
-  const wrapper = mount(element, createContext({ x: { type: String } }));
-
-  const found = wrapper.find('.ui');
-  expect(wrapper.props().label).toBeDefined();
   expect(found.hasClass('fitted')).toEqual(false);
 });

--- a/packages/uniforms-semantic/__tests__/BoolField.tsx
+++ b/packages/uniforms-semantic/__tests__/BoolField.tsx
@@ -182,3 +182,56 @@ test('<BoolField> - renders with a custom wrapClassName', () => {
 
   expect(wrapper.find('.ui.test-class-name')).toHaveLength(1);
 });
+
+test('<BoolField> - renders with a `fitted` className when no `label` prop is passed', () => {
+  const element = <BoolField name="x" />;
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  const found = wrapper.find('.ui');
+  expect(wrapper.props().label).not.toBeDefined();
+  expect(found.hasClass('fitted')).toEqual(true);
+});
+
+test('<BoolField> - renders with a `fitted` className when `label` prop is falsy', () => {
+  /**
+   * NOTE: According to https://react.semantic-ui.com/modules/checkbox/#variations-fitted
+   * `fitted` should only be passed if `label` is undefined:
+   * > The fitted class is automatically applied if there is no label prop.
+   * This test takes into account uniforms behaviour of putting empty string into label
+   */
+  const labels = [false, '', undefined, null];
+
+  labels.forEach(label => {
+    const element = <BoolField name="x" label={label} />;
+    const wrapper = mount(element, createContext({ x: { type: String } }));
+
+    const found = wrapper.find('.ui');
+    expect(wrapper.props().label).not.toBeTruthy();
+    expect(found.hasClass('fitted')).toEqual(true);
+  });
+});
+
+test('<BoolField> - renders with a `fitted` className when `label` prop equals true', () => {
+  /**
+   * NOTE: According to https://react.semantic-ui.com/modules/checkbox/#variations-fitted
+   * `fitted` should only be passed if `label` is undefined:
+   * > The fitted class is automatically applied if there is no label prop.
+   * This test takes into account uniforms behaviour of putting empty string into label
+   */
+
+  const element = <BoolField name="x" label />;
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  const found = wrapper.find('.ui');
+  expect(wrapper.props().label).toEqual(true);
+  expect(found.hasClass('fitted')).toEqual(false);
+});
+
+test('<BoolField> - renders without a `fitted` className when `label` prop is passed', () => {
+  const element = <BoolField name="x" label="test label" />;
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  const found = wrapper.find('.ui');
+  expect(wrapper.props().label).toBeDefined();
+  expect(found.hasClass('fitted')).toEqual(false);
+});

--- a/packages/uniforms-semantic/src/BoolField.tsx
+++ b/packages/uniforms-semantic/src/BoolField.tsx
@@ -22,7 +22,14 @@ const Bool = ({
     className={classnames(className, { disabled, error, required }, 'field')}
     {...filterDOMProps(props)}
   >
-    <div className={classnames('ui', wrapClassName, 'checkbox')}>
+    <div
+      className={classnames(
+        'ui',
+        wrapClassName,
+        !label && label !== true && 'fitted',
+        'checkbox',
+      )}
+    >
       <input
         checked={value}
         className="hidden"

--- a/packages/uniforms-semantic/src/BoolField.tsx
+++ b/packages/uniforms-semantic/src/BoolField.tsx
@@ -26,7 +26,7 @@ const Bool = ({
       className={classnames(
         'ui',
         wrapClassName,
-        !label && label !== true && 'fitted',
+        !label && 'fitted',
         'checkbox',
       )}
     >
@@ -41,7 +41,7 @@ const Bool = ({
         type="checkbox"
       />
 
-      {label && <label htmlFor={id}>{label}</label>}
+      {!!label && <label htmlFor={id}>{label}</label>}
     </div>
 
     {!!(error && showInlineError) && (

--- a/packages/uniforms-semantic/src/BoolField.tsx
+++ b/packages/uniforms-semantic/src/BoolField.tsx
@@ -15,13 +15,14 @@ const Bool = ({
   required,
   showInlineError,
   value,
+  wrapClassName,
   ...props
 }) => (
   <div
     className={classnames(className, { disabled, error, required }, 'field')}
     {...filterDOMProps(props)}
   >
-    <div className="ui checkbox">
+    <div className={classnames('ui', wrapClassName, 'checkbox')}>
       <input
         checked={value}
         className="hidden"
@@ -33,7 +34,7 @@ const Bool = ({
         type="checkbox"
       />
 
-      <label htmlFor={id}>{label}</label>
+      {label && <label htmlFor={id}>{label}</label>}
     </div>
 
     {!!(error && showInlineError) && (


### PR DESCRIPTION
This pull request fixes #680 and #681 by introducing `wrapClassName` prop into `BoolField` and logic for adding _fitted_ class name  if `label` prop is falsy (instead of only if `label` is `undefined`, not passed). This last functionality differs from the one specified [here](https://react.semantic-ui.com/modules/checkbox/#variations-fitted).