### PR TITLE
Fixed escaping special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Fixed:** Escaping special characters. [\#753](https://github.com/vazco/uniforms/issues/753)
+
 ## [v3.0.0-alpha.5](https://github.com/vazco/uniforms/tree/v3.0.0-alpha.5) (2020-06-17)
 
 - **Breaking:** Removed `modelSync` from `AutoForm` state. [\#739](https://github.com/vazco/uniforms/issues/739)

--- a/packages/uniforms-antd/__tests__/RadioField.tsx
+++ b/packages/uniforms-antd/__tests__/RadioField.tsx
@@ -181,3 +181,10 @@ test('<RadioField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find(Radio.Group).prop('data-y')).toBe('y');
   expect(wrapper.find(Radio.Group).prop('data-z')).toBe('z');
 });
+
+test('<RadioField> - works with special characters', () => {
+  mount(
+    <RadioField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});

--- a/packages/uniforms-antd/__tests__/SelectField.tsx
+++ b/packages/uniforms-antd/__tests__/SelectField.tsx
@@ -254,6 +254,13 @@ test('<SelectField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find(Select).prop('data-z')).toBe('z');
 });
 
+test('<SelectField> - works with special characters', () => {
+  mount(
+    <SelectField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});
+
 test('<SelectField checkboxes> - renders a set of checkboxes', () => {
   const element = <SelectField checkboxes name="x" />;
   const wrapper = mount(
@@ -472,4 +479,11 @@ test('<SelectField checkboxes> - renders a wrapper with unknown props', () => {
   expect(wrapper.find(Radio.Group).prop('data-x')).toBe('x');
   expect(wrapper.find(Radio.Group).prop('data-y')).toBe('y');
   expect(wrapper.find(Radio.Group).prop('data-z')).toBe('z');
+});
+
+test('<SelectField checkboxes> - works with special characters', () => {
+  mount(
+    <SelectField checkboxes name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
 });

--- a/packages/uniforms-bootstrap3/__tests__/RadioField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/RadioField.tsx
@@ -192,3 +192,10 @@ test('<RadioField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
 });
+
+test('<RadioField> - works with special characters', () => {
+  mount(
+    <RadioField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});

--- a/packages/uniforms-bootstrap3/__tests__/SelectField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/SelectField.tsx
@@ -259,6 +259,13 @@ test('<SelectField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
 });
 
+test('<SelectField> - works with special characters', () => {
+  mount(
+    <SelectField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});
+
 test('<SelectField checkboxes> - renders a set of checkboxes', () => {
   const element = <SelectField checkboxes name="x" />;
   const wrapper = mount(
@@ -490,4 +497,11 @@ test('<SelectField checkboxes> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-x')).toBe('x');
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
+});
+
+test('<SelectField checkboxes> - works with special characters', () => {
+  mount(
+    <SelectField checkboxes name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
 });

--- a/packages/uniforms-bootstrap3/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap3/src/RadioField.tsx
@@ -8,7 +8,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = Override<
   HTMLProps<HTMLDivElement>,

--- a/packages/uniforms-bootstrap3/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap3/src/SelectField.tsx
@@ -8,7 +8,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 const xor = (item, array) => {
   const index = array.indexOf(item);

--- a/packages/uniforms-bootstrap4/__tests__/RadioField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/RadioField.tsx
@@ -193,3 +193,10 @@ test('<RadioField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
 });
+
+test('<RadioField> - works with special characters', () => {
+  mount(
+    <RadioField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});

--- a/packages/uniforms-bootstrap4/__tests__/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/SelectField.tsx
@@ -259,6 +259,13 @@ test('<SelectField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
 });
 
+test('<SelectField> - works with special characters', () => {
+  mount(
+    <SelectField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});
+
 test('<SelectField checkboxes> - renders a set of checkboxes', () => {
   const element = <SelectField checkboxes name="x" />;
   const wrapper = mount(
@@ -490,4 +497,11 @@ test('<SelectField checkboxes> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-x')).toBe('x');
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
+});
+
+test('<SelectField checkboxes> - works with special characters', () => {
+  mount(
+    <SelectField checkboxes name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
 });

--- a/packages/uniforms-bootstrap4/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap4/src/RadioField.tsx
@@ -8,7 +8,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = Override<
   HTMLProps<HTMLDivElement>,

--- a/packages/uniforms-bootstrap4/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/src/SelectField.tsx
@@ -8,7 +8,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 const xor = (item, array) => {
   const index = array.indexOf(item);

--- a/packages/uniforms-material/__tests__/RadioField.tsx
+++ b/packages/uniforms-material/__tests__/RadioField.tsx
@@ -204,3 +204,10 @@ test('<RadioField> - renders a TextField with correct error text (specified)', (
 
   expect(wrapper.find(FormHelperText).text()).toBe('Error');
 });
+
+test('<RadioField> - works with special characters', () => {
+  mount(
+    <RadioField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});

--- a/packages/uniforms-material/__tests__/SelectField.tsx
+++ b/packages/uniforms-material/__tests__/SelectField.tsx
@@ -280,6 +280,13 @@ test('<SelectField> - renders a SelectField with correct error text (showInlineE
   expect(wrapper.find(FormHelperText)).toHaveLength(0);
 });
 
+test('<SelectField> - works with special characters', () => {
+  mount(
+    <SelectField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});
+
 test('<SelectField checkboxes> - renders a set of Radio buttons', () => {
   // @ts-ignore Fix SelectFieldProps.
   const element = <SelectField checkboxes name="x" />;
@@ -615,4 +622,11 @@ test('<SelectField checkboxes> - renders Switch with appearance=switch', () => {
 
   expect(wrapper.find(Checkbox)).toHaveLength(0);
   expect(wrapper.find(Switch)).toHaveLength(2);
+});
+
+test('<SelectField checkboxes> - works with special characters', () => {
+  mount(
+    <SelectField checkboxes name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
 });

--- a/packages/uniforms-material/src/SelectField.tsx
+++ b/packages/uniforms-material/src/SelectField.tsx
@@ -60,7 +60,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 const xor = (item, array) => {
   const index = array.indexOf(item);

--- a/packages/uniforms-semantic/__tests__/RadioField.tsx
+++ b/packages/uniforms-semantic/__tests__/RadioField.tsx
@@ -213,3 +213,10 @@ test('<RadioField> - renders correct error text (showInlineError=false)', () => 
 
   expect(wrapper.find('.ui.red.label').length).toBe(0);
 });
+
+test('<RadioField> - works with special characters', () => {
+  mount(
+    <RadioField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});

--- a/packages/uniforms-semantic/__tests__/SelectField.tsx
+++ b/packages/uniforms-semantic/__tests__/SelectField.tsx
@@ -259,6 +259,13 @@ test('<SelectField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
 });
 
+test('<SelectField> - works with special characters', () => {
+  mount(
+    <SelectField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});
+
 test('<SelectField checkboxes> - renders a set of checkboxes', () => {
   const element = <SelectField checkboxes name="x" />;
   const wrapper = mount(
@@ -479,6 +486,13 @@ test('<SelectField checkboxes> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-x')).toBe('x');
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
+});
+
+test('<SelectField checkboxes> - works with special characters', () => {
+  mount(
+    <SelectField checkboxes name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
 });
 
 test('<SelectField> - renders correct error text (specified)', () => {

--- a/packages/uniforms-semantic/src/RadioField.tsx
+++ b/packages/uniforms-semantic/src/RadioField.tsx
@@ -6,7 +6,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = Override<
   HTMLProps<HTMLDivElement>,

--- a/packages/uniforms-semantic/src/SelectField.tsx
+++ b/packages/uniforms-semantic/src/SelectField.tsx
@@ -6,7 +6,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 const xor = (item, array) => {
   const index = array.indexOf(item);

--- a/packages/uniforms-unstyled/__tests__/RadioField.tsx
+++ b/packages/uniforms-unstyled/__tests__/RadioField.tsx
@@ -181,3 +181,10 @@ test('<RadioField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
 });
+
+test('<RadioField> - works with special characters', () => {
+  mount(
+    <RadioField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});

--- a/packages/uniforms-unstyled/__tests__/SelectField.tsx
+++ b/packages/uniforms-unstyled/__tests__/SelectField.tsx
@@ -259,6 +259,13 @@ test('<SelectField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
 });
 
+test('<SelectField> - works with special characters', () => {
+  mount(
+    <SelectField name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
+});
+
 test('<SelectField checkboxes> - renders a set of checkboxes', () => {
   const element = <SelectField checkboxes name="x" />;
   const wrapper = mount(
@@ -479,4 +486,11 @@ test('<SelectField checkboxes> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-x')).toBe('x');
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
+});
+
+test('<SelectField checkboxes> - works with special characters', () => {
+  mount(
+    <SelectField checkboxes name="x" />,
+    createContext({ x: { type: String, allowedValues: ['ă', 'ș'] } }),
+  );
 });

--- a/packages/uniforms-unstyled/src/RadioField.tsx
+++ b/packages/uniforms-unstyled/src/RadioField.tsx
@@ -5,7 +5,7 @@ const base64 =
   typeof btoa !== 'undefined'
     ? btoa
     : (x: string) => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = Override<
   HTMLProps<HTMLDivElement>,

--- a/packages/uniforms-unstyled/src/SelectField.tsx
+++ b/packages/uniforms-unstyled/src/SelectField.tsx
@@ -4,7 +4,7 @@ import { connectField, filterDOMProps, Override } from 'uniforms';
 
 const base64: typeof btoa =
   typeof btoa !== 'undefined' ? btoa : x => Buffer.from(x).toString('base64');
-const escape = (x: string) => base64(x).replace(/=+$/, '');
+const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type SelectFieldProps = Override<
   HTMLProps<HTMLDivElement>,


### PR DESCRIPTION
This change fixes #753. As reported there, our [escape function](https://github.com/vazco/uniforms/blob/b0724e397d24fe4743de6c46487c4497f1de0a7e/packages/uniforms-material/src/SelectField.tsx#L135) (basically Base64) breaks on special characters (like diacritics). I've added `encodeURIComponent` to the pipeline to mitigate this issue.