### PR TITLE
Removed includeInChain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - **Breaking:** Removed `injectName` helper. It was used to force context updates and got replaced by the new context directly. [\#720](https://github.com/vazco/uniforms/issues/720)
+- **Breaking:** Removed `includeInChain` option of `connectField`. [\#738](https://github.com/vazco/uniforms/issues/738)
 
 ## [v3.0.0-alpha.3](https://github.com/vazco/uniforms/tree/v3.0.0-alpha.3) (2020-05-06)
 

--- a/packages/uniforms/__tests__/connectField.tsx
+++ b/packages/uniforms/__tests__/connectField.tsx
@@ -67,48 +67,6 @@ describe('connectField', () => {
     });
   });
 
-  describe('when called with `includeInChain`', () => {
-    it('is in chain (true)', () => {
-      const Field1 = connectField(props => <>{props.children}</>, {
-        includeInChain: true,
-      });
-      const Field2 = connectField(Test);
-
-      mount(
-        <Field1 name="field">
-          <Field2 name="subfield" />
-        </Field1>,
-        reactContext,
-      );
-
-      expect(Test.mock.calls[0]).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'field.subfield' }),
-        ]),
-      );
-    });
-
-    it('is not in chain (false)', () => {
-      const Field1 = connectField(props => <>{props.children}</>, {
-        includeInChain: false,
-      });
-      const Field2 = connectField(Test);
-
-      mount(
-        <Field1 name="field">
-          <Field2 name="field.subfield" />
-        </Field1>,
-        reactContext,
-      );
-
-      expect(Test.mock.calls[0]).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'field.subfield' }),
-        ]),
-      );
-    });
-  });
-
   describe('when called with `initialValue`', () => {
     it('includes default value (true)', () => {
       const Field = connectField(Test, { initialValue: true });

--- a/packages/uniforms/src/connectField.tsx
+++ b/packages/uniforms/src/connectField.tsx
@@ -9,10 +9,7 @@ import { useField } from './useField';
 export function connectField<
   Props extends Partial<GuaranteedProps<Value>>,
   Value = Props['value']
->(
-  Component: ComponentType<Props>,
-  options?: { includeInChain?: boolean; initialValue?: boolean },
-) {
+>(Component: ComponentType<Props>, options?: { initialValue?: boolean }) {
   type FieldProps = Override<
     Props,
     Override<
@@ -28,7 +25,7 @@ export function connectField<
   function Field(props: FieldProps) {
     const [fieldProps, context] = useField(props.name, props, options);
 
-    const hasChainName = options?.includeInChain !== false && props.name !== '';
+    const hasChainName = props.name !== '';
     const anyFlowingPropertySet = some(
       context.state,
       (_, key) => props[key] !== null && props[key] !== undefined,


### PR DESCRIPTION
Finally, with #720 and #721 merged, we can remove `includeInChain` flag from `connectField`. It was used only in the `NestField` and `ListField` family, and mostly because of the way how the old context API worked.