### PR TITLE
Simplified ListField

### DIFF
--- a/packages/uniforms-antd/__tests__/ListAddField.tsx
+++ b/packages/uniforms-antd/__tests__/ListAddField.tsx
@@ -1,76 +1,48 @@
 import React from 'react';
 import { ListAddField } from 'uniforms-antd';
+import merge from 'lodash/merge';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  value: [],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: [] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListAddField> - works', () => {
-  const element = <ListAddField name="x.$" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.$" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
 });
 
 test('<ListAddField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, maxCount: 0 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" />;
+  const wrapper = mount(element, context({ x: { maxCount: 0 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange })}
-      value="y"
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" value="y" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['y']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
 });

--- a/packages/uniforms-antd/__tests__/ListDelField.tsx
+++ b/packages/uniforms-antd/__tests__/ListDelField.tsx
@@ -1,73 +1,48 @@
 import React from 'react';
+import merge from 'lodash/merge';
 import { ListDelField } from 'uniforms-antd';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  minCount: 0,
-  value: ['x', 'y', 'z'],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: ['x', 'y', 'z'] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListDelField> - works', () => {
-  const element = <ListDelField name="x.1" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
 });
 
 test('<ListDelField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, minCount: 3 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context({ x: { minCount: 3 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField name="x.1" parent={Object.assign({}, parent, { onChange })} />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['x', 'z']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
 });

