### PR TITLE
Asyncified validate + submit flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 - **Breaking:** Removed `BaseForm.getChangedKeys`. Use `changedKeys` directly.
 - **Breaking:** Removed default exports in the `uniforms` package. Use named imports instead (e.g. `import { BaseForm } from 'uniforms'`). This allows to effectively export types along with values.
+- **Breaking:** Reworked validation flow. For motivation and more insigths see [\#711](https://github.com/vazco/uniforms/issues/711).
+  - `onValidate` is no longer using callbacks. The error (or the lack of it) has to be returned either synchronously or asynchronously (i.e. wrapped in a promise).
+  - `onSubmitSuccess` and `onSubmitFailure` got removed. To preserve the current behavior, simply combine them into the `onSubmit`:
+  ```diff
+  -onSubmit={onSubmit}
+  -onSubmitSuccess={onSubmitSuccess}
+  -onSubmitFailure={onSubmitFailure}
+  +onSubmit={model => {
+  +  const result = onSubmit(model);
+  +  result.then(onSubmitSuccess, onSubmitFailure);
+  +  return result;
+  +}}`
+  ```
 
 ## [v3.0.0-alpha.2](https://github.com/vazco/uniforms/tree/v3.0.0-alpha.2) (2020-04-08)
 

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -331,9 +331,9 @@ describe('SimpleSchema2Bridge', () => {
   });
 
   describe('#getValidator', () => {
-    it('calls correct validator', () => {
-      expect(() => bridge.getValidator()({})).toThrow();
-      expect(() => bridge.getValidator({})({})).toThrow();
+    it('calls correct validator', async () => {
+      await expect(bridge.getValidator()({})).rejects.toThrow();
+      await expect(bridge.getValidator({})({})).rejects.toThrow();
     });
   });
 });

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -331,9 +331,9 @@ describe('SimpleSchema2Bridge', () => {
   });
 
   describe('#getValidator', () => {
-    it('calls correct validator', async () => {
-      await expect(bridge.getValidator()({})).rejects.toThrow();
-      await expect(bridge.getValidator({})({})).rejects.toThrow();
+    it('calls correct validator', () => {
+      expect(bridge.getValidator()({})).not.toEqual(null);
+      expect(bridge.getValidator({})({})).not.toEqual(null);
     });
   });
 });

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -332,8 +332,11 @@ describe('SimpleSchema2Bridge', () => {
 
   describe('#getValidator', () => {
     it('calls correct validator', () => {
+      const schema = new SimpleSchema({ x: { type: Number } });
+      const bridge = new SimpleSchema2Bridge(schema);
+
       expect(bridge.getValidator()({})).not.toEqual(null);
-      expect(bridge.getValidator({})({})).not.toEqual(null);
+      expect(bridge.getValidator()({ x: 1 })).toEqual(null);
     });
   });
 });

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -336,7 +336,9 @@ describe('SimpleSchema2Bridge', () => {
       const bridge = new SimpleSchema2Bridge(schema);
 
       expect(bridge.getValidator()({})).not.toEqual(null);
+      expect(bridge.getValidator({})({})).not.toEqual(null);
       expect(bridge.getValidator()({ x: 1 })).toEqual(null);
+      expect(bridge.getValidator({})({ x: 1 })).toEqual(null);
     });
   });
 });

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -177,10 +177,14 @@ export default class SimpleSchema2Bridge extends Bridge {
 
   getValidator(options = { clean: true, mutate: true }) {
     const validator = this.schema.validator(options);
-
-    // Clean mutate its argument, even if mutate is false.
-    return options.clean
-      ? async model => validator(cloneDeep({ ...model }))
-      : async model => validator(model);
+    return model => {
+      try {
+        // Clean mutate its argument, even if mutate is false.
+        validator(options.clean ? cloneDeep({ ...model }) : model);
+        return null;
+      } catch (error) {
+        return error;
+      }
+    };
   }
 }

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -179,10 +179,8 @@ export default class SimpleSchema2Bridge extends Bridge {
     const validator = this.schema.validator(options);
 
     // Clean mutate its argument, even if mutate is false.
-    if (options.clean) {
-      return model => validator(cloneDeep({ ...model }));
-    }
-
-    return validator;
+    return options.clean
+      ? async model => validator(cloneDeep({ ...model }))
+      : async model => validator(model);
   }
 }

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -68,7 +68,9 @@ describe('SimpleSchemaBridge', () => {
     },
 
     validator() {
-      throw 'ValidationError';
+      return () => {
+        throw 'ValidationError';
+      };
     },
   };
 
@@ -311,7 +313,8 @@ describe('SimpleSchemaBridge', () => {
 
   describe('#getValidator', () => {
     it('calls correct validator', () => {
-      expect(() => bridge.getValidator()({})).toThrow();
+      expect(bridge.getValidator()({})).not.toEqual(null);
+      expect(bridge.getValidator({})({})).not.toEqual(null);
     });
   });
 });

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -325,7 +325,9 @@ describe('SimpleSchemaBridge', () => {
       });
 
       expect(bridge.getValidator()({})).not.toEqual(null);
+      expect(bridge.getValidator({})({})).not.toEqual(null);
       expect(bridge.getValidator()({ x: 1 })).toEqual(null);
+      expect(bridge.getValidator({})({ x: 1 })).toEqual(null);
     });
   });
 });

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -313,8 +313,19 @@ describe('SimpleSchemaBridge', () => {
 
   describe('#getValidator', () => {
     it('calls correct validator', () => {
+      const bridge = new SimpleSchemaBridge({
+        ...schema,
+        validator() {
+          return model => {
+            if (typeof model.x !== 'number') {
+              throw new Error();
+            }
+          };
+        },
+      });
+
       expect(bridge.getValidator()({})).not.toEqual(null);
-      expect(bridge.getValidator({})({})).not.toEqual(null);
+      expect(bridge.getValidator()({ x: 1 })).toEqual(null);
     });
   });
 });

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -162,10 +162,14 @@ export default class SimpleSchemaBridge extends Bridge {
 
   getValidator(options = { clean: true }) {
     const validator = this.schema.validator(options);
-
-    // Clean mutate its argument.
-    return options.clean
-      ? async model => validator(cloneDeep({ ...model }))
-      : async model => validator(model);
+    return model => {
+      try {
+        // Clean mutate its argument.
+        validator(options.clean ? cloneDeep({ ...model }) : model);
+        return null;
+      } catch (error) {
+        return error;
+      }
+    };
   }
 }

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -164,10 +164,8 @@ export default class SimpleSchemaBridge extends Bridge {
     const validator = this.schema.validator(options);
 
     // Clean mutate its argument.
-    if (options.clean) {
-      return model => validator(cloneDeep({ ...model }));
-    }
-
-    return validator;
+    return options.clean
+      ? async model => validator(cloneDeep({ ...model }))
+      : async model => validator(model);
   }
 }

--- a/packages/uniforms/__tests__/AutoForm.tsx
+++ b/packages/uniforms/__tests__/AutoForm.tsx
@@ -9,7 +9,7 @@ jest.mock('meteor/check');
 
 describe('AutoForm', () => {
   const onChangeModel = jest.fn();
-  const validator = jest.fn();
+  const validator = jest.fn(() => Promise.resolve());
   const onChange = jest.fn();
   const onSubmit = jest.fn();
   const model = { a: '1' };
@@ -21,10 +21,10 @@ describe('AutoForm', () => {
   });
 
   beforeEach(() => {
-    onChange.mockReset();
-    onChangeModel.mockReset();
-    onSubmit.mockReset();
-    validator.mockReset();
+    onChange.mockClear();
+    onChangeModel.mockClear();
+    onSubmit.mockClear();
+    validator.mockClear();
   });
 
   describe('when changed', () => {

--- a/packages/uniforms/__tests__/AutoForm.tsx
+++ b/packages/uniforms/__tests__/AutoForm.tsx
@@ -9,7 +9,7 @@ jest.mock('meteor/check');
 
 describe('AutoForm', () => {
   const onChangeModel = jest.fn();
-  const validator = jest.fn(() => Promise.resolve());
+  const validator = jest.fn();
   const onChange = jest.fn();
   const onSubmit = jest.fn();
   const model = { a: '1' };

--- a/packages/uniforms/__tests__/BaseForm.tsx
+++ b/packages/uniforms/__tests__/BaseForm.tsx
@@ -23,7 +23,7 @@ describe('BaseForm', () => {
   };
 
   const onChange = jest.fn();
-  const onSubmit = jest.fn(() => Promise.resolve());
+  const onSubmit = jest.fn();
 
   afterEach(() => {
     onChange.mockClear();

--- a/packages/uniforms/__tests__/BaseForm.tsx
+++ b/packages/uniforms/__tests__/BaseForm.tsx
@@ -23,15 +23,11 @@ describe('BaseForm', () => {
   };
 
   const onChange = jest.fn();
-  const onSubmit = jest.fn();
-  const onSubmitSuccess = jest.fn();
-  const onSubmitFailure = jest.fn();
+  const onSubmit = jest.fn(() => Promise.resolve());
 
   afterEach(() => {
-    onChange.mockReset();
-    onSubmit.mockReset();
-    onSubmitSuccess.mockReset();
-    onSubmitFailure.mockReset();
+    onChange.mockClear();
+    onSubmit.mockClear();
   });
 
   it('have correct context', () => {
@@ -255,20 +251,6 @@ describe('BaseForm', () => {
       wrapper.setProps({ modelTransform: undefined });
     });
 
-    it('without `onSubmit` calls only `onSubmitSuccess`', async () => {
-      wrapper.setProps({
-        onSubmit: undefined,
-        onSubmitSuccess,
-        onSubmitFailure,
-      });
-      wrapper.find('form').simulate('submit');
-
-      await new Promise(resolve => process.nextTick(resolve));
-      expect(onSubmit).not.toBeCalled();
-      expect(onSubmitSuccess).toBeCalledTimes(1);
-      expect(onSubmitFailure).not.toBeCalled();
-    });
-
     it('sets `submitting` state while submitting', async () => {
       let resolveSubmit = () => {};
       wrapper.setProps({
@@ -289,48 +271,6 @@ describe('BaseForm', () => {
 
       const context3 = wrapper.instance().getContext();
       expect(context3).toHaveProperty('submitting', false);
-    });
-
-    it('calls `onSubmitSuccess` with the returned value when `onSubmit` resolves', async () => {
-      const onSubmitValue = 'value';
-      onSubmit.mockReturnValueOnce(Promise.resolve(onSubmitValue));
-
-      const wrapper = mount<BaseForm<any>>(
-        <BaseForm
-          model={model}
-          schema={schema}
-          onSubmit={onSubmit}
-          onSubmitSuccess={onSubmitSuccess}
-        />,
-      );
-
-      wrapper.find('form').simulate('submit');
-
-      await new Promise(resolve => process.nextTick(resolve));
-
-      expect(onSubmitSuccess).toHaveBeenCalledTimes(1);
-      expect(onSubmitSuccess).toHaveBeenLastCalledWith(onSubmitValue);
-    });
-
-    it('calls `onSubmitFailure` with the thrown error when `onSubmit` rejects', async () => {
-      const onSubmitError = 'error';
-      onSubmit.mockReturnValueOnce(Promise.reject(onSubmitError));
-
-      const wrapper = mount<BaseForm<any>>(
-        <BaseForm
-          model={model}
-          schema={schema}
-          onSubmit={onSubmit}
-          onSubmitFailure={onSubmitFailure}
-        />,
-      );
-
-      wrapper.find('form').simulate('submit');
-
-      await new Promise(resolve => process.nextTick(resolve));
-
-      expect(onSubmitFailure).toHaveBeenCalledTimes(1);
-      expect(onSubmitFailure).toHaveBeenLastCalledWith(onSubmitError);
     });
   });
 });

--- a/packages/uniforms/__tests__/ValidatedForm.tsx
+++ b/packages/uniforms/__tests__/ValidatedForm.tsx
@@ -388,12 +388,13 @@ describe('ValidatedForm', () => {
         keys(variantGroups[0]),
         cartesian(keys(variantGroups[1]), keys(variantGroups[2])),
       ),
-    ).map(([a, [b, [c, d]]]) => [a, b, c, d] as const);
+    );
 
     const schema = new SimpleSchemaBridge(schemaDefinition);
     schema.getValidator = () => validator;
 
-    it.each(cases)('works for %p/%p/%p/%p', async (...modes) => {
+    const flatPair4 = ([a, [b, [c, d]]]) => [a, b, c, d] as const;
+    it.each(cases.map(flatPair4))('works for %p/%p/%p/%p', async (...modes) => {
       const [hasError, validatorMode, onValidateMode, onSubmitMode] = modes;
       const wrapper = mount<ValidatedForm>(
         <ValidatedForm

--- a/packages/uniforms/__tests__/connectField.tsx
+++ b/packages/uniforms/__tests__/connectField.tsx
@@ -56,7 +56,7 @@ describe('connectField', () => {
 
   beforeEach(() => {
     Test.mockClear();
-    onChange.mockReset();
+    onChange.mockClear();
   });
 
   describe('when called', () => {

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -16,7 +16,7 @@ export type BaseFormProps<Model> = {
   autosave: boolean;
   autosaveDelay: number;
   disabled?: boolean;
-  error?: any;
+  error: any;
   id?: string;
   label: boolean;
   model: DeepPartial<Model>;
@@ -49,6 +49,7 @@ export class BaseForm<
   static defaultProps = {
     autosave: false,
     autosaveDelay: 0,
+    error: null,
     label: true,
     model: Object.create(null),
     noValidate: true,

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -26,9 +26,7 @@ export type BaseFormProps<Model> = {
   ) => DeepPartial<Model>;
   noValidate: boolean;
   onChange?(key: string, value: any): void;
-  onSubmit?(model: DeepPartial<Model>): any;
-  onSubmitFailure?(result: any): void;
-  onSubmitSuccess?(result: any): void;
+  onSubmit(model: DeepPartial<Model>): Promise<any>;
   placeholder?: boolean;
   schema: any;
   showInlineError?: boolean;
@@ -54,6 +52,9 @@ export class BaseForm<
     label: true,
     model: Object.create(null),
     noValidate: true,
+    onSubmit() {
+      return Promise.resolve();
+    },
   };
 
   constructor(props: Props) {
@@ -245,24 +246,10 @@ export class BaseForm<
       event.stopPropagation();
     }
 
-    const result =
-      this.props.onSubmit && this.props.onSubmit(this.getModel('submit'));
-
-    // Set the `submitting` state only if onSubmit is async so we don't cause an unnecessary re-render
-    let submitting: Promise<any>;
-    if (isPromiseLike(result)) {
-      this.setState({ submitting: true });
-      submitting = result.finally(() => {
-        this.setState({ submitting: false });
-      });
-    } else {
-      submitting = Promise.resolve(result);
-    }
-
-    return submitting.then(
-      this.props.onSubmitSuccess,
-      this.props.onSubmitFailure,
-    );
+    this.setState({ submitting: true });
+    return this.props.onSubmit(this.getModel('submit')).finally(() => {
+      this.setState({ submitting: false });
+    });
   }
 
   render() {
@@ -272,8 +259,4 @@ export class BaseForm<
       </context.Provider>
     );
   }
-}
-
-function isPromiseLike(value: any): value is Promise<any> {
-  return !!value && isFunction(value.then);
 }

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -26,7 +26,7 @@ export type BaseFormProps<Model> = {
   ) => DeepPartial<Model>;
   noValidate: boolean;
   onChange?(key: string, value: any): void;
-  onSubmit(model: DeepPartial<Model>): Promise<any>;
+  onSubmit(model: DeepPartial<Model>): any;
   placeholder?: boolean;
   schema: any;
   showInlineError?: boolean;
@@ -52,9 +52,7 @@ export class BaseForm<
     label: true,
     model: Object.create(null),
     noValidate: true,
-    onSubmit() {
-      return Promise.resolve();
-    },
+    onSubmit() {},
   };
 
   constructor(props: Props) {
@@ -246,8 +244,13 @@ export class BaseForm<
       event.stopPropagation();
     }
 
+    const result = this.props.onSubmit(this.getModel('submit'));
+    if (!(result instanceof Promise)) {
+      return Promise.resolve(result);
+    }
+
     this.setState({ submitting: true });
-    return this.props.onSubmit(this.getModel('submit')).finally(() => {
+    return result.finally(() => {
       this.setState({ submitting: false });
     });
   }

--- a/packages/uniforms/src/Bridge.ts
+++ b/packages/uniforms/src/Bridge.ts
@@ -90,7 +90,7 @@ export abstract class Bridge {
     );
   }
 
-  getValidator(options?: any): (model: Record<string, any>) => void {
+  getValidator(options?: any): (model: Record<string, any>) => Promise<void> {
     return invariant(
       false,
       '%s have not implemented `getValidator` method (args=%o).',

--- a/packages/uniforms/src/Bridge.ts
+++ b/packages/uniforms/src/Bridge.ts
@@ -90,7 +90,7 @@ export abstract class Bridge {
     );
   }
 
-  getValidator(options?: any): (model: Record<string, any>) => Promise<void> {
+  getValidator(options?: any): (model: Record<string, any>) => any {
     return invariant(
       false,
       '%s have not implemented `getValidator` method (args=%o).',

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -179,7 +179,7 @@ export function Validated<Base extends typeof BaseForm>(Base: Base) {
       this.setState({ validating: true });
       return result.then(error => {
         this.setState((state, props) => ({
-          error: props.error === error ? null : error,
+          error: props.error === error ? null : error || null,
           validating: false,
         }));
 

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -126,16 +126,14 @@ export function Validated<Base extends typeof BaseForm>(Base: Base) {
       this.setState({ validate: true });
 
       const result = this.onValidate().then(error => {
-        if (error) {
+        if (error !== null) {
           return Promise.reject(error);
         }
 
         return super.onSubmit().catch(error => {
-          this.setState((state, props) =>
-            state.error === error
-              ? null
-              : { error: props.error === error ? null : error || null },
-          );
+          this.setState({
+            error: this.props.error === error ? null : error || null,
+          });
 
           throw error;
         });

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -33,7 +33,6 @@ export function Validated<Base extends typeof BaseForm>(Base: Base) {
     static displayName = `Validated${Base.displayName}`;
     static defaultProps = {
       ...Base.defaultProps,
-      error: null,
       onValidate(model, error) {
         return error;
       },

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -1,10 +1,9 @@
 import cloneDeep from 'lodash/cloneDeep';
-import identity from 'lodash/identity';
 import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
 import omit from 'lodash/omit';
 import set from 'lodash/set';
-import { Component, SyntheticEvent } from 'react';
+import { SyntheticEvent } from 'react';
 
 import { BaseForm, BaseFormProps, BaseFormState } from './BaseForm';
 import { Context, DeepPartial, ValidateMode } from './types';


### PR DESCRIPTION
Let's start with a short flashback from #644:
> [...] Well, the first bridge ever was the SimpleSchema (the Meteor one), and its validator throws an error instead of returning it. It was perfectly fine, up to the point when we wanted to add `onSubmitSuccess`/`onSubmitFailure` and async validation. Of course, we managed to do so, but the solution is not very elegant.

This _not very elegant solution_ got implemented in #51. Why it's not elegant? Because it's redundant. There's no need for such hooks if one can simply add it directly to the `onSubmit`. Another problem (non-elegancy) is the asynchronous validation - invented in #17 and implemented in 4a56596f8a2e296f891316430cdba104cd21f8e6. It's weird and is using callbacks.

This PR introduces a new, clean flow (including https://github.com/vazco/uniforms/pull/711#issuecomment-618319641):
* **Bridge validators can to be asynchronous.**
* **Bridge validators have to return errors instead of throwing them.** More background is in #644.
* **The `onValidate` is now `(model, error?) => error? | Promise<error?>`.** This is far better and obvious than the callback version before.
* **Removed `onSubmitSuccess` and `onSubmitFailure`.** I'm pretty sure there's no viable case for them at all. Migration is straightforward:
  ```diff
  -onSubmit={onSubmit}
  -onSubmitSuccess={onSubmitSuccess}
  -onSubmitFailure={onSubmitFailure}
  +onSubmit={model => {
  +  const result = onSubmit(model);
  +  result.then(onSubmitSuccess, onSubmitFailure);
  +  return result;
  +}}`
  ```
* **Separated `submitting` and `validating` states.** Now `validating` is `true` only while the bridge validator or `onValidate` are currently running. Same for `submitting` - it's try only while `onSubmit` is running.

**TODO:**
- [x] Perform some manual tests to check if there's no visible difference with this change. It might be the case as few things got _asyncified_.
- [x] Run benchmarks to ensure no performance degradation.
- [x] Add missing tests.
- [x] Update `CHANGELOG.md`.

---

Closes #644.