### PR TITLE
Fixed AutoForm validation (fixes #769).

### DIFF
--- a/packages/uniforms/__tests__/AutoForm.tsx
+++ b/packages/uniforms/__tests__/AutoForm.tsx
@@ -40,6 +40,23 @@ describe('AutoForm', () => {
       expect(onChange).toHaveBeenLastCalledWith('a', '2');
     });
 
+    it('validates', () => {
+      // FIXME: AutoForm is not a valid Component.
+      const wrapper = mount<AutoForm | any>(
+        <AutoForm onChange={onChange} schema={schema} />,
+      );
+
+      wrapper.instance().submit();
+
+      expect(validator).toHaveBeenCalledTimes(1);
+      expect(validator).toHaveBeenLastCalledWith({});
+
+      wrapper.instance().getContext().onChange('a', '1');
+
+      expect(validator).toHaveBeenCalledTimes(2);
+      expect(validator).toHaveBeenLastCalledWith({ a: '1' });
+    });
+
     it('calls `onChangeModel`', () => {
       // FIXME: AutoForm is not a valid Component.
       const wrapper = mount<AutoForm | any>(

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -74,10 +74,6 @@ export function Auto<Base extends typeof ValidatedQuickForm>(Base: Base) {
         model: this.props.model,
       } as Partial<State>;
     }
-
-    onValidate() {
-      return this.onValidateModel(this.getContextModel());
-    }
   }
 
   return AutoForm;


### PR DESCRIPTION
The fix made in #765 broke the validation of `AutoForm`, as reported in #769. This change fixes that, by removing an obsolete `onValidate` override in `AutoForm`.