### PR TITLE
Fixed changed state of AutoForm

### DIFF
--- a/packages/uniforms/__tests__/AutoForm.tsx
+++ b/packages/uniforms/__tests__/AutoForm.tsx
@@ -28,16 +28,12 @@ describe('AutoForm', () => {
   });
 
   describe('when changed', () => {
-    // FIXME: AutoForm is not a valid Component.
-    const wrapper = mount<AutoForm | any>(
-      <AutoForm
-        onChange={onChange}
-        onChangeModel={onChangeModel}
-        schema={schema}
-      />,
-    );
-
     it('updates', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(
+        <AutoForm onChange={onChange} schema={schema} />,
+      );
+
       wrapper.instance().getContext().onChange('a', '2');
 
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -45,10 +41,31 @@ describe('AutoForm', () => {
     });
 
     it('calls `onChangeModel`', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(
+        <AutoForm onChangeModel={onChangeModel} schema={schema} />,
+      );
+
       wrapper.instance().getContext().onChange('a', '2');
 
       expect(onChangeModel).toHaveBeenCalledTimes(1);
       expect(onChangeModel).toHaveBeenLastCalledWith({ a: '2' });
+    });
+
+    it('updates `changed` and `changedMap`', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(<AutoForm schema={schema} />);
+
+      const context1 = wrapper.instance().getContext();
+      expect(context1).toHaveProperty('changed', false);
+      expect(context1).toHaveProperty('changedMap', {});
+
+      wrapper.instance().getContext().onChange('a', '2');
+
+      const context2 = wrapper.instance().getContext();
+      expect(context2).toHaveProperty('changed', true);
+      expect(context2).toHaveProperty('changedMap.a');
+      expect(context2.changedMap.a).toBeTruthy();
     });
   });
 
@@ -57,12 +74,13 @@ describe('AutoForm', () => {
       const field = () => null;
       const Field = connectField(field);
 
-      mount<AutoForm>(
+      // FIXME: AutoForm is not a valid Component.
+      mount<AutoForm | any>(
         <AutoForm
-          onChange={onChange}
-          schema={schema}
           autoField={Field}
           model={model}
+          onChange={onChange}
+          schema={schema}
         />,
       );
 
@@ -74,7 +92,7 @@ describe('AutoForm', () => {
     it('skips `onSubmit` until rendered (`autosave` = true)', async () => {
       // FIXME: AutoForm is not a valid Component.
       const wrapper = mount<AutoForm | any>(
-        <AutoForm onSubmit={onSubmit} schema={schema} autosave />,
+        <AutoForm autosave onSubmit={onSubmit} schema={schema} />,
       );
 
       expect(onSubmit).not.toBeCalled();
@@ -88,43 +106,50 @@ describe('AutoForm', () => {
   });
 
   describe('when reset', () => {
-    const intialModel = { a: 'foo' };
-    // FIXME: AutoForm is not a valid Component.
-    const wrapper = mount<AutoForm | any>(
-      <AutoForm
-        onSubmit={onSubmit}
-        schema={schema}
-        autosave
-        model={intialModel}
-      />,
-    );
-
     it('reset `model`', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(
+        <AutoForm autosave model={model} schema={schema} />,
+      );
+
       wrapper.instance().reset();
-      expect(wrapper.instance().getContext().model).toEqual(intialModel);
+      expect(wrapper.instance().getContext().model).toEqual(model);
     });
 
     it('resets state `changedMap`', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(
+        <AutoForm autosave model={model} onSubmit={onSubmit} schema={schema} />,
+      );
+
       wrapper.instance().reset();
       expect(wrapper.instance().getContext().changedMap).toEqual({});
     });
 
     it('resets state `changed`', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(
+        <AutoForm autosave model={model} onSubmit={onSubmit} schema={schema} />,
+      );
+
       wrapper.instance().reset();
       expect(wrapper.instance().getContext().changed).toEqual(false);
     });
   });
 
   describe('when updated', () => {
-    // FIXME: AutoForm is not a valid Component.
-    const wrapper = mount<AutoForm | any>(<AutoForm schema={schema} />);
-
     it('updates', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(<AutoForm schema={schema} />);
+
       wrapper.setProps({ model: {} });
       expect(wrapper.instance().props.model).toEqual({});
     });
 
     it('validates', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(<AutoForm schema={schema} />);
+
       wrapper.setProps({ model, validate: 'onChange' });
       expect(validator).toHaveBeenCalledTimes(1);
     });

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -58,10 +58,10 @@ export function Auto<Base extends typeof ValidatedQuickForm>(Base: Base) {
     }
 
     onChange(key: string, value: any) {
+      super.onChange(key, value);
       this.setState(
         state => ({ model: setWith(clone(state.model), key, value, clone) }),
         () => {
-          super.onChange(key, value);
           if (this.props.onChangeModel)
             this.props.onChangeModel(this.state.model);
         },


### PR DESCRIPTION
This change should fix the regression introduced in #739. Due to the removal of `modelSync`, `AutoForm` was no longer resolving `changed` and `changedMap` correctly, effectively not tracking `changed` states at all. I've fixed that, added test for that, ~and fixed other tests, as they were using shared form instance~ (I've moved that directly to v3 branch).

Once more, thanks to @mvgijssel for https://github.com/vazco/uniforms/pull/739#issuecomment-656643894!