--- a/packages/uniforms-antd/__tests__/ListField.tsx
+++ b/packages/uniforms-antd/__tests__/ListField.tsx
@@ -79,6 +79,7 @@ test('<ListField> - renders children (specified)', () => {
   const element = (
     <ListField name="x" initialCount={2}>
       <Child />
+      PlainText
     </ListField>
   );
   mount(

--- a/packages/uniforms-antd/__tests__/ListField.tsx
+++ b/packages/uniforms-antd/__tests__/ListField.tsx
@@ -23,7 +23,7 @@ test('<ListField> - renders ListAddField', () => {
   );
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
-  expect(wrapper.find(ListAddField).prop('name')).toBe('x.$');
+  expect(wrapper.find(ListAddField).prop('name')).toBe('$');
 });
 
 test('<ListField> - renders correct label and info (specified)', () => {
@@ -102,8 +102,8 @@ test('<ListField> - renders children with correct name (children)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(Child).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(Child).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(Child).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
@@ -113,8 +113,8 @@ test('<ListField> - renders children with correct name (value)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders correct error text (specified)', () => {

--- a/packages/uniforms-antd/__tests__/ListItemField.tsx
+++ b/packages/uniforms-antd/__tests__/ListItemField.tsx
@@ -22,7 +22,7 @@ test('<ListItemField> - renders ListDelField', () => {
   );
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
-  expect(wrapper.find(ListDelField).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListDelField).childAt(0).prop('name')).toBe('x.1');
 });
 
 test('<ListItemField> - renders AutoField', () => {

--- a/packages/uniforms-antd/__tests__/_createContext.ts
+++ b/packages/uniforms-antd/__tests__/_createContext.ts
@@ -6,8 +6,8 @@ const randomId = randomIds();
 
 export default function createContext(
   schema?: {},
-  context?: Partial<Context>,
-): { context: Context } {
+  context?: Partial<Context<any>>,
+): { context: Context<any> } {
   return {
     context: {
       changed: false,

--- a/packages/uniforms-antd/src/ListAddField.tsx
+++ b/packages/uniforms-antd/src/ListAddField.tsx
@@ -1,13 +1,11 @@
 import Button, { ButtonProps } from 'antd/lib/button';
-import cloneDeep from 'lodash/cloneDeep';
-import omit from 'lodash/omit';
 import React from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import cloneDeep from 'lodash/cloneDeep';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListAddFieldProps<T> = Override<
   ButtonProps,
   {
-    disabled?: boolean;
     initialCount?: number;
     name: string;
     parent?: any;
@@ -15,34 +13,33 @@ export type ListAddFieldProps<T> = Override<
   }
 >;
 
-function ListAdd<T>(rawProps: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
+  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const parentName = joinName(joinName(null, props.name).slice(0, -1));
+  const nameParts = joinName(null, rawProps.name);
+  const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (props.parent) Object.assign(parent, props.parent);
 
   const limitNotReached =
     !props.disabled && !(parent.maxCount! <= parent.value!.length);
+
   return (
     <Button
-      disabled={!limitNotReached || rawProps.disabled}
+      // FIXME: filterDOMProps will remove value.
+      {...(filterDOMProps(props) as Omit<typeof props, 'value'>)}
+      disabled={!limitNotReached}
       onClick={() => {
         if (limitNotReached)
           parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
       }}
-      {...filterDOMProps(omit(props, ['value']))}
     />
   );
 }
 
-ListAdd.defaultProps = {
+ListAddField.defaultProps = {
   icon: 'plus-square-o',
   size: 'small',
   style: { width: '100%' },
   type: 'dashed',
 };
-
-export default ListAdd;

--- a/packages/uniforms-antd/src/ListAddField.tsx
+++ b/packages/uniforms-antd/src/ListAddField.tsx
@@ -1,28 +1,30 @@
-import Button, { ButtonProps } from 'antd/lib/button';
+import Button, { ButtonProps, ButtonSize, ButtonType } from 'antd/lib/button';
 import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  filterDOMProps,
+  joinName,
+  useField,
+  connectField,
+} from 'uniforms';
 
-export type ListAddFieldProps<T> = Override<
-  ButtonProps,
-  {
-    initialCount?: number;
-    name: string;
-    parent?: any;
-    value?: T;
-  }
+export type ListAddFieldProps = Override<
+  Omit<ButtonProps, 'onChange'>,
+  { initialCount?: number; name: string; value: unknown }
 >;
 
-export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListAdd({ disabled, name, value, ...props }: ListAddFieldProps) {
+  const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (props.parent) Object.assign(parent, props.parent);
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
-    !props.disabled && !(parent.maxCount! <= parent.value!.length);
+    !disabled && !(parent.maxCount! <= parent.value!.length);
 
   return (
     <Button
@@ -30,16 +32,19 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
       {...(filterDOMProps(props) as Omit<typeof props, 'value'>)}
       disabled={!limitNotReached}
       onClick={() => {
-        if (limitNotReached)
-          parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
+        if (limitNotReached) {
+          parent.onChange(parent.value!.concat([cloneDeep(value)]));
+        }
       }}
     />
   );
 }
 
-ListAddField.defaultProps = {
+ListAdd.defaultProps = {
   icon: 'plus-square-o',
-  size: 'small',
+  size: 'small' as ButtonSize,
   style: { width: '100%' },
-  type: 'dashed',
+  type: 'dashed' as ButtonType,
 };
+
+export default connectField(ListAdd, { initialValue: false });

--- a/packages/uniforms-antd/src/ListAddField.tsx
+++ b/packages/uniforms-antd/src/ListAddField.tsx
@@ -32,9 +32,7 @@ function ListAdd({ disabled, name, value, ...props }: ListAddFieldProps) {
       {...(filterDOMProps(props) as Omit<typeof props, 'value'>)}
       disabled={!limitNotReached}
       onClick={() => {
-        if (limitNotReached) {
-          parent.onChange(parent.value!.concat([cloneDeep(value)]));
-        }
+        parent.onChange(parent.value!.concat([cloneDeep(value)]));
       }}
     />
   );

--- a/packages/uniforms-antd/src/ListDelField.tsx
+++ b/packages/uniforms-antd/src/ListDelField.tsx
@@ -1,25 +1,35 @@
-import Button, { ButtonProps } from 'antd/lib/button';
-import React from 'react';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
-
-export type ListDelFieldProps<T> = Override<
+import Button, {
   ButtonProps,
-  {
-    name: string;
-    parent?: any;
-  }
+  ButtonType,
+  ButtonSize,
+  ButtonShape,
+} from 'antd/lib/button';
+import React from 'react';
+import {
+  Override,
+  filterDOMProps,
+  joinName,
+  useField,
+  connectField,
+} from 'uniforms';
+
+export type ListDelFieldProps = Override<
+  Omit<ButtonProps, 'onChange'>,
+  { name: string }
 >;
 
-export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListDel({ disabled, name, ...props }: ListDelFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (props.parent) Object.assign(parent, props.parent);
+  const parent = useField<{ minCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
-    !props.disabled && !(parent.minCount! >= parent.value!.length);
+    !disabled && !(parent.minCount! >= parent.value!.length);
 
   return (
     <Button
@@ -29,7 +39,7 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(+nameParts[nameParts.length - 1], 1);
+          value.splice(nameIndex, 1);
           parent.onChange(value);
         }
       }}
@@ -37,9 +47,11 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
   );
 }
 
-ListDelField.defaultProps = {
+ListDel.defaultProps = {
   icon: 'delete',
-  shape: 'circle-outline',
-  size: 'small',
-  type: 'ghost',
+  shape: 'circle-outline' as ButtonShape,
+  size: 'small' as ButtonSize,
+  type: 'ghost' as ButtonType,
 };
+
+export default connectField(ListDel);

--- a/packages/uniforms-antd/src/ListDelField.tsx
+++ b/packages/uniforms-antd/src/ListDelField.tsx
@@ -37,11 +37,9 @@ function ListDel({ disabled, name, ...props }: ListDelFieldProps) {
       {...(filterDOMProps(props) as Omit<typeof props, 'value'>)}
       disabled={!limitNotReached}
       onClick={() => {
-        if (limitNotReached) {
-          const value = parent.value!.slice();
-          value.splice(nameIndex, 1);
-          parent.onChange(value);
-        }
+        const value = parent.value!.slice();
+        value.splice(nameIndex, 1);
+        parent.onChange(value);
       }}
     />
   );

--- a/packages/uniforms-antd/src/ListDelField.tsx
+++ b/packages/uniforms-antd/src/ListDelField.tsx
@@ -1,50 +1,45 @@
 import Button, { ButtonProps } from 'antd/lib/button';
-import omit from 'lodash/omit';
 import React from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListDelFieldProps<T> = Override<
   ButtonProps,
   {
     name: string;
     parent?: any;
-    value?: T;
   }
 >;
 
-function ListDel<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
+  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const nameParts = joinName(null, props.name);
+  const nameParts = joinName(null, rawProps.name);
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (props.parent) Object.assign(parent, props.parent);
 
-  const fieldIndex = +nameParts[nameParts.length - 1];
   const limitNotReached =
     !props.disabled && !(parent.minCount! >= parent.value!.length);
+
   return (
     <Button
-      disabled={!limitNotReached || rawProps.disabled}
+      // FIXME: filterDOMProps will remove value.
+      {...(filterDOMProps(props) as Omit<typeof props, 'value'>)}
+      disabled={!limitNotReached}
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(fieldIndex, 1);
+          value.splice(+nameParts[nameParts.length - 1], 1);
           parent.onChange(value);
         }
       }}
-      {...filterDOMProps(omit(props, ['value']))}
     />
   );
 }
 
-ListDel.defaultProps = {
+ListDelField.defaultProps = {
   icon: 'delete',
   shape: 'circle-outline',
   size: 'small',
   type: 'ghost',
 };
-
-export default ListDel;

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -1,5 +1,11 @@
 import Icon from 'antd/lib/icon';
-import React, { Children, HTMLProps, ReactNode, cloneElement } from 'react';
+import React, {
+  Children,
+  HTMLProps,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
 import Tooltip from 'antd/lib/tooltip';
 import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
 
@@ -58,30 +64,27 @@ function List<T>({
       {!!(error && showInlineError) && <div>{errorMessage}</div>}
 
       {children
-        ? value.map((item: any, index: number) =>
-            Children.map(children as JSX.Element, child =>
-              cloneElement(child, {
-                key: index,
-                label: null,
-                name: joinName(
-                  name,
-                  child.props.name && child.props.name.replace('$', index),
-                ),
-              }),
+        ? value.map((item, index) =>
+            Children.map(children, child =>
+              isValidElement(child) && child.props.name
+                ? cloneElement(child, {
+                    key: index,
+                    name: child.props.name.replace('$', '' + index),
+                  })
+                : child,
             ),
           )
-        : value.map((item: any, index: number) => (
+        : value.map((item, index) => (
             <ListItemField
               key={index}
-              label={undefined}
               labelCol={labelCol}
-              name={joinName(name, index)}
+              name={'' + index}
               wrapperCol={wrapperCol}
               {...itemProps}
             />
           ))}
 
-      <ListAddField name={`${name}.$`} initialCount={initialCount} />
+      <ListAddField name="$" initialCount={initialCount} />
     </div>
   );
 }
@@ -96,6 +99,4 @@ List.defaultProps = {
   },
 };
 
-export default connectField(List, {
-  includeInChain: false,
-});
+export default connectField(List);

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -15,7 +15,7 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
-    addIcon?: any;
+    addIcon?: ReactNode;
     children: ReactNode;
     error?: boolean;
     errorMessage?: string;

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -7,16 +7,16 @@ import React, {
   isValidElement,
 } from 'react';
 import Tooltip from 'antd/lib/tooltip';
-import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
+import { connectField, filterDOMProps, Override } from 'uniforms';
 
 import ListAddField from './ListAddField';
 import ListItemField from './ListItemField';
 
-export type ListFieldProps<T> = Override<
-  HTMLProps<HTMLDivElement>,
+export type ListFieldProps = Override<
+  Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
     addIcon?: any;
-    children?: ReactNode;
+    children: ReactNode;
     error?: boolean;
     errorMessage?: string;
     info?: boolean;
@@ -26,11 +26,11 @@ export type ListFieldProps<T> = Override<
     labelCol?: any;
     name: string;
     showInlineError?: boolean;
-    value: T[];
+    value: unknown[];
     wrapperCol?: any;
   }
 >;
-function List<T>({
+function List({
   children,
   error,
   errorMessage,
@@ -39,12 +39,11 @@ function List<T>({
   itemProps,
   label,
   labelCol,
-  name,
   showInlineError,
   value,
   wrapperCol,
   ...props
-}: ListFieldProps<T>) {
+}: ListFieldProps) {
   return (
     <div {...filterDOMProps(props)}>
       {label && (
@@ -63,26 +62,19 @@ function List<T>({
 
       {!!(error && showInlineError) && <div>{errorMessage}</div>}
 
-      {children
-        ? value.map((item, index) =>
-            Children.map(children, child =>
-              isValidElement(child) && child.props.name
-                ? cloneElement(child, {
-                    key: index,
-                    name: child.props.name.replace('$', '' + index),
-                  })
-                : child,
-            ),
-          )
-        : value.map((item, index) => (
-            <ListItemField
-              key={index}
-              labelCol={labelCol}
-              name={'' + index}
-              wrapperCol={wrapperCol}
-              {...itemProps}
-            />
-          ))}
+      {value.map((item, itemIndex) =>
+        Children.map(children, (child, childIndex) =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                key: `${itemIndex}-${childIndex}`,
+                name: child.props.name?.replace('$', '' + itemIndex),
+                labelCol,
+                wrapperCol,
+                ...itemProps,
+              })
+            : child,
+        ),
+      )}
 
       <ListAddField name="$" initialCount={initialCount} />
     </div>
@@ -97,6 +89,7 @@ List.defaultProps = {
     marginTop: '5px',
     padding: '10px',
   },
+  children: <ListItemField name="$" />,
 };
 
 export default connectField(List);

--- a/packages/uniforms-antd/src/ListItemField.tsx
+++ b/packages/uniforms-antd/src/ListItemField.tsx
@@ -1,4 +1,9 @@
-import React, { Children, ReactNode, cloneElement } from 'react';
+import React, {
+  Children,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
 import { joinName } from 'uniforms';
 
 import AutoField from './AutoField';
@@ -12,7 +17,7 @@ export type ListItemFieldProps = {
   wrapperCol?: any;
 };
 
-export default function ListItem(props: ListItemFieldProps) {
+export default function ListItemField(props: ListItemFieldProps) {
   return (
     <div>
       <div
@@ -39,11 +44,13 @@ export default function ListItem(props: ListItemFieldProps) {
 
       <div style={{ width: '100%' }}>
         {props.children ? (
-          Children.map(props.children as JSX.Element, child =>
-            cloneElement(child, {
-              name: joinName(props.name, child.props.name),
-              label: null,
-            }),
+          Children.map(props.children, child =>
+            isValidElement(child)
+              ? cloneElement(child, {
+                  name: joinName(props.name, child.props.name),
+                  label: null,
+                })
+              : child,
           )
         ) : (
           <AutoField {...props} />

--- a/packages/uniforms-antd/src/ListItemField.tsx
+++ b/packages/uniforms-antd/src/ListItemField.tsx
@@ -1,23 +1,18 @@
-import React, {
-  Children,
-  ReactNode,
-  cloneElement,
-  isValidElement,
-} from 'react';
-import { joinName } from 'uniforms';
+import React, { ReactNode } from 'react';
+import { connectField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   label?: any;
   labelCol?: string;
   name: string;
   wrapperCol?: any;
 };
 
-export default function ListItemField(props: ListItemFieldProps) {
+function ListItem({ children }: ListItemFieldProps) {
   return (
     <div>
       <div
@@ -29,7 +24,7 @@ export default function ListItemField(props: ListItemFieldProps) {
           width: '20px',
         }}
       >
-        <ListDelField className="top aligned" name={props.name} />
+        <ListDelField className="top aligned" name="" />
       </div>
 
       <div style={{ marginBottom: '4px', overflow: 'hidden' }}>
@@ -42,20 +37,11 @@ export default function ListItemField(props: ListItemFieldProps) {
         />
       </div>
 
-      <div style={{ width: '100%' }}>
-        {props.children ? (
-          Children.map(props.children, child =>
-            isValidElement(child)
-              ? cloneElement(child, {
-                  name: joinName(props.name, child.props.name),
-                  label: null,
-                })
-              : child,
-          )
-        ) : (
-          <AutoField {...props} />
-        )}
-      </div>
+      <div style={{ width: '100%' }}>{children}</div>
     </div>
   );
 }
+
+ListItem.defaultProps = { children: <AutoField label={null} name="" /> };
+
+export default connectField(ListItem);

--- a/packages/uniforms-bootstrap3/__tests__/ListAddField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListAddField.tsx
@@ -1,76 +1,48 @@
 import React from 'react';
 import { ListAddField } from 'uniforms-bootstrap3';
+import merge from 'lodash/merge';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  value: [],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: [] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListAddField> - works', () => {
-  const element = <ListAddField name="x.$" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.$" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
 });
 
 test('<ListAddField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, maxCount: 0 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" />;
+  const wrapper = mount(element, context({ x: { maxCount: 0 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange })}
-      value="y"
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" value="y" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['y']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
 });

--- a/packages/uniforms-bootstrap3/__tests__/ListDelField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListDelField.tsx
@@ -1,73 +1,48 @@
 import React from 'react';
 import { ListDelField } from 'uniforms-bootstrap3';
+import merge from 'lodash/merge';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  minCount: 0,
-  value: ['x', 'y', 'z'],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: ['x', 'y', 'z'] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListDelField> - works', () => {
-  const element = <ListDelField name="x.1" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
 });
 
 test('<ListDelField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, minCount: 3 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context({ x: { minCount: 3 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField name="x.1" parent={Object.assign({}, parent, { onChange })} />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['x', 'z']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
 });

--- a/packages/uniforms-bootstrap3/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListField.tsx
@@ -22,7 +22,7 @@ test('<ListField> - renders ListAddField', () => {
   );
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
-  expect(wrapper.find(ListAddField).prop('name')).toBe('x.$');
+  expect(wrapper.find(ListAddField).prop('name')).toBe('$');
 });
 
 test('<ListField> - renders correct label (specified)', () => {
@@ -89,8 +89,8 @@ test('<ListField> - renders children with correct name (children)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(Child).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(Child).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(Child).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
@@ -100,8 +100,8 @@ test('<ListField> - renders children with correct name (value)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders correct error text (specified)', () => {

--- a/packages/uniforms-bootstrap3/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListField.tsx
@@ -66,6 +66,7 @@ test('<ListField> - renders children (specified)', () => {
   const element = (
     <ListField name="x" initialCount={2}>
       <Child />
+      PlainText
     </ListField>
   );
   mount(

--- a/packages/uniforms-bootstrap3/__tests__/ListItemField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListItemField.tsx
@@ -22,7 +22,7 @@ test('<ListItemField> - renders ListDelField', () => {
   );
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
-  expect(wrapper.find(ListDelField).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListDelField).childAt(0).prop('name')).toBe('x.1');
 });
 
 test('<ListItemField> - renders AutoField', () => {

--- a/packages/uniforms-bootstrap3/__tests__/_createContext.ts
+++ b/packages/uniforms-bootstrap3/__tests__/_createContext.ts
@@ -6,8 +6,8 @@ const randomId = randomIds();
 
 export default function createContext(
   schema?: {},
-  context?: Partial<Context>,
-): { context: Context } {
+  context?: Partial<Context<any>>,
+): { context: Context<any> } {
   return {
     context: {
       changed: false,

--- a/packages/uniforms-bootstrap3/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListAddField.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, ReactNode } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
 import {
@@ -12,7 +12,7 @@ import {
 export type ListAddFieldProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
-    addIcon?: any;
+    addIcon?: ReactNode;
     initialCount?: number;
     name: string;
     parent?: any;

--- a/packages/uniforms-bootstrap3/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListAddField.tsx
@@ -1,33 +1,40 @@
 import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  filterDOMProps,
+  joinName,
+  useField,
+  connectField,
+} from 'uniforms';
 
-export type ListAddFieldProps<T> = Override<
-  HTMLProps<HTMLDivElement>,
+export type ListAddFieldProps = Override<
+  Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
     addIcon?: any;
     initialCount?: number;
     name: string;
     parent?: any;
-    value?: T;
+    value?: unknown;
   }
 >;
 
-export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
-  const {
-    addIcon,
-    className,
-    disabled,
-    parent: parentFromProps,
-    value,
-    ...props
-  } = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListAdd({
+  name,
+  addIcon,
+  className,
+  disabled,
+  value,
+  ...props
+}: ListAddFieldProps) {
+  const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (parentFromProps) Object.assign(parent, parentFromProps);
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);
@@ -38,7 +45,7 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
       className={classnames('badge pull-right', className)}
       onClick={() => {
         if (limitNotReached)
-          parent.onChange(parent.value!.concat([cloneDeep(value!)]));
+          parent.onChange(parent.value!.concat([cloneDeep(value)]));
       }}
     >
       {addIcon}
@@ -46,6 +53,8 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
   );
 }
 
-ListAddField.defaultProps = {
+ListAdd.defaultProps = {
   addIcon: <i className="glyphicon glyphicon-plus" />,
 };
+
+export default connectField(ListAdd, { initialValue: false });

--- a/packages/uniforms-bootstrap3/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListAddField.tsx
@@ -1,45 +1,51 @@
+import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
-import React, { HTMLProps } from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListAddFieldProps<T> = Override<
   HTMLProps<HTMLDivElement>,
   {
     addIcon?: any;
-    disabled?: boolean;
+    initialCount?: number;
     name: string;
     parent?: any;
     value?: T;
   }
 >;
 
-function ListAdd<T>({ addIcon, ...rawProps }: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
+  const {
+    addIcon,
+    className,
+    disabled,
+    parent: parentFromProps,
+    value,
+    ...props
+  } = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const parentName = joinName(joinName(null, props.name).slice(0, -1));
+  const nameParts = joinName(null, rawProps.name);
+  const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (parentFromProps) Object.assign(parent, parentFromProps);
 
   const limitNotReached =
-    !props.disabled && !(parent.maxCount! <= parent.value!.length);
+    !disabled && !(parent.maxCount! <= parent.value!.length);
 
   return (
     <div
-      className={classnames('badge pull-right', rawProps.className)}
+      {...filterDOMProps(props)}
+      className={classnames('badge pull-right', className)}
       onClick={() => {
         if (limitNotReached)
-          parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
+          parent.onChange(parent.value!.concat([cloneDeep(value!)]));
       }}
-      {...filterDOMProps(props)}
     >
       {addIcon}
     </div>
   );
 }
 
-ListAdd.defaultProps = { addIcon: <i className="glyphicon glyphicon-plus" /> };
-
-export default ListAdd;
+ListAddField.defaultProps = {
+  addIcon: <i className="glyphicon glyphicon-plus" />,
+};

--- a/packages/uniforms-bootstrap3/src/ListDelField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListDelField.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, ReactNode } from 'react';
 import classnames from 'classnames';
 import {
   Override,
@@ -13,7 +13,7 @@ export type ListDelFieldProps = Override<
   {
     name: string;
     parent?: any;
-    removeIcon?: any;
+    removeIcon?: ReactNode;
   }
 >;
 

--- a/packages/uniforms-bootstrap3/src/ListDelField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListDelField.tsx
@@ -1,9 +1,15 @@
 import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  filterDOMProps,
+  joinName,
+  useField,
+  connectField,
+} from 'uniforms';
 
-export type ListDelFieldProps<T> = Override<
-  HTMLProps<HTMLDivElement>,
+export type ListDelFieldProps = Override<
+  Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
     name: string;
     parent?: any;
@@ -11,20 +17,21 @@ export type ListDelFieldProps<T> = Override<
   }
 >;
 
-export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
-  const {
-    className,
-    disabled,
-    parent: parentFromProps,
-    removeIcon,
-    ...props
-  } = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListDel({
+  name,
+  className,
+  disabled,
+  removeIcon,
+  ...props
+}: ListDelFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (parentFromProps) Object.assign(parent, parentFromProps);
-
+  const parent = useField<{ minCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
   const limitNotReached =
     !disabled && !(parent.minCount! >= parent.value!.length);
 
@@ -35,7 +42,7 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(+nameParts[nameParts.length - 1], 1);
+          value.splice(nameIndex, 1);
           parent.onChange(value);
         }
       }}
@@ -45,6 +52,8 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
   );
 }
 
-ListDelField.defaultProps = {
+ListDel.defaultProps = {
   removeIcon: <i className="glyphicon glyphicon-minus" />,
 };
+
+export default connectField(ListDel, { initialValue: false });

--- a/packages/uniforms-bootstrap3/src/ListDelField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListDelField.tsx
@@ -1,49 +1,50 @@
-import classnames from 'classnames';
 import React, { HTMLProps } from 'react';
-import { filterDOMProps, joinName, useField, Override } from 'uniforms';
+import classnames from 'classnames';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListDelFieldProps<T> = Override<
   HTMLProps<HTMLDivElement>,
   {
-    className?: string;
     name: string;
     parent?: any;
     removeIcon?: any;
   }
 >;
 
-function ListDel<T>({ removeIcon, ...rawProps }: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
+  const {
+    className,
+    disabled,
+    parent: parentFromProps,
+    removeIcon,
+    ...props
+  } = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const nameParts = joinName(null, props.name);
+  const nameParts = joinName(null, rawProps.name);
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (parentFromProps) Object.assign(parent, parentFromProps);
 
-  const fieldIndex = +nameParts[nameParts.length - 1];
   const limitNotReached =
-    !props.disabled && !(parent.minCount! >= parent.value!.length);
+    !disabled && !(parent.minCount! >= parent.value!.length);
+
   return (
     <span
-      className={classnames('badge', rawProps.className)}
+      {...filterDOMProps(props)}
+      className={classnames('badge', className)}
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(fieldIndex, 1);
+          value.splice(+nameParts[nameParts.length - 1], 1);
           parent.onChange(value);
         }
       }}
-      {...filterDOMProps(props)}
     >
       {removeIcon}
     </span>
   );
 }
 
-ListDel.defaultProps = {
+ListDelField.defaultProps = {
   removeIcon: <i className="glyphicon glyphicon-minus" />,
 };
-
-export default ListDel;

--- a/packages/uniforms-bootstrap3/src/ListField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListField.tsx
@@ -14,14 +14,14 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
-    addIcon?: any;
+    addIcon?: ReactNode;
     children: ReactNode;
     error?: boolean;
     errorMessage?: string;
     initialCount?: number;
     itemProps?: {};
     name: string;
-    removeIcon?: any;
+    removeIcon?: ReactNode;
     showInlineError?: boolean;
     value: unknown[];
   }

--- a/packages/uniforms-bootstrap3/src/ListField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListField.tsx
@@ -11,11 +11,11 @@ import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
 import ListAddField from './ListAddField';
 import ListItemField from './ListItemField';
 
-export type ListFieldProps<T> = Override<
-  HTMLProps<HTMLDivElement>,
+export type ListFieldProps = Override<
+  Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
     addIcon?: any;
-    children?: ReactNode;
+    children: ReactNode;
     error?: boolean;
     errorMessage?: string;
     initialCount?: number;
@@ -23,11 +23,11 @@ export type ListFieldProps<T> = Override<
     name: string;
     removeIcon?: any;
     showInlineError?: boolean;
-    value: T[];
+    value: unknown[];
   }
 >;
 
-function List<T>({
+function List({
   addIcon,
   children,
   className,
@@ -36,12 +36,11 @@ function List<T>({
   initialCount,
   itemProps,
   label,
-  name,
   removeIcon,
   showInlineError,
   value,
   ...props
-}: ListFieldProps<T>) {
+}: ListFieldProps) {
   return (
     <div
       className={classnames(
@@ -68,29 +67,23 @@ function List<T>({
           </div>
         )}
 
-        {children
-          ? value.map((item, index) =>
-              Children.map(children, child =>
-                isValidElement(child) && child.props.name
-                  ? cloneElement(child, {
-                      key: index,
-                      name: child.props.name.replace('$', '' + index),
-                      removeIcon,
-                    })
-                  : child,
-              ),
-            )
-          : value.map((item, index) => (
-              <ListItemField
-                key={index}
-                name={'' + index}
-                removeIcon={removeIcon}
-                {...itemProps}
-              />
-            ))}
+        {value.map((item, itemIndex) =>
+          Children.map(children, (child, childIndex) =>
+            isValidElement(child)
+              ? cloneElement(child, {
+                  key: `${itemIndex}-${childIndex}`,
+                  name: child.props.name?.replace('$', '' + itemIndex),
+                  ...itemProps,
+                  removeIcon,
+                })
+              : child,
+          ),
+        )}
       </div>
     </div>
   );
 }
+
+List.defaultProps = { children: <ListItemField name="$" /> };
 
 export default connectField(List);

--- a/packages/uniforms-bootstrap3/src/ListField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListField.tsx
@@ -1,5 +1,11 @@
+import React, {
+  Children,
+  HTMLProps,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
 import classnames from 'classnames';
-import React, { Children, HTMLProps, ReactNode, cloneElement } from 'react';
 import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
 
 import ListAddField from './ListAddField';
@@ -36,11 +42,6 @@ function List<T>({
   value,
   ...props
 }: ListFieldProps<T>) {
-  const listAddProps = {
-    name: `${name}.$`,
-    initialCount,
-    addIcon,
-  };
   return (
     <div
       className={classnames(
@@ -55,7 +56,11 @@ function List<T>({
           <div className={classnames('panel-heading', { 'has-error': error })}>
             <label className="control-label">{label}&nbsp;</label>
 
-            <ListAddField {...listAddProps} />
+            <ListAddField
+              addIcon={addIcon}
+              initialCount={initialCount}
+              name="$"
+            />
 
             {!!(error && showInlineError) && (
               <span className="help-block">{errorMessage}</span>
@@ -64,24 +69,21 @@ function List<T>({
         )}
 
         {children
-          ? value.map((item: any, index: number) =>
-              Children.map(children as JSX.Element, child =>
-                cloneElement(child, {
-                  key: index,
-                  label: null,
-                  name: joinName(
-                    name,
-                    child.props.name && child.props.name.replace('$', index),
-                  ),
-                  removeIcon,
-                }),
+          ? value.map((item, index) =>
+              Children.map(children, child =>
+                isValidElement(child) && child.props.name
+                  ? cloneElement(child, {
+                      key: index,
+                      name: child.props.name.replace('$', '' + index),
+                      removeIcon,
+                    })
+                  : child,
               ),
             )
-          : value.map((item: any, index: number) => (
+          : value.map((item, index) => (
               <ListItemField
                 key={index}
-                label={undefined}
-                name={joinName(name, index)}
+                name={'' + index}
                 removeIcon={removeIcon}
                 {...itemProps}
               />
@@ -91,6 +93,4 @@ function List<T>({
   );
 }
 
-export default connectField(List, {
-  includeInChain: false,
-});
+export default connectField(List);

--- a/packages/uniforms-bootstrap3/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListItemField.tsx
@@ -1,5 +1,10 @@
-import React, { Children, ReactNode, cloneElement } from 'react';
-import { connectField, joinName } from 'uniforms';
+import React, {
+  Children,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import { joinName } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
@@ -10,25 +15,29 @@ export type ListItemFieldProps = {
   removeIcon?: any;
 };
 
-function ListItem({ removeIcon, children, name }: ListItemFieldProps) {
+export default function ListItemField({
+  children,
+  removeIcon,
+  ...props
+}: ListItemFieldProps) {
   return (
     <div className="row">
       <div className="col-xs-1">
-        <ListDelField name={name} removeIcon={removeIcon} />
+        <ListDelField name={props.name} removeIcon={removeIcon} />
       </div>
 
       {children ? (
-        Children.map(children as JSX.Element, child =>
-          cloneElement(child, {
-            className: 'col-xs-11',
-            name: joinName(name, child.props.name),
-            label: null,
-          }),
+        Children.map(children, child =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                name: joinName(props.name, child.props.name),
+                label: null,
+              })
+            : child,
         )
       ) : (
-        <AutoField children={children} className="col-xs-11" name={name} />
+        <AutoField {...props} className="col-xs-11" />
       )}
     </div>
   );
 }
-export default connectField(ListItem, { includeInChain: false });

--- a/packages/uniforms-bootstrap3/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListItemField.tsx
@@ -5,9 +5,9 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   name: string;
-  removeIcon?: any;
+  removeIcon?: ReactNode;
 };
 
 function ListItem({ children, removeIcon }: ListItemFieldProps) {

--- a/packages/uniforms-bootstrap3/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListItemField.tsx
@@ -1,10 +1,5 @@
-import React, {
-  Children,
-  ReactNode,
-  cloneElement,
-  isValidElement,
-} from 'react';
-import { joinName } from 'uniforms';
+import React, { ReactNode } from 'react';
+import { connectField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
@@ -15,29 +10,17 @@ export type ListItemFieldProps = {
   removeIcon?: any;
 };
 
-export default function ListItemField({
-  children,
-  removeIcon,
-  ...props
-}: ListItemFieldProps) {
+function ListItem({ children, removeIcon }: ListItemFieldProps) {
   return (
     <div className="row">
       <div className="col-xs-1">
-        <ListDelField name={props.name} removeIcon={removeIcon} />
+        <ListDelField name="" removeIcon={removeIcon} />
       </div>
-
-      {children ? (
-        Children.map(children, child =>
-          isValidElement(child)
-            ? cloneElement(child, {
-                name: joinName(props.name, child.props.name),
-                label: null,
-              })
-            : child,
-        )
-      ) : (
-        <AutoField {...props} className="col-xs-11" />
-      )}
+      {children}
     </div>
   );
 }
+
+ListItem.defaultProps = { children: <AutoField label={null} name="" /> };
+
+export default connectField(ListItem, { initialValue: false });

--- a/packages/uniforms-bootstrap4/__tests__/ListAddField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListAddField.tsx
@@ -1,76 +1,48 @@
 import React from 'react';
 import { ListAddField } from 'uniforms-bootstrap4';
+import merge from 'lodash/merge';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  value: [],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: [] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListAddField> - works', () => {
-  const element = <ListAddField name="x.$" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.$" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
 });
 
 test('<ListAddField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, maxCount: 0 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" />;
+  const wrapper = mount(element, context({ x: { maxCount: 0 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange })}
-      value="y"
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" value="y" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['y']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
 });

--- a/packages/uniforms-bootstrap4/__tests__/ListDelField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListDelField.tsx
@@ -1,73 +1,48 @@
 import React from 'react';
 import { ListDelField } from 'uniforms-bootstrap4';
+import merge from 'lodash/merge';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  minCount: 0,
-  value: ['x', 'y', 'z'],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: ['x', 'y', 'z'] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListDelField> - works', () => {
-  const element = <ListDelField name="x.1" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
 });
 
 test('<ListDelField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, minCount: 3 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context({ x: { minCount: 3 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField name="x.1" parent={Object.assign({}, parent, { onChange })} />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['x', 'z']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
 });

--- a/packages/uniforms-bootstrap4/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListField.tsx
@@ -22,7 +22,7 @@ test('<ListField> - renders ListAddField', () => {
   );
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
-  expect(wrapper.find(ListAddField).prop('name')).toBe('x.$');
+  expect(wrapper.find(ListAddField).prop('name')).toBe('$');
 });
 
 test('<ListField> - renders correct label (specified)', () => {
@@ -89,8 +89,8 @@ test('<ListField> - renders children with correct name (children)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(Child).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(Child).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(Child).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
@@ -100,8 +100,8 @@ test('<ListField> - renders children with correct name (value)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders correct error text (specified)', () => {

--- a/packages/uniforms-bootstrap4/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListField.tsx
@@ -66,6 +66,7 @@ test('<ListField> - renders children (specified)', () => {
   const element = (
     <ListField name="x" initialCount={2}>
       <Child />
+      PlainText
     </ListField>
   );
   mount(

--- a/packages/uniforms-bootstrap4/__tests__/ListItemField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListItemField.tsx
@@ -22,7 +22,7 @@ test('<ListItemField> - renders ListDelField', () => {
   );
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
-  expect(wrapper.find(ListDelField).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListDelField).childAt(0).prop('name')).toBe('x.1');
 });
 
 test('<ListItemField> - renders AutoField', () => {

--- a/packages/uniforms-bootstrap4/__tests__/_createContext.ts
+++ b/packages/uniforms-bootstrap4/__tests__/_createContext.ts
@@ -6,8 +6,8 @@ const randomId = randomIds();
 
 export default function createContext(
   schema?: {},
-  context?: Partial<Context>,
-): { context: Context } {
+  context?: Partial<Context<any>>,
+): { context: Context<any> } {
   return {
     context: {
       changed: false,

--- a/packages/uniforms-bootstrap4/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListAddField.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, ReactNode } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
 import {
@@ -12,7 +12,7 @@ import {
 export type ListAddFieldProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
-    addIcon?: any;
+    addIcon?: ReactNode;
     initialCount?: number;
     name: string;
     parent?: any;

--- a/packages/uniforms-bootstrap4/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListAddField.tsx
@@ -1,44 +1,49 @@
+import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
-import React, { HTMLProps } from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListAddFieldProps<T> = Override<
   HTMLProps<HTMLDivElement>,
   {
     addIcon?: any;
+    initialCount?: number;
     name: string;
     parent?: any;
     value?: T;
   }
 >;
 
-function ListAdd<T>({ addIcon, ...rawProps }: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
+  const {
+    addIcon,
+    className,
+    disabled,
+    parent: parentFromProps,
+    value,
+    ...props
+  } = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const parentName = joinName(joinName(null, props.name).slice(0, -1));
+  const nameParts = joinName(null, rawProps.name);
+  const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (parentFromProps) Object.assign(parent, parentFromProps);
 
   const limitNotReached =
-    !props.disabled && !(parent.maxCount! <= parent.value!.length);
+    !disabled && !(parent.maxCount! <= parent.value!.length);
 
   return (
     <div
-      className={classnames('badge badge-pill float-right', rawProps.className)}
+      {...filterDOMProps(props)}
+      className={classnames('badge badge-pill float-right', className)}
       onClick={() => {
         if (limitNotReached)
-          parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
+          parent.onChange(parent.value!.concat([cloneDeep(value!)]));
       }}
-      {...filterDOMProps(props)}
     >
       {addIcon}
     </div>
   );
 }
 
-ListAdd.defaultProps = { addIcon: <i className="octicon octicon-plus" /> };
-
-export default ListAdd;
+ListAddField.defaultProps = { addIcon: <i className="octicon octicon-plus" /> };

--- a/packages/uniforms-bootstrap4/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListAddField.tsx
@@ -1,33 +1,40 @@
 import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  filterDOMProps,
+  joinName,
+  useField,
+  connectField,
+} from 'uniforms';
 
-export type ListAddFieldProps<T> = Override<
-  HTMLProps<HTMLDivElement>,
+export type ListAddFieldProps = Override<
+  Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
     addIcon?: any;
     initialCount?: number;
     name: string;
     parent?: any;
-    value?: T;
+    value?: unknown;
   }
 >;
 
-export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
-  const {
-    addIcon,
-    className,
-    disabled,
-    parent: parentFromProps,
-    value,
-    ...props
-  } = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListAdd({
+  name,
+  addIcon,
+  className,
+  disabled,
+  value,
+  ...props
+}: ListAddFieldProps) {
+  const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (parentFromProps) Object.assign(parent, parentFromProps);
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);
@@ -38,7 +45,7 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
       className={classnames('badge badge-pill float-right', className)}
       onClick={() => {
         if (limitNotReached)
-          parent.onChange(parent.value!.concat([cloneDeep(value!)]));
+          parent.onChange(parent.value!.concat([cloneDeep(value)]));
       }}
     >
       {addIcon}
@@ -46,4 +53,6 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
   );
 }
 
-ListAddField.defaultProps = { addIcon: <i className="octicon octicon-plus" /> };
+ListAdd.defaultProps = { addIcon: <i className="octicon octicon-plus" /> };
+
+export default connectField(ListAdd, { initialValue: false });

--- a/packages/uniforms-bootstrap4/src/ListDelField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListDelField.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, ReactNode } from 'react';
 import classnames from 'classnames';
 import {
   Override,
@@ -13,7 +13,7 @@ export type ListDelFieldProps = Override<
   {
     name: string;
     parent?: any;
-    removeIcon?: any;
+    removeIcon?: ReactNode;
   }
 >;
 

--- a/packages/uniforms-bootstrap4/src/ListDelField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListDelField.tsx
@@ -1,6 +1,6 @@
-import classnames from 'classnames';
 import React, { HTMLProps } from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import classnames from 'classnames';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListDelFieldProps<T> = Override<
   HTMLProps<HTMLSpanElement>,
@@ -8,41 +8,43 @@ export type ListDelFieldProps<T> = Override<
     name: string;
     parent?: any;
     removeIcon?: any;
-    value?: T;
   }
 >;
 
-function ListDel<T>({ removeIcon, ...rawProps }: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
+  const {
+    className,
+    disabled,
+    parent: parentFromProps,
+    removeIcon,
+    ...props
+  } = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const nameParts = joinName(null, props.name);
+  const nameParts = joinName(null, rawProps.name);
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (parentFromProps) Object.assign(parent, parentFromProps);
 
-  const fieldIndex = +nameParts[nameParts.length - 1];
   const limitNotReached =
-    !props.disabled && !(parent.minCount! >= parent.value!.length);
+    !disabled && !(parent.minCount! >= parent.value!.length);
 
   return (
     <span
-      className={classnames('badge badge-pill', rawProps.className)}
+      {...filterDOMProps(props)}
+      className={classnames('badge badge-pill', className)}
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(fieldIndex, 1);
+          value.splice(+nameParts[nameParts.length - 1], 1);
           parent.onChange(value);
         }
       }}
-      {...filterDOMProps(props)}
     >
       {removeIcon}
     </span>
   );
 }
 
-ListDel.defaultProps = { removeIcon: <i className="octicon octicon-dash" /> };
-
-export default ListDel;
+ListDelField.defaultProps = {
+  removeIcon: <i className="octicon octicon-dash" />,
+};

--- a/packages/uniforms-bootstrap4/src/ListField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListField.tsx
@@ -1,6 +1,12 @@
-import React, { Children, HTMLProps, ReactNode, cloneElement } from 'react';
+import React, {
+  Children,
+  HTMLProps,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
 import classnames from 'classnames';
-import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
+import { Override, connectField, filterDOMProps } from 'uniforms';
 
 import ListItemField from './ListItemField';
 import ListAddField from './ListAddField';
@@ -36,11 +42,6 @@ function List<T>({
   value,
   ...props
 }: ListFieldProps<T>) {
-  const listAddProps = {
-    name: `${name}.$`,
-    initialCount,
-    addIcon,
-  };
   return (
     <div
       className={classnames('card mb-3', className)}
@@ -51,7 +52,11 @@ function List<T>({
           <div className="card-title">
             <label className="col-form-label">{label}&nbsp;</label>
 
-            <ListAddField {...listAddProps} />
+            <ListAddField
+              addIcon={addIcon}
+              initialCount={initialCount}
+              name="$"
+            />
 
             {!!(error && showInlineError) && (
               <span className="text-danger">{errorMessage}</span>
@@ -61,23 +66,20 @@ function List<T>({
 
         {children
           ? value.map((item, index) =>
-              Children.map(children as JSX.Element, child =>
-                cloneElement(child, {
-                  key: index,
-                  label: null,
-                  name: joinName(
-                    name,
-                    child.props.name && child.props.name.replace('$', index),
-                  ),
-                  removeIcon,
-                }),
+              Children.map(children, child =>
+                isValidElement(child) && child.props.name
+                  ? cloneElement(child, {
+                      key: index,
+                      name: child.props.name.replace('$', '' + index),
+                      removeIcon,
+                    })
+                  : child,
               ),
             )
           : value.map((item, index) => (
               <ListItemField
                 key={index}
-                label={undefined}
-                name={joinName(name, index)}
+                name={'' + index}
                 removeIcon={removeIcon}
                 {...itemProps}
               />
@@ -87,6 +89,4 @@ function List<T>({
   );
 }
 
-export default connectField(List, {
-  includeInChain: false,
-});
+export default connectField(List);

--- a/packages/uniforms-bootstrap4/src/ListField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListField.tsx
@@ -14,14 +14,14 @@ import ListAddField from './ListAddField';
 export type ListFieldProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
-    addIcon?: any;
+    addIcon?: ReactNode;
     children: ReactNode;
     error?: boolean;
     errorMessage?: string;
     initialCount?: number;
     itemProps?: {};
     name: string;
-    removeIcon?: any;
+    removeIcon?: ReactNode;
     showInlineError?: boolean;
     value: unknown[];
   }

--- a/packages/uniforms-bootstrap4/src/ListField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListField.tsx
@@ -11,11 +11,11 @@ import { Override, connectField, filterDOMProps } from 'uniforms';
 import ListItemField from './ListItemField';
 import ListAddField from './ListAddField';
 
-export type ListFieldProps<T> = Override<
-  HTMLProps<HTMLDivElement>,
+export type ListFieldProps = Override<
+  Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
     addIcon?: any;
-    children?: ReactNode;
+    children: ReactNode;
     error?: boolean;
     errorMessage?: string;
     initialCount?: number;
@@ -23,11 +23,11 @@ export type ListFieldProps<T> = Override<
     name: string;
     removeIcon?: any;
     showInlineError?: boolean;
-    value: T[];
+    value: unknown[];
   }
 >;
 
-function List<T>({
+function List({
   addIcon,
   children,
   className,
@@ -36,12 +36,11 @@ function List<T>({
   initialCount,
   itemProps,
   label,
-  name,
   removeIcon,
   showInlineError,
   value,
   ...props
-}: ListFieldProps<T>) {
+}: ListFieldProps) {
   return (
     <div
       className={classnames('card mb-3', className)}
@@ -64,29 +63,23 @@ function List<T>({
           </div>
         )}
 
-        {children
-          ? value.map((item, index) =>
-              Children.map(children, child =>
-                isValidElement(child) && child.props.name
-                  ? cloneElement(child, {
-                      key: index,
-                      name: child.props.name.replace('$', '' + index),
-                      removeIcon,
-                    })
-                  : child,
-              ),
-            )
-          : value.map((item, index) => (
-              <ListItemField
-                key={index}
-                name={'' + index}
-                removeIcon={removeIcon}
-                {...itemProps}
-              />
-            ))}
+        {value.map((item, itemIndex) =>
+          Children.map(children, (child, childIndex) =>
+            isValidElement(child)
+              ? cloneElement(child, {
+                  key: `${itemIndex}-${childIndex}`,
+                  name: child.props.name?.replace('$', '' + itemIndex),
+                  ...itemProps,
+                  removeIcon,
+                })
+              : child,
+          ),
+        )}
       </div>
     </div>
   );
 }
+
+List.defaultProps = { children: <ListItemField name="$" /> };
 
 export default connectField(List);

--- a/packages/uniforms-bootstrap4/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListItemField.tsx
@@ -1,5 +1,10 @@
-import React, { Children, ReactNode, cloneElement } from 'react';
-import { connectField, joinName } from 'uniforms';
+import React, {
+  Children,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import { joinName } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
@@ -10,21 +15,25 @@ export type ListItemFieldProps = {
   removeIcon?: any;
 };
 
-function ListItem({ removeIcon, ...props }: ListItemFieldProps) {
-  const { name, children } = props;
+export default function ListItemField({
+  children,
+  removeIcon,
+  ...props
+}: ListItemFieldProps) {
   return (
     <div className="row">
       <div className="col-1">
-        <ListDelField name={name} removeIcon={removeIcon} />
+        <ListDelField name={props.name} removeIcon={removeIcon} />
       </div>
 
       {children ? (
-        Children.map(children as JSX.Element, child =>
-          cloneElement(child, {
-            className: 'col-11',
-            name: joinName(name, child.props.name),
-            label: null,
-          }),
+        Children.map(children, child =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                name: joinName(props.name, child.props.name),
+                label: null,
+              })
+            : child,
         )
       ) : (
         <AutoField {...props} className="col-11" />
@@ -32,5 +41,3 @@ function ListItem({ removeIcon, ...props }: ListItemFieldProps) {
     </div>
   );
 }
-
-export default connectField(ListItem, { includeInChain: false });

--- a/packages/uniforms-bootstrap4/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListItemField.tsx
@@ -5,9 +5,9 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   name: string;
-  removeIcon?: any;
+  removeIcon?: ReactNode;
 };
 
 function ListItem({ children, removeIcon, ...props }: ListItemFieldProps) {

--- a/packages/uniforms-bootstrap4/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListItemField.tsx
@@ -5,7 +5,7 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children: ReactNode;
+  children?: ReactNode;
   name: string;
   removeIcon?: any;
 };

--- a/packages/uniforms-bootstrap4/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListItemField.tsx
@@ -1,43 +1,26 @@
-import React, {
-  Children,
-  ReactNode,
-  cloneElement,
-  isValidElement,
-} from 'react';
-import { joinName } from 'uniforms';
+import React, { ReactNode } from 'react';
+import { connectField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   name: string;
   removeIcon?: any;
 };
 
-export default function ListItemField({
-  children,
-  removeIcon,
-  ...props
-}: ListItemFieldProps) {
+function ListItem({ children, removeIcon, ...props }: ListItemFieldProps) {
   return (
     <div className="row">
       <div className="col-1">
-        <ListDelField name={props.name} removeIcon={removeIcon} />
+        <ListDelField name="" removeIcon={removeIcon} />
       </div>
-
-      {children ? (
-        Children.map(children, child =>
-          isValidElement(child)
-            ? cloneElement(child, {
-                name: joinName(props.name, child.props.name),
-                label: null,
-              })
-            : child,
-        )
-      ) : (
-        <AutoField {...props} className="col-11" />
-      )}
+      {children}
     </div>
   );
 }
+
+ListItem.defaultProps = { children: <AutoField label={null} name="" /> };
+
+export default connectField(ListItem, { initialValue: false });

--- a/packages/uniforms-material/__tests__/ListAddField.tsx
+++ b/packages/uniforms-material/__tests__/ListAddField.tsx
@@ -1,88 +1,53 @@
 import IconButton from '@material-ui/core/IconButton';
 import React from 'react';
+import merge from 'lodash/merge';
 import { ListAddField } from 'uniforms-material';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
 const Icon = () => <i />;
-const parent = {
-  maxCount: 3,
-  value: [],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: [] } },
+  );
 
 test('<ListAddField> - works', () => {
-  const element = <ListAddField name="x.$" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.$" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
 });
 
 test('<ListAddField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(IconButton).simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, maxCount: 0 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" />;
+  const wrapper = mount(element, context({ x: { maxCount: 0 } }));
 
   expect(wrapper.find(IconButton).simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange })}
-      value="y"
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" value="y" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(IconButton).simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['y']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
 });
 
 test('<ListAddField> - renders correct icon', () => {
-  const element = <ListAddField name="x.$" parent={parent} icon={<Icon />} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.$" icon={<Icon />} />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(Icon)).toHaveLength(1);
 });

--- a/packages/uniforms-material/__tests__/ListDelField.tsx
+++ b/packages/uniforms-material/__tests__/ListDelField.tsx
@@ -1,85 +1,53 @@
 import IconButton from '@material-ui/core/IconButton';
 import React from 'react';
+import merge from 'lodash/merge';
 import { ListDelField } from 'uniforms-material';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
 const Icon = () => <i />;
-const parent = {
-  maxCount: 3,
-  minCount: 0,
-  value: ['x', 'y', 'z'],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: ['x', 'y', 'z'] } },
+  );
 
 test('<ListDelField> - works', () => {
-  const element = <ListDelField name="x.1" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
 });
 
 test('<ListDelField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(IconButton).simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, minCount: 3 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context({ x: { minCount: 3 } }));
 
   expect(wrapper.find(IconButton).simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField name="x.1" parent={Object.assign({}, parent, { onChange })} />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(IconButton).simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['x', 'z']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
 });
 
 test('<ListDelField> - renders correct icon', () => {
-  const element = <ListDelField name="x.1" parent={parent} icon={<Icon />} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" icon={<Icon />} />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(Icon)).toHaveLength(1);
 });

--- a/packages/uniforms-material/__tests__/ListField.tsx
+++ b/packages/uniforms-material/__tests__/ListField.tsx
@@ -23,7 +23,7 @@ test('<ListField> - renders ListAddField', () => {
   );
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
-  expect(wrapper.find(ListAddField).prop('name')).toBe('x.$');
+  expect(wrapper.find(ListAddField).prop('name')).toBe('$');
 });
 
 test('<ListField> - renders correct label (specified)', () => {
@@ -88,8 +88,8 @@ test('<ListField> - renders children with correct name (children)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(Child).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(Child).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(Child).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
@@ -99,6 +99,6 @@ test('<ListField> - renders children with correct name (value)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });

--- a/packages/uniforms-material/__tests__/ListField.tsx
+++ b/packages/uniforms-material/__tests__/ListField.tsx
@@ -65,6 +65,7 @@ test('<ListField> - renders children (specified)', () => {
   const element = (
     <ListField name="x" initialCount={2}>
       <Child />
+      PlainText
     </ListField>
   );
   mount(

--- a/packages/uniforms-material/__tests__/ListItemField.tsx
+++ b/packages/uniforms-material/__tests__/ListItemField.tsx
@@ -22,7 +22,7 @@ test('<ListItemField> - renders ListDelField', () => {
   );
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
-  expect(wrapper.find(ListDelField).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListDelField).childAt(0).prop('name')).toBe('x.1');
 });
 
 test('<ListItemField> - renders AutoField', () => {

--- a/packages/uniforms-material/__tests__/_createContext.ts
+++ b/packages/uniforms-material/__tests__/_createContext.ts
@@ -6,8 +6,8 @@ const randomId = randomIds();
 
 export default function createContext(
   schema?: {},
-  context?: Partial<Context>,
-): { context: Context } {
+  context?: Partial<Context<any>>,
+): { context: Context<any> } {
   return {
     context: {
       changed: false,

--- a/packages/uniforms-material/src/ListAddField.tsx
+++ b/packages/uniforms-material/src/ListAddField.tsx
@@ -1,36 +1,45 @@
 import FormControl, { FormControlProps } from '@material-ui/core/FormControl';
 import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  connectField,
+  filterDOMProps,
+  joinName,
+  useField,
+} from 'uniforms';
 
-export type ListAddFieldProps<T> = Override<
+export type ListAddFieldProps = Override<
   IconButtonProps,
   {
-    icon?: any;
+    fullWidth?: FormControlProps['fullWidth'];
+    icon: ReactNode;
     initialCount?: number;
+    margin?: FormControlProps['margin'];
     name: string;
-    parent?: any;
-    value?: T;
-  } & Pick<FormControlProps, 'fullWidth' | 'margin' | 'variant'>
+    value: unknown;
+    variant?: FormControlProps['variant'];
+  }
 >;
 
-export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
-  const {
-    disabled,
-    fullWidth,
-    icon,
-    margin,
-    parent: parentFromProps,
-    value,
-    variant,
-    ...props
-  } = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListAdd({
+  disabled,
+  fullWidth,
+  icon,
+  margin,
+  name,
+  value,
+  variant,
+  ...props
+}: ListAddFieldProps) {
+  const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (parentFromProps) Object.assign(parent, parentFromProps);
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);
@@ -41,8 +50,9 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
         {...filterDOMProps(props)}
         disabled={!limitNotReached}
         onClick={() => {
-          if (limitNotReached)
-            parent.onChange(parent.value!.concat([cloneDeep(value!)]));
+          if (limitNotReached) {
+            parent.onChange(parent.value!.concat([cloneDeep(value)]));
+          }
         }}
       >
         {icon}
@@ -51,8 +61,10 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
   );
 }
 
-ListAddField.defaultProps = {
+ListAdd.defaultProps = {
   fullWidth: true,
   icon: '+',
-  margin: 'dense',
+  margin: 'dense' as 'dense',
 };
+
+export default connectField(ListAdd, { initialValue: false });

--- a/packages/uniforms-material/src/ListAddField.tsx
+++ b/packages/uniforms-material/src/ListAddField.tsx
@@ -1,9 +1,8 @@
-import cloneDeep from 'lodash/cloneDeep';
 import FormControl, { FormControlProps } from '@material-ui/core/FormControl';
 import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
-import omit from 'lodash/omit';
 import React from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import cloneDeep from 'lodash/cloneDeep';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListAddFieldProps<T> = Override<
   IconButtonProps,
@@ -16,45 +15,44 @@ export type ListAddFieldProps<T> = Override<
   } & Pick<FormControlProps, 'fullWidth' | 'margin' | 'variant'>
 >;
 
-function ListAdd<T>(rawProps: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(
-    rawProps.name,
-    omit(rawProps, 'fullWidth'),
-    {
-      initialValue: false,
-    },
-  )[0];
+export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
+  const {
+    disabled,
+    fullWidth,
+    icon,
+    margin,
+    parent: parentFromProps,
+    value,
+    variant,
+    ...props
+  } = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const parentName = joinName(joinName(null, props.name).slice(0, -1));
+  const nameParts = joinName(null, rawProps.name);
+  const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (parentFromProps) Object.assign(parent, parentFromProps);
 
   const limitNotReached =
-    !props.disabled && !(parent.maxCount! <= parent.value!.length);
+    !disabled && !(parent.maxCount! <= parent.value!.length);
+
   return (
-    <FormControl
-      fullWidth={rawProps.fullWidth}
-      margin={rawProps.margin}
-      variant={rawProps.variant}
-    >
+    <FormControl fullWidth={fullWidth} margin={margin} variant={variant}>
       <IconButton
+        {...filterDOMProps(props)}
         disabled={!limitNotReached}
         onClick={() => {
           if (limitNotReached)
-            parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
+            parent.onChange(parent.value!.concat([cloneDeep(value!)]));
         }}
-        {...filterDOMProps(omit(props, 'value'))}
       >
-        {rawProps.icon}
+        {icon}
       </IconButton>
     </FormControl>
   );
 }
 
-ListAdd.defaultProps = {
+ListAddField.defaultProps = {
   fullWidth: true,
   icon: '+',
   margin: 'dense',
 };
-
-export default ListAdd;

--- a/packages/uniforms-material/src/ListAddField.tsx
+++ b/packages/uniforms-material/src/ListAddField.tsx
@@ -50,9 +50,7 @@ function ListAdd({
         {...filterDOMProps(props)}
         disabled={!limitNotReached}
         onClick={() => {
-          if (limitNotReached) {
-            parent.onChange(parent.value!.concat([cloneDeep(value)]));
-          }
+          parent.onChange(parent.value!.concat([cloneDeep(value)]));
         }}
       >
         {icon}

--- a/packages/uniforms-material/src/ListDelField.tsx
+++ b/packages/uniforms-material/src/ListDelField.tsx
@@ -1,26 +1,30 @@
 import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
-import React from 'react';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import React, { ReactNode } from 'react';
+import {
+  Override,
+  connectField,
+  filterDOMProps,
+  joinName,
+  useField,
+} from 'uniforms';
 
-export type ListDelFieldProps<T> = Override<
-  IconButtonProps,
-  {
-    icon: any;
-    name: string;
-    parent?: any;
-  }
+export type ListDelFieldProps = Override<
+  Omit<IconButtonProps, 'value'>,
+  { icon: ReactNode; name: string }
 >;
 
-export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListDel({ disabled, icon, name, ...props }: ListDelFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (props.parent) Object.assign(parent, props.parent);
+  const parent = useField<{ minCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
-    !props.disabled && !(parent.minCount! >= parent.value!.length);
+    !disabled && !(parent.minCount! >= parent.value!.length);
 
   return (
     <IconButton
@@ -29,16 +33,18 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(+nameParts[nameParts.length - 1], 1);
+          value.splice(nameIndex, 1);
           parent.onChange(value);
         }
       }}
     >
-      {props.icon}
+      {icon}
     </IconButton>
   );
 }
 
-ListDelField.defaultProps = {
-  icon: '-',
+ListDel.defaultProps = {
+  icon: '-' as ReactNode,
 };
+
+export default connectField(ListDel, { initialValue: false });

--- a/packages/uniforms-material/src/ListDelField.tsx
+++ b/packages/uniforms-material/src/ListDelField.tsx
@@ -31,11 +31,9 @@ function ListDel({ disabled, icon, name, ...props }: ListDelFieldProps) {
       {...filterDOMProps(props)}
       disabled={!limitNotReached}
       onClick={() => {
-        if (limitNotReached) {
-          const value = parent.value!.slice();
-          value.splice(nameIndex, 1);
-          parent.onChange(value);
-        }
+        const value = parent.value!.slice();
+        value.splice(nameIndex, 1);
+        parent.onChange(value);
       }}
     >
       {icon}
@@ -44,7 +42,7 @@ function ListDel({ disabled, icon, name, ...props }: ListDelFieldProps) {
 }
 
 ListDel.defaultProps = {
-  icon: '-' as ReactNode,
+  icon: '-',
 };
 
 export default connectField(ListDel, { initialValue: false });

--- a/packages/uniforms-material/src/ListDelField.tsx
+++ b/packages/uniforms-material/src/ListDelField.tsx
@@ -1,53 +1,44 @@
 import IconButton, { IconButtonProps } from '@material-ui/core/IconButton';
-import omit from 'lodash/omit';
 import React from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListDelFieldProps<T> = Override<
   IconButtonProps,
   {
-    disabled?: boolean;
     icon: any;
-    initialCount?: number;
     name: string;
     parent?: any;
-    value?: T;
   }
 >;
 
-function ListDel<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
+  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const nameParts = joinName(null, props.name);
+  const nameParts = joinName(null, rawProps.name);
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (props.parent) Object.assign(parent, props.parent);
 
-  const fieldIndex = +nameParts[nameParts.length - 1];
   const limitNotReached =
     !props.disabled && !(parent.minCount! >= parent.value!.length);
 
   return (
     <IconButton
+      {...filterDOMProps(props)}
       disabled={!limitNotReached}
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(fieldIndex, 1);
+          value.splice(+nameParts[nameParts.length - 1], 1);
           parent.onChange(value);
         }
       }}
-      {...filterDOMProps(omit(props, 'value'))}
     >
-      {rawProps.icon}
+      {props.icon}
     </IconButton>
   );
 }
 
-ListDel.defaultProps = {
+ListDelField.defaultProps = {
   icon: '-',
 };
-
-export default ListDel;

--- a/packages/uniforms-material/src/ListField.tsx
+++ b/packages/uniforms-material/src/ListField.tsx
@@ -12,19 +12,20 @@ import { Override, connectField, filterDOMProps } from 'uniforms';
 import ListAddField from './ListAddField';
 import ListItemField from './ListItemField';
 
-export type ListFieldProps<T> = Override<
-  ListProps,
+export type ListFieldProps = Override<
+  Omit<ListProps, 'onChange'>,
   {
-    addIcon?: any;
+    addIcon?: ReactNode;
+    children: ReactNode;
     initialCount?: number;
     itemProps?: {};
-    label: string;
+    label?: string;
     name: string;
-    value: T[];
+    value: unknown[];
   }
 >;
 
-function List<T>({
+function List({
   addIcon,
   children,
   dense,
@@ -34,40 +35,35 @@ function List<T>({
   name,
   value,
   ...props
-}: ListFieldProps<T>) {
-  return [
-    <ListMaterial
-      key="list"
-      dense={dense ?? true}
-      subheader={
-        label ? <ListSubheader disableSticky>{label}</ListSubheader> : undefined
-      }
-      {...filterDOMProps(props)}
-    >
-      {children
-        ? value.map((item, index) =>
-            Children.map(children, child =>
-              isValidElement(child) && child.props.name
-                ? cloneElement(child, {
-                    key: index,
-                    name: child.props.name.replace('$', '' + index),
-                  })
-                : child,
-            ),
-          )
-        : value.map((item, index) => (
-            <ListItemField key={index} name={'' + index} {...itemProps} />
-          ))}
-    </ListMaterial>,
-    <ListAddField
-      icon={addIcon}
-      initialCount={initialCount}
-      key="listAddField"
-      name="$"
-    />,
-  ];
+}: ListFieldProps) {
+  return (
+    <>
+      <ListMaterial
+        dense={dense ?? true}
+        subheader={
+          label ? (
+            <ListSubheader disableSticky>{label}</ListSubheader>
+          ) : undefined
+        }
+        {...filterDOMProps(props)}
+      >
+        {value.map((item, itemIndex) =>
+          Children.map(children, (child, childIndex) =>
+            isValidElement(child)
+              ? cloneElement(child, {
+                  key: `${itemIndex}-${childIndex}`,
+                  name: child.props.name?.replace('$', '' + itemIndex),
+                  ...itemProps,
+                })
+              : child,
+          ),
+        )}
+      </ListMaterial>
+      <ListAddField icon={addIcon} initialCount={initialCount} name="$" />
+    </>
+  );
 }
 
-// FIXME: Use React.Fragment instead of returning an array if possible.
-// @ts-ignore
+List.defaultProps = { children: <ListItemField name="$" /> };
+
 export default connectField(List);

--- a/packages/uniforms-material/src/ListField.tsx
+++ b/packages/uniforms-material/src/ListField.tsx
@@ -1,15 +1,19 @@
-import ListMaterial, {
-  ListProps as MaterialListProps,
-} from '@material-ui/core/List';
+import ListMaterial, { ListProps } from '@material-ui/core/List';
 import ListSubheader from '@material-ui/core/ListSubheader';
-import React, { Children, cloneElement } from 'react';
-import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
+import React, {
+  Children,
+  HTMLProps,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import { Override, connectField, filterDOMProps } from 'uniforms';
 
 import ListAddField from './ListAddField';
 import ListItemField from './ListItemField';
 
 export type ListFieldProps<T> = Override<
-  MaterialListProps,
+  ListProps,
   {
     addIcon?: any;
     initialCount?: number;
@@ -42,37 +46,28 @@ function List<T>({
     >
       {children
         ? value.map((item, index) =>
-            Children.map(children as JSX.Element, child =>
-              cloneElement(child, {
-                key: index,
-                label: null,
-                name: joinName(
-                  name,
-                  child.props.name && child.props.name.replace('$', index),
-                ),
-              }),
+            Children.map(children, child =>
+              isValidElement(child) && child.props.name
+                ? cloneElement(child, {
+                    key: index,
+                    name: child.props.name.replace('$', '' + index),
+                  })
+                : child,
             ),
           )
         : value.map((item, index) => (
-            <ListItemField
-              key={index}
-              label={undefined}
-              name={joinName(name, index)}
-              {...itemProps}
-            />
+            <ListItemField key={index} name={'' + index} {...itemProps} />
           ))}
     </ListMaterial>,
     <ListAddField
-      key="listAddField"
-      name={`${name}.$`}
       icon={addIcon}
       initialCount={initialCount}
+      key="listAddField"
+      name="$"
     />,
   ];
 }
 
 // FIXME: Use React.Fragment instead of returning an array if possible.
 // @ts-ignore
-export default connectField(List, {
-  includeInChain: false,
-});
+export default connectField(List);

--- a/packages/uniforms-material/src/ListItemField.tsx
+++ b/packages/uniforms-material/src/ListItemField.tsx
@@ -5,49 +5,42 @@ import React, {
   cloneElement,
   isValidElement,
 } from 'react';
-import { joinName } from 'uniforms';
+import { connectField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
+  dense?: ListItemProps['dense'];
+  disableGutters?: ListItemProps['disableGutters'];
+  divider?: ListItemProps['divider'];
   name: string;
-  removeIcon?: any;
-} & Pick<ListItemProps, 'dense' | 'divider' | 'disableGutters'>;
+  removeIcon?: ReactNode;
+};
 
-export default function ListItemField({
+function ListItem({
   children,
   dense,
   disableGutters,
   divider,
-  name,
   removeIcon,
-  ...props
 }: ListItemFieldProps) {
   return (
     <ListItemMaterial
       dense={dense}
-      divider={divider}
       disableGutters={disableGutters}
+      divider={divider}
     >
-      {children ? (
-        Children.map(children, child =>
-          isValidElement(child)
-            ? cloneElement(child, {
-                name: joinName(name, child.props.name),
-                label: null,
-              })
-            : child,
-        )
-      ) : (
-        <AutoField children={children} name={name} {...props} />
-      )}
-      <ListDelField name={name} icon={removeIcon} />
+      {children}
+      <ListDelField name="" icon={removeIcon} />
     </ListItemMaterial>
   );
 }
 
-ListItemField.defaultProps = {
+ListItem.defaultProps = {
+  children: <AutoField label={null} name="" />,
   dense: true,
 };
+
+export default connectField(ListItem, { initialValue: false });

--- a/packages/uniforms-material/src/ListItemField.tsx
+++ b/packages/uniforms-material/src/ListItemField.tsx
@@ -1,8 +1,11 @@
-import ListItemMaterial, {
-  ListItemProps as ListItemMaterialProps,
-} from '@material-ui/core/ListItem';
-import React, { Children, ReactNode, cloneElement } from 'react';
-import { connectField, joinName } from 'uniforms';
+import ListItemMaterial, { ListItemProps } from '@material-ui/core/ListItem';
+import React, {
+  Children,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import { joinName } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
@@ -11,9 +14,9 @@ export type ListItemFieldProps = {
   children?: ReactNode;
   name: string;
   removeIcon?: any;
-} & Pick<ListItemMaterialProps, 'dense' | 'divider' | 'disableGutters'>;
+} & Pick<ListItemProps, 'dense' | 'divider' | 'disableGutters'>;
 
-const ListItem = ({
+export default function ListItemField({
   children,
   dense,
   disableGutters,
@@ -21,7 +24,7 @@ const ListItem = ({
   name,
   removeIcon,
   ...props
-}: ListItemFieldProps) => {
+}: ListItemFieldProps) {
   return (
     <ListItemMaterial
       dense={dense}
@@ -29,11 +32,13 @@ const ListItem = ({
       disableGutters={disableGutters}
     >
       {children ? (
-        Children.map(children as JSX.Element, child =>
-          cloneElement(child, {
-            name: joinName(name, child.props.name),
-            label: null,
-          }),
+        Children.map(children, child =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                name: joinName(name, child.props.name),
+                label: null,
+              })
+            : child,
         )
       ) : (
         <AutoField children={children} name={name} {...props} />
@@ -41,10 +46,8 @@ const ListItem = ({
       <ListDelField name={name} icon={removeIcon} />
     </ListItemMaterial>
   );
-};
+}
 
-ListItem.defaultProps = {
+ListItemField.defaultProps = {
   dense: true,
 };
-
-export default connectField(ListItem, { includeInChain: false });

--- a/packages/uniforms-material/src/ListItemField.tsx
+++ b/packages/uniforms-material/src/ListItemField.tsx
@@ -11,7 +11,7 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children: ReactNode;
+  children?: ReactNode;
   dense?: ListItemProps['dense'];
   disableGutters?: ListItemProps['disableGutters'];
   divider?: ListItemProps['divider'];

--- a/packages/uniforms-material/src/ListItemField.tsx
+++ b/packages/uniforms-material/src/ListItemField.tsx
@@ -11,7 +11,7 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   dense?: ListItemProps['dense'];
   disableGutters?: ListItemProps['disableGutters'];
   divider?: ListItemProps['divider'];

--- a/packages/uniforms-semantic/__tests__/ListAddField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListAddField.tsx
@@ -1,76 +1,48 @@
 import React from 'react';
+import merge from 'lodash/merge';
 import { ListAddField } from 'uniforms-semantic';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  value: [],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: [] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListAddField> - works', () => {
-  const element = <ListAddField name="x.$" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.$" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
 });
 
 test('<ListAddField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, maxCount: 0 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" />;
+  const wrapper = mount(element, context({ x: { maxCount: 0 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange })}
-      value="y"
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" value="y" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['y']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
 });

--- a/packages/uniforms-semantic/__tests__/ListDelField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListDelField.tsx
@@ -1,73 +1,48 @@
 import React from 'react';
 import { ListDelField } from 'uniforms-semantic';
+import merge from 'lodash/merge';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  minCount: 0,
-  value: ['x', 'y', 'z'],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: ['x', 'y', 'z'] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListDelField> - works', () => {
-  const element = <ListDelField name="x.1" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
 });
 
 test('<ListDelField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, minCount: 3 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context({ x: { minCount: 3 } }));
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField name="x.1" parent={Object.assign({}, parent, { onChange })} />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('i').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['x', 'z']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
 });

--- a/packages/uniforms-semantic/__tests__/ListField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListField.tsx
@@ -22,7 +22,7 @@ test('<ListField> - renders ListAddField', () => {
   );
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
-  expect(wrapper.find(ListAddField).prop('name')).toBe('x.$');
+  expect(wrapper.find(ListAddField).prop('name')).toBe('$');
 });
 
 test('<ListField> - renders correct label (specified)', () => {
@@ -89,8 +89,8 @@ test('<ListField> - renders children with correct name (children)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(Child).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(Child).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(Child).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
@@ -100,8 +100,8 @@ test('<ListField> - renders children with correct name (value)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders correct error text (specified)', () => {

--- a/packages/uniforms-semantic/__tests__/ListField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListField.tsx
@@ -66,6 +66,7 @@ test('<ListField> - renders children (specified)', () => {
   const element = (
     <ListField name="x" initialCount={2}>
       <Child />
+      PlainText
     </ListField>
   );
   mount(

--- a/packages/uniforms-semantic/__tests__/ListItemField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListItemField.tsx
@@ -22,7 +22,7 @@ test('<ListItemField> - renders ListDelField', () => {
   );
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
-  expect(wrapper.find(ListDelField).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListDelField).childAt(0).prop('name')).toBe('x.1');
 });
 
 test('<ListItemField> - renders AutoField', () => {

--- a/packages/uniforms-semantic/__tests__/_createContext.ts
+++ b/packages/uniforms-semantic/__tests__/_createContext.ts
@@ -6,8 +6,8 @@ const randomId = randomIds();
 
 export default function createContext(
   schema?: {},
-  context?: Partial<Context>,
-): { context: Context } {
+  context?: Partial<Context<any>>,
+): { context: Context<any> } {
   return {
     context: {
       changed: false,

--- a/packages/uniforms-semantic/src/ListAddField.tsx
+++ b/packages/uniforms-semantic/src/ListAddField.tsx
@@ -1,28 +1,30 @@
 import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import {
+  filterDOMProps,
+  joinName,
+  Override,
+  useField,
+  connectField,
+} from 'uniforms';
 
-export type ListAddFieldProps<T> = Override<
-  HTMLProps<HTMLSpanElement>,
-  {
-    initialCount?: number;
-    name: string;
-    parent?: any;
-    value?: T;
-  }
+export type ListAddFieldProps = Override<
+  Omit<HTMLProps<HTMLSpanElement>, 'onChange'>,
+  { initialCount?: number; name: string; value: unknown }
 >;
 
-export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListAdd({ disabled, name, value, ...props }: ListAddFieldProps) {
+  const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (props.parent) Object.assign(parent, props.parent);
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
-    !props.disabled && !(parent.maxCount! <= parent.value!.length);
+    !disabled && !(parent.maxCount! <= parent.value!.length);
 
   return (
     <i
@@ -35,8 +37,10 @@ export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
       )}
       onClick={() => {
         if (limitNotReached)
-          parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
+          parent.onChange(parent.value!.concat([cloneDeep(value)]));
       }}
     />
   );
 }
+
+export default connectField(ListAdd, { initialValue: false });

--- a/packages/uniforms-semantic/src/ListAddField.tsx
+++ b/packages/uniforms-semantic/src/ListAddField.tsx
@@ -1,26 +1,25 @@
+import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
-import React, { HTMLProps } from 'react';
 import { filterDOMProps, joinName, Override, useField } from 'uniforms';
 
 export type ListAddFieldProps<T> = Override<
   HTMLProps<HTMLSpanElement>,
   {
-    className?: string;
+    initialCount?: number;
     name: string;
     parent?: any;
     value?: T;
   }
 >;
 
-export default function ListAdd<T>(rawProps: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
+  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const parentName = joinName(joinName(null, props.name).slice(0, -1));
+  const nameParts = joinName(null, rawProps.name);
+  const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (props.parent) Object.assign(parent, props.parent);
 
   const limitNotReached =
     !props.disabled && !(parent.maxCount! <= parent.value!.length);
@@ -30,14 +29,14 @@ export default function ListAdd<T>(rawProps: ListAddFieldProps<T>) {
       {...filterDOMProps(props)}
       className={classnames(
         'ui',
-        rawProps.className,
+        props.className,
         limitNotReached ? 'link' : 'disabled',
         'fitted add icon',
       )}
-      onClick={() =>
-        limitNotReached &&
-        parent.onChange(parent.value!.concat([cloneDeep(props.value!)]))
-      }
+      onClick={() => {
+        if (limitNotReached)
+          parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
+      }}
     />
   );
 }

--- a/packages/uniforms-semantic/src/ListDelField.tsx
+++ b/packages/uniforms-semantic/src/ListDelField.tsx
@@ -1,25 +1,30 @@
 import React, { HTMLProps } from 'react';
 import classnames from 'classnames';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  filterDOMProps,
+  joinName,
+  useField,
+  connectField,
+} from 'uniforms';
 
-export type ListDelFieldProps<T> = Override<
-  HTMLProps<HTMLSpanElement>,
-  {
-    name: string;
-    parent?: any;
-  }
+export type ListDelFieldProps = Override<
+  Omit<HTMLProps<HTMLSpanElement>, 'onChange'>,
+  { name: string }
 >;
 
-export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListDel({ disabled, name, ...props }: ListDelFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (props.parent) Object.assign(parent, props.parent);
+  const parent = useField<{ minCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
-    !props.disabled && !(parent.minCount! >= parent.value!.length);
+    !disabled && !(parent.minCount! >= parent.value!.length);
 
   return (
     <i
@@ -33,10 +38,12 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(+nameParts[nameParts.length - 1], 1);
+          value.splice(nameIndex, 1);
           parent.onChange(value);
         }
       }}
     />
   );
 }
+
+export default connectField(ListDel, { initialValue: false });

--- a/packages/uniforms-semantic/src/ListDelField.tsx
+++ b/packages/uniforms-semantic/src/ListDelField.tsx
@@ -1,44 +1,39 @@
-import classnames from 'classnames';
 import React, { HTMLProps } from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import classnames from 'classnames';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListDelFieldProps<T> = Override<
   HTMLProps<HTMLSpanElement>,
   {
-    className: string;
-    disabled?: boolean;
     name: string;
     parent?: any;
-    value?: any;
   }
 >;
 
-export default function ListDel<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
+  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const nameParts = joinName(null, props.name);
+  const nameParts = joinName(null, rawProps.name);
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (props.parent) Object.assign(parent, props.parent);
 
-  const fieldIndex = +nameParts[nameParts.length - 1];
   const limitNotReached =
     !props.disabled && !(parent.minCount! >= parent.value!.length);
+
   return (
     <i
       {...filterDOMProps(props)}
       className={classnames(
         'ui',
-        rawProps.className,
+        props.className,
         limitNotReached ? 'link' : 'disabled',
         'fitted close icon',
       )}
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(fieldIndex, 1);
+          value.splice(+nameParts[nameParts.length - 1], 1);
           parent.onChange(value);
         }
       }}

--- a/packages/uniforms-semantic/src/ListField.tsx
+++ b/packages/uniforms-semantic/src/ListField.tsx
@@ -11,7 +11,7 @@ import { Override, connectField, filterDOMProps } from 'uniforms';
 import ListAddField from './ListAddField';
 import ListItemField from './ListItemField';
 
-export type ListFieldProps<T> = Override<
+export type ListFieldProps = Override<
   HTMLProps<HTMLDivElement>,
   {
     children?: ReactNode;
@@ -21,11 +21,11 @@ export type ListFieldProps<T> = Override<
     itemProps?: {};
     name: string;
     showInlineError?: boolean;
-    value: T[];
+    value: unknown[];
   }
 >;
 
-function List<T>({
+function List({
   children,
   className,
   disabled,
@@ -39,7 +39,7 @@ function List<T>({
   showInlineError,
   value,
   ...props
-}: ListFieldProps<T>) {
+}: ListFieldProps) {
   return (
     <div
       className={classnames(
@@ -70,22 +70,21 @@ function List<T>({
         <div className="ui red basic label">{errorMessage}</div>
       )}
 
-      {children
-        ? value.map((item, index) =>
-            Children.map(children, child =>
-              isValidElement(child) && child.props.name
-                ? cloneElement(child, {
-                    key: index,
-                    name: child.props.name.replace('$', '' + index),
-                  })
-                : child,
-            ),
-          )
-        : value.map((item, index) => (
-            <ListItemField key={index} name={'' + index} {...itemProps} />
-          ))}
+      {value.map((item, itemIndex) =>
+        Children.map(children, (child, childIndex) =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                key: `${itemIndex}-${childIndex}`,
+                name: child.props.name?.replace('$', '' + itemIndex),
+                ...itemProps,
+              })
+            : child,
+        ),
+      )}
     </div>
   );
 }
+
+List.defaultProps = { children: <ListItemField name="$" /> };
 
 export default connectField(List);

--- a/packages/uniforms-semantic/src/ListField.tsx
+++ b/packages/uniforms-semantic/src/ListField.tsx
@@ -14,7 +14,7 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = Override<
   HTMLProps<HTMLDivElement>,
   {
-    children?: ReactNode;
+    children: ReactNode;
     error?: boolean;
     errorMessage?: string;
     initialCount?: number;

--- a/packages/uniforms-semantic/src/ListField.tsx
+++ b/packages/uniforms-semantic/src/ListField.tsx
@@ -1,6 +1,12 @@
+import React, {
+  Children,
+  HTMLProps,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
 import classnames from 'classnames';
-import React, { Children, HTMLProps, ReactNode, cloneElement } from 'react';
-import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
+import { Override, connectField, filterDOMProps } from 'uniforms';
 
 import ListAddField from './ListAddField';
 import ListItemField from './ListItemField';
@@ -34,11 +40,6 @@ function List<T>({
   value,
   ...props
 }: ListFieldProps<T>) {
-  const listAddFieldProps = {
-    name: `${name}.$`,
-    initialCount,
-    className: 'right floated',
-  };
   return (
     <div
       className={classnames(
@@ -53,7 +54,11 @@ function List<T>({
         <div className={classnames({ error, required }, 'field item')}>
           <label className="left floated">{label}</label>
 
-          <ListAddField {...listAddFieldProps} />
+          <ListAddField
+            className="right floated"
+            initialCount={initialCount}
+            name="$"
+          />
         </div>
       )}
 
@@ -67,29 +72,20 @@ function List<T>({
 
       {children
         ? value.map((item, index) =>
-            Children.map(children as JSX.Element, child =>
-              cloneElement(child, {
-                key: index,
-                label: null,
-                name: joinName(
-                  name,
-                  child.props.name && child.props.name.replace('$', index),
-                ),
-              }),
+            Children.map(children, child =>
+              isValidElement(child) && child.props.name
+                ? cloneElement(child, {
+                    key: index,
+                    name: child.props.name.replace('$', '' + index),
+                  })
+                : child,
             ),
           )
         : value.map((item, index) => (
-            <ListItemField
-              key={index}
-              label={undefined}
-              name={joinName(name, index)}
-              {...itemProps}
-            />
+            <ListItemField key={index} name={'' + index} {...itemProps} />
           ))}
     </div>
   );
 }
 
-export default connectField(List, {
-  includeInChain: false,
-});
+export default connectField(List);

--- a/packages/uniforms-semantic/src/ListItemField.tsx
+++ b/packages/uniforms-semantic/src/ListItemField.tsx
@@ -5,7 +5,7 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children: ReactNode;
+  children?: ReactNode;
   name: string;
 };
 

--- a/packages/uniforms-semantic/src/ListItemField.tsx
+++ b/packages/uniforms-semantic/src/ListItemField.tsx
@@ -5,7 +5,7 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   name: string;
 };
 

--- a/packages/uniforms-semantic/src/ListItemField.tsx
+++ b/packages/uniforms-semantic/src/ListItemField.tsx
@@ -1,5 +1,10 @@
-import React, { Children, ReactNode, cloneElement } from 'react';
-import { connectField, joinName } from 'uniforms';
+import React, {
+  Children,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import { joinName } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
@@ -9,7 +14,7 @@ export type ListItemFieldProps = {
   children?: ReactNode;
 };
 
-function ListItem(props: ListItemFieldProps) {
+export default function ListItemField(props: ListItemFieldProps) {
   const { children, name } = props;
   return (
     <div className="item">
@@ -17,15 +22,17 @@ function ListItem(props: ListItemFieldProps) {
 
       <div className="middle aligned content" style={{ width: '100%' }}>
         {children ? (
-          Children.map(children as JSX.Element, child =>
-            cloneElement(child, {
-              name: joinName(name, child.props.name),
-              label: null,
-              style: {
-                margin: 0,
-                ...child.props.style,
-              },
-            }),
+          Children.map(props.children, child =>
+            isValidElement(child)
+              ? cloneElement(child, {
+                  name: joinName(props.name, child.props.name),
+                  label: null,
+                  style: {
+                    margin: 0,
+                    ...child.props.style,
+                  },
+                })
+              : child,
           )
         ) : (
           <AutoField {...props} style={{ margin: 0 }} />
@@ -34,7 +41,3 @@ function ListItem(props: ListItemFieldProps) {
     </div>
   );
 }
-
-export default connectField(ListItem, {
-  includeInChain: false,
-});

--- a/packages/uniforms-semantic/src/ListItemField.tsx
+++ b/packages/uniforms-semantic/src/ListItemField.tsx
@@ -1,43 +1,26 @@
-import React, {
-  Children,
-  ReactNode,
-  cloneElement,
-  isValidElement,
-} from 'react';
-import { joinName } from 'uniforms';
+import React, { ReactNode } from 'react';
+import { connectField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
+  children: ReactNode;
   name: string;
-  children?: ReactNode;
 };
 
-export default function ListItemField(props: ListItemFieldProps) {
-  const { children, name } = props;
+function ListItem({ children }: ListItemFieldProps) {
   return (
     <div className="item">
-      <ListDelField className="top aligned" name={name} />
+      <ListDelField className="top aligned" name="" />
 
       <div className="middle aligned content" style={{ width: '100%' }}>
-        {children ? (
-          Children.map(props.children, child =>
-            isValidElement(child)
-              ? cloneElement(child, {
-                  name: joinName(props.name, child.props.name),
-                  label: null,
-                  style: {
-                    margin: 0,
-                    ...child.props.style,
-                  },
-                })
-              : child,
-          )
-        ) : (
-          <AutoField {...props} style={{ margin: 0 }} />
-        )}
+        {children}
       </div>
     </div>
   );
 }
+
+ListItem.defaultProps = { children: <AutoField label={null} name="" /> };
+
+export default connectField(ListItem, { initialValue: false });

--- a/packages/uniforms-unstyled/__tests__/ListAddField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListAddField.tsx
@@ -1,76 +1,48 @@
 import React from 'react';
+import merge from 'lodash/merge';
 import { ListAddField } from 'uniforms-unstyled';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  value: [],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: [] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListAddField> - works', () => {
-  const element = <ListAddField name="x.$" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.$" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
 });
 
 test('<ListAddField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('span').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, maxCount: 0 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" />;
+  const wrapper = mount(element, context({ x: { maxCount: 0 } }));
 
   expect(wrapper.find('span').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListAddField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListAddField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange })}
-      value="y"
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListAddField name="x.1" value="y" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('span').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['y']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
 });

--- a/packages/uniforms-unstyled/__tests__/ListDelField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListDelField.tsx
@@ -1,73 +1,48 @@
 import React from 'react';
+import merge from 'lodash/merge';
 import { ListDelField } from 'uniforms-unstyled';
 
 import createContext from './_createContext';
 import mount from './_mount';
 
-const parent = {
-  maxCount: 3,
-  minCount: 0,
-  value: ['x', 'y', 'z'],
-};
+const onChange = jest.fn();
+const context = (schema?: {}) =>
+  createContext(
+    merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
+    { onChange, model: { x: ['x', 'y', 'z'] } },
+  );
+
+beforeEach(() => {
+  onChange.mockClear();
+});
 
 test('<ListDelField> - works', () => {
-  const element = <ListDelField name="x.1" parent={parent} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
 });
 
 test('<ListDelField> - prevents onClick when disabled', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      disabled
-      parent={Object.assign({}, parent, { onChange })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" disabled />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('span').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - prevents onClick when limit reached', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField
-      name="x.1"
-      parent={Object.assign({}, parent, { onChange, minCount: 3 })}
-    />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context({ x: { minCount: 3 } }));
 
   expect(wrapper.find('span').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 test('<ListDelField> - correctly reacts on click', () => {
-  const onChange = jest.fn();
-
-  const element = (
-    <ListDelField name="x.1" parent={Object.assign({}, parent, { onChange })} />
-  );
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
+  const element = <ListDelField name="x.1" />;
+  const wrapper = mount(element, context());
 
   expect(wrapper.find('span').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith(['x', 'z']);
+  expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
 });

--- a/packages/uniforms-unstyled/__tests__/ListField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListField.tsx
@@ -22,7 +22,7 @@ test('<ListField> - renders ListAddField', () => {
   );
 
   expect(wrapper.find(ListAddField)).toHaveLength(1);
-  expect(wrapper.find(ListAddField).prop('name')).toBe('x.$');
+  expect(wrapper.find(ListAddField).prop('name')).toBe('$');
 });
 
 test('<ListField> - renders correct label (specified)', () => {
@@ -89,8 +89,8 @@ test('<ListField> - renders children with correct name (children)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(Child).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(Child).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(Child).at(1).prop('name')).toBe('1');
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
@@ -100,6 +100,6 @@ test('<ListField> - renders children with correct name (value)', () => {
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('x.0');
-  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
+  expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });

--- a/packages/uniforms-unstyled/__tests__/ListField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListField.tsx
@@ -66,6 +66,7 @@ test('<ListField> - renders children (specified)', () => {
   const element = (
     <ListField name="x" initialCount={2}>
       <Child />
+      PlainText
     </ListField>
   );
   mount(

--- a/packages/uniforms-unstyled/__tests__/ListItemField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListItemField.tsx
@@ -22,7 +22,7 @@ test('<ListItemField> - renders ListDelField', () => {
   );
 
   expect(wrapper.find(ListDelField)).toHaveLength(1);
-  expect(wrapper.find(ListDelField).prop('name')).toBe('x.1');
+  expect(wrapper.find(ListDelField).childAt(0).prop('name')).toBe('x.1');
 });
 
 test('<ListItemField> - renders AutoField', () => {

--- a/packages/uniforms-unstyled/__tests__/_createContext.ts
+++ b/packages/uniforms-unstyled/__tests__/_createContext.ts
@@ -6,8 +6,8 @@ const randomId = randomIds();
 
 export default function createContext(
   schema?: {},
-  context?: Partial<Context>,
-): { context: Context } {
+  context?: Partial<Context<any>>,
+): { context: Context<any> } {
   return {
     context: {
       changed: false,

--- a/packages/uniforms-unstyled/src/ListAddField.tsx
+++ b/packages/uniforms-unstyled/src/ListAddField.tsx
@@ -1,37 +1,43 @@
 import React, { HTMLProps } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  connectField,
+  filterDOMProps,
+  joinName,
+  useField,
+} from 'uniforms';
 
-export type ListAddFieldProps<T> = Override<
-  HTMLProps<HTMLSpanElement>,
-  {
-    initialCount?: number;
-    name: string;
-    parent?: any;
-    value?: T;
-  }
+export type ListAddFieldProps = Override<
+  Omit<HTMLProps<HTMLSpanElement>, 'onChange'>,
+  { initialCount?: number; name: string; value: unknown }
 >;
 
-export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListAdd({ disabled, name, value, ...props }: ListAddFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (props.parent) Object.assign(parent, props.parent);
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
-    !props.disabled && !(parent.maxCount! <= parent.value!.length);
+    !disabled && !(parent.maxCount! <= parent.value!.length);
 
   return (
     <span
       {...filterDOMProps(props)}
       onClick={() => {
-        if (limitNotReached)
-          parent.onChange(parent.value!.concat([cloneDeep(props.value!)]));
+        if (limitNotReached) {
+          parent.onChange(parent.value!.concat([cloneDeep(value)]));
+        }
       }}
     >
       +
     </span>
   );
 }
+
+export default connectField(ListAdd, { initialValue: false });

--- a/packages/uniforms-unstyled/src/ListAddField.tsx
+++ b/packages/uniforms-unstyled/src/ListAddField.tsx
@@ -15,7 +15,6 @@ export type ListAddFieldProps = Override<
 
 function ListAdd({ disabled, name, value, ...props }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
-  const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ maxCount?: number }, unknown[]>(
     parentName,

--- a/packages/uniforms-unstyled/src/ListAddField.tsx
+++ b/packages/uniforms-unstyled/src/ListAddField.tsx
@@ -1,6 +1,6 @@
-import cloneDeep from 'lodash/cloneDeep';
 import React, { HTMLProps } from 'react';
-import { filterDOMProps, joinName, useField, Override } from 'uniforms';
+import cloneDeep from 'lodash/cloneDeep';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListAddFieldProps<T> = Override<
   HTMLProps<HTMLSpanElement>,
@@ -12,14 +12,13 @@ export type ListAddFieldProps<T> = Override<
   }
 >;
 
-export default function ListAdd<T>(rawProps: ListAddFieldProps<T>) {
-  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListAddField<T>(rawProps: ListAddFieldProps<T>) {
+  const props = useField<ListAddFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const parentName = joinName(joinName(null, props.name).slice(0, -1));
+  const nameParts = joinName(null, rawProps.name);
+  const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ maxCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (props.parent) Object.assign(parent, props.parent);
 
   const limitNotReached =
     !props.disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-unstyled/src/ListDelField.tsx
+++ b/packages/uniforms-unstyled/src/ListDelField.tsx
@@ -41,4 +41,4 @@ function ListDel({ disabled, name, ...props }: ListDelFieldProps) {
   );
 }
 
-export default connectField(ListDel);
+export default connectField(ListDel, { initialValue: false });

--- a/packages/uniforms-unstyled/src/ListDelField.tsx
+++ b/packages/uniforms-unstyled/src/ListDelField.tsx
@@ -1,24 +1,29 @@
 import React, { HTMLProps } from 'react';
-import { Override, filterDOMProps, joinName, useField } from 'uniforms';
+import {
+  Override,
+  connectField,
+  filterDOMProps,
+  joinName,
+  useField,
+} from 'uniforms';
 
-export type ListDelFieldProps<T> = Override<
-  HTMLProps<HTMLSpanElement>,
-  {
-    name: string;
-    parent?: any;
-  }
+export type ListDelFieldProps = Override<
+  Omit<HTMLProps<HTMLSpanElement>, 'onChange'>,
+  { name: string }
 >;
 
-export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
-
-  const nameParts = joinName(null, rawProps.name);
+function ListDel({ disabled, name, ...props }: ListDelFieldProps) {
+  const nameParts = joinName(null, name);
+  const nameIndex = +nameParts[nameParts.length - 1];
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (props.parent) Object.assign(parent, props.parent);
+  const parent = useField<{ minCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
-    !props.disabled && !(parent.minCount! >= parent.value!.length);
+    !disabled && !(parent.minCount! >= parent.value!.length);
 
   return (
     <span
@@ -26,7 +31,7 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(+nameParts[nameParts.length - 1], 1);
+          value.splice(nameIndex, 1);
           parent.onChange(value);
         }
       }}
@@ -35,3 +40,5 @@ export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
     </span>
   );
 }
+
+export default connectField(ListDel);

--- a/packages/uniforms-unstyled/src/ListDelField.tsx
+++ b/packages/uniforms-unstyled/src/ListDelField.tsx
@@ -1,26 +1,22 @@
 import React, { HTMLProps } from 'react';
-import { filterDOMProps, joinName, Override, useField } from 'uniforms';
+import { Override, filterDOMProps, joinName, useField } from 'uniforms';
 
 export type ListDelFieldProps<T> = Override<
   HTMLProps<HTMLSpanElement>,
   {
     name: string;
     parent?: any;
-    value?: T;
   }
 >;
 
-export default function ListDel<T>(rawProps: ListDelFieldProps<T>) {
-  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps, {
-    initialValue: false,
-  })[0];
+export default function ListDelField<T>(rawProps: ListDelFieldProps<T>) {
+  const props = useField<ListDelFieldProps<T>, T>(rawProps.name, rawProps)[0];
 
-  const nameParts = joinName(null, props.name);
+  const nameParts = joinName(null, rawProps.name);
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<{ minCount?: number }, T[]>(parentName, {})[0];
-  if (rawProps.parent) Object.assign(parent, rawProps.parent);
+  if (props.parent) Object.assign(parent, props.parent);
 
-  const fieldIndex = +nameParts[nameParts.length - 1];
   const limitNotReached =
     !props.disabled && !(parent.minCount! >= parent.value!.length);
 
@@ -30,7 +26,7 @@ export default function ListDel<T>(rawProps: ListDelFieldProps<T>) {
       onClick={() => {
         if (limitNotReached) {
           const value = parent.value!.slice();
-          value.splice(fieldIndex, 1);
+          value.splice(+nameParts[nameParts.length - 1], 1);
           parent.onChange(value);
         }
       }}

--- a/packages/uniforms-unstyled/src/ListField.tsx
+++ b/packages/uniforms-unstyled/src/ListField.tsx
@@ -1,5 +1,11 @@
-import React, { Children, HTMLProps, ReactNode, cloneElement } from 'react';
-import { connectField, filterDOMProps, joinName, Override } from 'uniforms';
+import React, {
+  Children,
+  HTMLProps,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
+import { Override, connectField, filterDOMProps } from 'uniforms';
 
 import ListItemField from './ListItemField';
 import ListAddField from './ListAddField';
@@ -30,35 +36,26 @@ function List<T>({
       {label && (
         <label>
           {label}
-          <ListAddField initialCount={initialCount} name={`${name}.$`} />
+          <ListAddField initialCount={initialCount} name="$" />
         </label>
       )}
 
       {children
         ? value.map((item, index) =>
-            Children.map(children as JSX.Element, child =>
-              cloneElement(child, {
-                key: index,
-                label: null,
-                name: joinName(
-                  name,
-                  child.props.name && child.props.name.replace('$', index),
-                ),
-              }),
+            Children.map(children, child =>
+              isValidElement(child) && child.props.name
+                ? cloneElement(child, {
+                    key: index,
+                    name: child.props.name.replace('$', '' + index),
+                  })
+                : child,
             ),
           )
         : value.map((item, index) => (
-            <ListItemField
-              key={index}
-              label={null}
-              name={joinName(name, index)}
-              {...itemProps}
-            />
+            <ListItemField key={index} name={'' + index} {...itemProps} />
           ))}
     </ul>
   );
 }
 
-export default connectField(List, {
-  includeInChain: false,
-});
+export default connectField(List);

--- a/packages/uniforms-unstyled/src/ListField.tsx
+++ b/packages/uniforms-unstyled/src/ListField.tsx
@@ -7,30 +7,29 @@ import React, {
 } from 'react';
 import { Override, connectField, filterDOMProps } from 'uniforms';
 
-import ListItemField from './ListItemField';
 import ListAddField from './ListAddField';
+import ListItemField from './ListItemField';
 
-export type ListFieldProps<T> = Override<
-  HTMLProps<HTMLUListElement>,
+export type ListFieldProps = Override<
+  Omit<HTMLProps<HTMLUListElement>, 'onChange'>,
   {
-    children?: ReactNode;
+    children: ReactNode;
     initialCount?: number;
     itemProps?: {};
-    label: string;
+    label?: string;
     name: string;
-    value: T[];
+    value: unknown[];
   }
 >;
 
-function List<T>({
+function List({
   children,
   initialCount,
   itemProps,
   label,
-  name,
   value,
   ...props
-}: ListFieldProps<T>) {
+}: ListFieldProps) {
   return (
     <ul {...filterDOMProps(props)}>
       {label && (
@@ -40,22 +39,21 @@ function List<T>({
         </label>
       )}
 
-      {children
-        ? value.map((item, index) =>
-            Children.map(children, child =>
-              isValidElement(child) && child.props.name
-                ? cloneElement(child, {
-                    key: index,
-                    name: child.props.name.replace('$', '' + index),
-                  })
-                : child,
-            ),
-          )
-        : value.map((item, index) => (
-            <ListItemField key={index} name={'' + index} {...itemProps} />
-          ))}
+      {value.map((item, itemIndex) =>
+        Children.map(children, (child, childIndex) =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                key: `${itemIndex}-${childIndex}`,
+                name: child.props.name?.replace('$', '' + itemIndex),
+                ...itemProps,
+              })
+            : child,
+        ),
+      )}
     </ul>
   );
 }
+
+List.defaultProps = { children: <ListItemField name="$" /> };
 
 export default connectField(List);

--- a/packages/uniforms-unstyled/src/ListItemField.tsx
+++ b/packages/uniforms-unstyled/src/ListItemField.tsx
@@ -5,7 +5,7 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children: ReactNode;
+  children?: ReactNode;
   name: string;
 };
 

--- a/packages/uniforms-unstyled/src/ListItemField.tsx
+++ b/packages/uniforms-unstyled/src/ListItemField.tsx
@@ -4,33 +4,25 @@ import React, {
   cloneElement,
   isValidElement,
 } from 'react';
-import { joinName } from 'uniforms';
+import { connectField, joinName } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   name: string;
 };
 
-export default function ListItemField(props: ListItemFieldProps) {
+function ListItem({ children }: ListItemFieldProps) {
   return (
     <div>
-      <ListDelField name={props.name} />
-
-      {props.children ? (
-        Children.map(props.children, child =>
-          isValidElement(child)
-            ? cloneElement(child, {
-                name: joinName(props.name, child.props.name),
-                label: null,
-              })
-            : child,
-        )
-      ) : (
-        <AutoField {...props} />
-      )}
+      <ListDelField name="" />
+      {children}
     </div>
   );
 }
+
+ListItem.defaultProps = { children: <AutoField label={null} name="" /> };
+
+export default connectField(ListItem);

--- a/packages/uniforms-unstyled/src/ListItemField.tsx
+++ b/packages/uniforms-unstyled/src/ListItemField.tsx
@@ -5,7 +5,7 @@ import AutoField from './AutoField';
 import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
-  children?: ReactNode;
+  children: ReactNode;
   name: string;
 };
 

--- a/packages/uniforms-unstyled/src/ListItemField.tsx
+++ b/packages/uniforms-unstyled/src/ListItemField.tsx
@@ -1,4 +1,9 @@
-import React, { Children, ReactNode, cloneElement } from 'react';
+import React, {
+  Children,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react';
 import { joinName } from 'uniforms';
 
 import AutoField from './AutoField';
@@ -6,21 +11,22 @@ import ListDelField from './ListDelField';
 
 export type ListItemFieldProps = {
   children?: ReactNode;
-  label: null | string;
   name: string;
 };
 
-export default function ListItem(props: ListItemFieldProps) {
+export default function ListItemField(props: ListItemFieldProps) {
   return (
     <div>
       <ListDelField name={props.name} />
 
       {props.children ? (
-        Children.map(props.children as JSX.Element, child =>
-          cloneElement(child, {
-            name: joinName(props.name, child.props.name),
-            label: null,
-          }),
+        Children.map(props.children, child =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                name: joinName(props.name, child.props.name),
+                label: null,
+              })
+            : child,
         )
       ) : (
         <AutoField {...props} />

--- a/packages/uniforms-unstyled/src/ListItemField.tsx
+++ b/packages/uniforms-unstyled/src/ListItemField.tsx
@@ -1,10 +1,5 @@
-import React, {
-  Children,
-  ReactNode,
-  cloneElement,
-  isValidElement,
-} from 'react';
-import { connectField, joinName } from 'uniforms';
+import React, { ReactNode } from 'react';
+import { connectField } from 'uniforms';
 
 import AutoField from './AutoField';
 import ListDelField from './ListDelField';
@@ -25,4 +20,4 @@ function ListItem({ children }: ListItemFieldProps) {
 
 ListItem.defaultProps = { children: <AutoField label={null} name="" /> };
 
-export default connectField(ListItem);
+export default connectField(ListItem, { initialValue: false });

--- a/packages/uniforms/src/useField.tsx
+++ b/packages/uniforms/src/useField.tsx
@@ -28,10 +28,14 @@ export function useField<
   Props extends Record<string, any>,
   Value = Props['value'],
   Model = Record<string, any>
->(fieldName: string, props: Props, options?: { initialValue?: boolean }) {
+>(
+  fieldName: string,
+  props: Props,
+  options?: { absoluteName?: boolean; initialValue?: boolean },
+) {
   const context = useForm<Model>();
 
-  const name = joinName(context.name, fieldName);
+  const name = joinName(options?.absoluteName ? '' : context.name, fieldName);
   const state = mapValues(context.state, (prev, key) => {
     const next = props[key];
     return next === null || next === undefined ? prev : !!next;

--- a/packages/uniforms/src/useField.tsx
+++ b/packages/uniforms/src/useField.tsx
@@ -18,7 +18,10 @@ function propagate(
   const resultValue =
     typeof prop === 'string'
       ? prop
-      : prop === false || (prop === undefined && !state) || schemaDisabled
+      : prop === null ||
+        prop === false ||
+        (prop === undefined && !state) ||
+        schemaDisabled
       ? ''
       : schemaValue;
   return [resultValue, schemaValue];
@@ -71,20 +74,22 @@ export function useField<
   );
 
   const valueFromModel: Value | undefined = get(context.model, name);
+  let initialValue: Value | undefined;
   let value: Value | undefined = props.value ?? valueFromModel;
 
+  if (value === undefined) {
+    value = context.schema.getInitialValue(name, props);
+    initialValue = value;
+  } else if (props.value !== undefined && props.value !== valueFromModel) {
+    initialValue = props.value;
+  }
+
   if (options?.initialValue !== false) {
-    let initialValue;
-
-    if ((schemaProps.required ?? props.required) && value === undefined) {
-      value = context.schema.getInitialValue(name, props);
-      initialValue = value;
-    } else if (props.value !== undefined && props.value !== valueFromModel) {
-      initialValue = props.value;
-    }
-
     useEffect(() => {
-      if (initialValue !== undefined) onChange(initialValue);
+      const required = props.required ?? schemaProps.required;
+      if (required && initialValue !== undefined) {
+        onChange(initialValue);
+      }
     }, []);
   }
 


### PR DESCRIPTION
As said in #717, there are different types of fields. `ListField` is very special due to the `ListAddField` and `ListDelField`. A typical `ListField` looks like this:

```tsx
// This is not valid usage! All names are absolute for presentational purposes!
<ListField name="list">
  <ListAddField name="list.$" />
  <ListItemField name="list.0">
    <ListDelField name="list.0" />
    <AutoField name="list.0.fieldA" />
    <AutoField name="list.0.fieldB" />
  </ListItemField>
  <ListItemField name="list.1">
    <ListDelField name="list.1" />
    <AutoField name="list.1.fieldA" />
    <AutoField name="list.1.fieldB" />
  </ListItemField>
</ListField>
```

The problem that `ListAddField` and `ListDelField` have is that they require parent (`list` in this example) props to work. In v2 every field receives its parent as a part of the guaranteed props. In v3 we removed that functionality, as every field can use `useField` hook multiple times to get all it needs. Well, it works in most cases, but here it may cause problems as `useField` always appends the name from the context, therefore there's no way of getting parent props at all. I see three ways of dealing with that:

1. Introduce a special symbol to make `joinName` _pop_ a name. Something like `joinName('list.0', POP) === 'list'`. It will cover this case and allow granular stepping up the name chain. The downside is it makes name handling more complex.
2. Introduce a flag for `useField` to treat the received name as a top-level one. It will cover this case and allow referencing arbitrary fields. The downside is that it may lead to some very complex relations, but we could teach users not to overuse that.
3. Introduce a new helper, which will work just like the `useField` does but with the `context` as a parameter instead of a name. It'd make the usage slightly more complex (`useField` + adjust the context + use the new helper), but also more performant (one `useContext` instead of two). 
4. Do nothing. This will make `ListField` a special and probably error-prone while implementing in user themes.

---

This is the second step of removing `includeInChain` option of `connectField`. For the first one, see #720.