### PR TITLE
Fixed resolving parallel properties in JSONSchema (fixes #746).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Fixed:** Resolving parallel `properties` and `required` in `JSONSchemaBridge`. [\#746](https://github.com/vazco/uniforms/issues/746)
+
 ## [v2.6.8](https://github.com/vazco/uniforms/tree/v2.6.8) (2020-06-03)
 
 - **Fixed:** Resolving some `$ref`s in `JSONSchemaBridge`. [\#722](https://github.com/vazco/uniforms/issues/722)

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -119,6 +119,14 @@ describe('JSONSchemaBridge', () => {
       password: { type: 'string', uniforms: { type: 'password' } },
       passwordNumeric: { type: 'number', uniforms: { type: 'password' } },
       recursive: { $ref: '#/definitions/recursive' },
+      arrayWithAllOf: {
+        type: 'array',
+        items: {
+          type: 'object',
+          allOf: [{ required: ['child'] }],
+          properties: { child: { type: 'string' } },
+        },
+      },
     },
     required: ['dateOfBirth'],
   };
@@ -597,6 +605,13 @@ describe('JSONSchemaBridge', () => {
         },
       );
     });
+
+    it('works with allOf in items', () => {
+      expect(bridge.getProps('arrayWithAllOf.0.child')).toEqual({
+        label: 'Child',
+        required: true,
+      });
+    });
   });
 
   describe('#getSubfields', () => {
@@ -618,10 +633,12 @@ describe('JSONSchemaBridge', () => {
         'password',
         'passwordNumeric',
         'recursive',
+        'arrayWithAllOf',
       ]);
     });
 
     it('works with nested types', () => {
+      expect(bridge.getSubfields('arrayWithAllOf.0')).toEqual(['child']);
       expect(bridge.getSubfields('shippingAddress')).toEqual([
         'city',
         'state',

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -6,14 +6,14 @@ import omit from 'lodash/omit';
 import upperFirst from 'lodash/upperFirst';
 import { Bridge, joinName } from 'uniforms';
 
-const resolveRef = (referance, schema) => {
+const resolveRef = (reference, schema) => {
   invariant(
-    referance.startsWith('#'),
+    reference.startsWith('#'),
     'Reference is not an internal reference, and only such are allowed: "%s"',
-    referance,
+    reference,
   );
 
-  const resolvedReference = referance
+  const resolvedReference = reference
     .split('/')
     .filter(part => part && part !== '#')
     .reduce((definition, next) => definition[next], schema);
@@ -21,7 +21,7 @@ const resolveRef = (referance, schema) => {
   invariant(
     resolvedReference,
     'Reference not found in schema: "%s"',
-    referance,
+    reference,
   );
 
   return resolvedReference;
@@ -194,7 +194,7 @@ export default class JSONSchemaBridge extends Bridge {
               Object.assign(_properties, properties),
               _required.concat(required),
             ],
-            [{}, []],
+            [definition.properties || {}, definition.required || []],
           );
 
         _definition.properties = properties;


### PR DESCRIPTION
This change fixes resolving `properties` and `required` fields in JSONSchema when combined with `allOf`/`anyOf`/`oneOf`.

_I've also fixed our lovely, long-standing typo._