### PR TITLE
Improved filterDOMProps return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Next
+
+- **Added:** Improved typing of `filterDOMProps`. To properly register a new property, extend `FilterDOMProps` interface. [\#763](https://github.com/vazco/uniforms/issues/763)
+
+  ```ts
+  declare module 'uniforms' {
+    interface FilterDOMProps {
+      customPropToFilter: never;
+    }
+  }
+
+  filterDOMProps.register('customPropToFilter');
+  ```
+
 ## [v3.0.0-alpha.5](https://github.com/vazco/uniforms/tree/v3.0.0-alpha.5) (2020-06-17)
 
 - **Breaking:** Removed `modelSync` from `AutoForm` state. [\#739](https://github.com/vazco/uniforms/issues/739)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
   filterDOMProps.register('customPropToFilter');
   ```
+
 - **Fixed:** Escaping special characters. [\#753](https://github.com/vazco/uniforms/issues/753)
 
 ## [v3.0.0-alpha.5](https://github.com/vazco/uniforms/tree/v3.0.0-alpha.5) (2020-06-17)

--- a/packages/uniforms-antd/src/DateField.tsx
+++ b/packages/uniforms-antd/src/DateField.tsx
@@ -20,7 +20,6 @@ function Date(props: DateFieldProps) {
     props,
     <DatePicker
       disabled={props.disabled}
-      id={props.id}
       name={props.name}
       onChange={value => {
         props.onChange && props.onChange(value && value.toDate());

--- a/packages/uniforms-antd/src/HiddenField.tsx
+++ b/packages/uniforms-antd/src/HiddenField.tsx
@@ -21,7 +21,6 @@ export default function HiddenField({ value, ...rawProps }: HiddenFieldProps) {
   return props.noDOM ? null : (
     <input
       disabled={props.disabled}
-      id={props.id}
       name={props.name}
       ref={props.inputRef}
       type="hidden"

--- a/packages/uniforms-antd/src/SelectField.tsx
+++ b/packages/uniforms-antd/src/SelectField.tsx
@@ -48,9 +48,7 @@ function Select(props: SelectFieldProps) {
     props.checkboxes ? (
       <Group
         disabled={props.disabled}
-        id={props.id}
         name={props.name}
-        // @ts-ignore: Different value and onChange based on fieldType.
         onChange={
           props.fieldType === Array
             ? value => props.onChange(value)
@@ -64,12 +62,11 @@ function Select(props: SelectFieldProps) {
         {...filterDOMProps(props)}
       />
     ) : (
-      // @ts-ignore: We can do better than any.
       <SelectAntD<any>
         allowClear={!props.required}
         disabled={props.disabled}
-        id={props.id}
         mode={props.fieldType === Array ? 'multiple' : undefined}
+        // @ts-ignore: There's no `name` property on Select?
         name={props.name}
         onChange={value => props.onChange(value)}
         placeholder={props.placeholder}

--- a/packages/uniforms-antd/src/wrapField.tsx
+++ b/packages/uniforms-antd/src/wrapField.tsx
@@ -66,4 +66,13 @@ export default function wrapField(
   );
 }
 
+declare module 'uniforms' {
+  interface FilterDOMProps {
+    colon: never;
+    labelCol: never;
+    wrapperCol: never;
+    wrapperStyle: never;
+  }
+}
+
 filterDOMProps.register('colon', 'labelCol', 'wrapperCol', 'wrapperStyle');

--- a/packages/uniforms-bootstrap3/src/HiddenField.tsx
+++ b/packages/uniforms-bootstrap3/src/HiddenField.tsx
@@ -21,7 +21,6 @@ export default function HiddenField({ value, ...rawProps }: HiddenFieldProps) {
   return props.noDOM ? null : (
     <input
       disabled={props.disabled}
-      id={props.id}
       name={props.name}
       ref={props.inputRef}
       type="hidden"

--- a/packages/uniforms-bootstrap3/src/gridClassName.ts
+++ b/packages/uniforms-bootstrap3/src/gridClassName.ts
@@ -1,5 +1,11 @@
 import { filterDOMProps } from 'uniforms';
 
+declare module 'uniforms' {
+  interface FilterDOMProps {
+    grid: never;
+  }
+}
+
 filterDOMProps.register('grid');
 
 function gridClassNamePart(

--- a/packages/uniforms-bootstrap4/src/HiddenField.tsx
+++ b/packages/uniforms-bootstrap4/src/HiddenField.tsx
@@ -21,7 +21,6 @@ export default function HiddenField({ value, ...rawProps }: HiddenFieldProps) {
   return props.noDOM ? null : (
     <input
       disabled={props.disabled}
-      id={props.id}
       name={props.name}
       ref={props.inputRef}
       type="hidden"

--- a/packages/uniforms-bootstrap4/src/gridClassName.ts
+++ b/packages/uniforms-bootstrap4/src/gridClassName.ts
@@ -1,5 +1,11 @@
 import { filterDOMProps } from 'uniforms';
 
+declare module 'uniforms' {
+  interface FilterDOMProps {
+    grid: never;
+  }
+}
+
 filterDOMProps.register('grid');
 
 function gridClassNamePart(

--- a/packages/uniforms-bridge-simple-schema-2/src/register.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/register.ts
@@ -4,9 +4,28 @@ import { filterDOMProps } from 'uniforms';
 // Register custom property.
 SimpleSchema.extendOptions(['uniforms']);
 
-// There's no possibility to retrieve them at runtime
+// There's no possibility to retrieve them at runtime.
+declare module 'uniforms' {
+  interface FilterDOMProps {
+    autoValue: never;
+    blackbox: never;
+    custom: never;
+    decimal: never;
+    defaultValue: never;
+    exclusiveMax: never;
+    exclusiveMin: never;
+    max: never;
+    maxCount: never;
+    min: never;
+    minCount: never;
+    optional: never;
+    regEx: never;
+    trim: never;
+    type: never;
+  }
+}
+
 filterDOMProps.register(
-  'allowedValues',
   'autoValue',
   'blackbox',
   'custom',
@@ -14,7 +33,6 @@ filterDOMProps.register(
   'defaultValue',
   'exclusiveMax',
   'exclusiveMin',
-  'label',
   'max',
   'maxCount',
   'min',

--- a/packages/uniforms-bridge-simple-schema/src/register.ts
+++ b/packages/uniforms-bridge-simple-schema/src/register.ts
@@ -17,9 +17,28 @@ SimpleSchema.extendOptions({
   ),
 });
 
-// There's no possibility to retrieve them at runtime
+// There's no possibility to retrieve them at runtime.
+declare module 'uniforms' {
+  interface FilterDOMProps {
+    autoValue: never;
+    blackbox: never;
+    custom: never;
+    decimal: never;
+    defaultValue: never;
+    exclusiveMax: never;
+    exclusiveMin: never;
+    max: never;
+    maxCount: never;
+    min: never;
+    minCount: never;
+    optional: never;
+    regEx: never;
+    trim: never;
+    type: never;
+  }
+}
+
 filterDOMProps.register(
-  'allowedValues',
   'autoValue',
   'blackbox',
   'custom',
@@ -27,7 +46,6 @@ filterDOMProps.register(
   'defaultValue',
   'exclusiveMax',
   'exclusiveMin',
-  'label',
   'max',
   'maxCount',
   'min',

--- a/packages/uniforms-material/src/HiddenField.tsx
+++ b/packages/uniforms-material/src/HiddenField.tsx
@@ -21,7 +21,6 @@ export default function HiddenField({ value, ...rawProps }: HiddenFieldProps) {
   return props.noDOM ? null : (
     <input
       disabled={props.disabled}
-      id={props.id}
       name={props.name}
       ref={props.inputRef}
       type="hidden"

--- a/packages/uniforms-semantic/src/HiddenField.tsx
+++ b/packages/uniforms-semantic/src/HiddenField.tsx
@@ -21,7 +21,6 @@ export default function HiddenField({ value, ...rawProps }: HiddenFieldProps) {
   return props.noDOM ? null : (
     <input
       disabled={props.disabled}
-      id={props.id}
       name={props.name}
       ref={props.inputRef}
       type="hidden"

--- a/packages/uniforms-unstyled/src/HiddenField.tsx
+++ b/packages/uniforms-unstyled/src/HiddenField.tsx
@@ -21,7 +21,6 @@ export default function HiddenField({ value, ...rawProps }: HiddenFieldProps) {
   return props.noDOM ? null : (
     <input
       disabled={props.disabled}
-      id={props.id}
       name={props.name}
       ref={props.inputRef}
       type="hidden"

--- a/packages/uniforms/__tests__/filterDOMProps.ts
+++ b/packages/uniforms/__tests__/filterDOMProps.ts
@@ -11,6 +11,7 @@ describe('joinName', () => {
   });
 
   it('removes registered props', () => {
+    // @ts-ignore: Do not register its type not to pollute it.
     filterDOMProps.register('__special__');
 
     expect(filterDOMProps({ __special__: true })).toEqual({});

--- a/packages/uniforms/__tests__/filterDOMProps.ts
+++ b/packages/uniforms/__tests__/filterDOMProps.ts
@@ -17,6 +17,12 @@ describe('joinName', () => {
     expect(filterDOMProps({ __special__: true })).toEqual({});
   });
 
+  it('ignores double registers', () => {
+    const { length } = filterDOMProps.registered;
+    filterDOMProps.register('value');
+    expect(filterDOMProps.registered).toHaveLength(length);
+  });
+
   it('omits rest', () => {
     expect(filterDOMProps({ a: 1 })).toEqual({ a: 1 });
     expect(filterDOMProps({ b: 2 })).toEqual({ b: 2 });

--- a/packages/uniforms/src/filterDOMProps.ts
+++ b/packages/uniforms/src/filterDOMProps.ts
@@ -2,7 +2,34 @@ import pickBy from 'lodash/pickBy';
 import sortedIndex from 'lodash/sortedIndex';
 import sortedIndexOf from 'lodash/sortedIndexOf';
 
-const registered = [
+import { FilterDOMProps } from '.';
+
+type FilterDOMPropsKeys = keyof FilterDOMProps;
+
+const registered: FilterDOMPropsKeys[] = [];
+
+function filter<T extends object>(props: T) {
+  return pickBy(props, filterOne) as Omit<T, FilterDOMPropsKeys>;
+}
+
+function filterOne(value: unknown, prop: string) {
+  return sortedIndexOf(registered, prop) === -1;
+}
+
+function register(...props: FilterDOMPropsKeys[]) {
+  props.forEach(prop => {
+    if (sortedIndexOf(registered, prop) === -1) {
+      registered.splice(sortedIndex(registered, prop), 0, prop);
+    }
+  });
+}
+
+export const filterDOMProps = Object.assign(filter, {
+  register,
+  registered: registered as readonly FilterDOMPropsKeys[],
+});
+
+register(
   // These props are provided by useField directly.
   'changed',
   'error',
@@ -27,25 +54,4 @@ const registered = [
 
   // These is used by AutoField and bridges.
   'allowedValues',
-].sort();
-
-function filter<T extends object>(props: T) {
-  return pickBy(props, filterOne);
-}
-
-function filterOne(value: unknown, prop: string) {
-  return sortedIndexOf(registered, prop) === -1;
-}
-
-function register(...props: string[]) {
-  props.forEach(prop => {
-    if (sortedIndexOf(registered, prop) === -1) {
-      registered.splice(sortedIndex(registered, prop), 0, prop);
-    }
-  });
-}
-
-export const filterDOMProps = Object.assign(filter, {
-  register,
-  registered: registered as readonly string[],
-});
+);

--- a/packages/uniforms/src/types.ts
+++ b/packages/uniforms/src/types.ts
@@ -30,6 +30,9 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends {} ? DeepPartial<T[P]> : T[P];
 };
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface FilterDOMProps {}
+
 export type GuaranteedProps<Value> = {
   changed: boolean;
   disabled: boolean;
@@ -54,3 +57,27 @@ export type Override<T, U> = U & Omit<T, keyof U>;
 export type Partialize<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export type ValidateMode = 'onChange' | 'onChangeAfterSubmit' | 'onSubmit';
+
+// Explicit declaration to allow users extend it directly.
+// Would it be possible not to use `declare` here?
+declare module '.' {
+  interface FilterDOMProps {
+    allowedValues: never;
+    changed: never;
+    component: never;
+    disabled: never;
+    error: never;
+    errorMessage: never;
+    field: never;
+    fieldType: never;
+    fields: never;
+    initialCount: never;
+    label: never;
+    name: never;
+    onChange: never;
+    placeholder: never;
+    showInlineError: never;
+    transform: never;
+    value: never;
+  }
+}


### PR DESCRIPTION
This change enhances `filterDOMProps` return type from `Partial<T>` to `Omit<T, keyof FilterDOMProps>`. In short, this allows us to properly exclude all filtered props, including the ones in the user app. New props have to be registered in the type as well:

```ts
declare module 'uniforms' {
  interface FilterDOMProps {
    customPropToFilter: never;
  }
}

filterDOMProps.register('customPropToFilter');
```

This showed a few unnecessarily passed props.