### PR TITLE
Removed modelSync from AutoForm state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Breaking:** Removed `modelSync` from `AutoForm` state. [\#739](https://github.com/vazco/uniforms/issues/739)
+
 ## [v3.0.0-alpha.4](https://github.com/vazco/uniforms/tree/v3.0.0-alpha.4) (2020-06-03)
 
 - **Breaking:** Removed `injectName` helper. It was used to force context updates and got replaced by the new context directly. [\#720](https://github.com/vazco/uniforms/issues/720)


### PR DESCRIPTION
The `modelSync` was introduced back in da56d32a9d0ee03e6a061a8b674492beac4b3fc6, without any additional comment. I remember it was required to make the async validation work at all. I've run some extensive testing and it looks like it's not the case in the current React version.

Performance-wise, this removes one complete re-render of the `AutoForm`, which is the most used form component.