### PR TITLE
Reworked GraphQLBridge.getField (closes #786).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next:
+
+- **Breaking:** Reworked `GraphQLBridge.getField`. [\#769](https://github.com/vazco/uniforms/issues/769)
+
 ## [v3.0.0-rc.3](https://github.com/vazco/uniforms/tree/v3.0.0-rc.3) (2020-08-13)
 
 - **Breaking:** Minimum `graphql` version for `uniforms-bridge-graphql` is now `15.0.0`. [\#781](https://github.com/vazco/uniforms/issues/781)

--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -78,23 +78,19 @@ describe('GraphQLBridge', () => {
   const astT = buildASTSchema(parse(schemaT));
 
   const bridgeI = new GraphQLBridge(
-    astI.getType('Post') as GraphQLInputObjectType,
+    astI.getType('Post')!,
     schemaValidator,
     schemaData,
   );
   const bridgeT = new GraphQLBridge(
-    astT.getType('Post') as GraphQLObjectType,
+    astT.getType('Post')!,
     schemaValidator,
     schemaData,
   );
 
   describe('#constructor()', () => {
     it('always ensures `extras`', () => {
-      const bridge = new GraphQLBridge(
-        astI.getType('Post') as GraphQLInputObjectType,
-        schemaValidator,
-      );
-
+      const bridge = new GraphQLBridge(astI.getType('Post')!, schemaValidator);
       expect(bridge.extras).toEqual({});
     });
   });

--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -193,10 +193,10 @@ describe('GraphQLBridge', () => {
     });
 
     it('throws on not found field', () => {
-      expect(() => bridgeI.getField('x')).toThrow(/Field not found in schema/);
-      expect(() => bridgeI.getField('author.x')).toThrow(
-        /Field not found in schema/,
-      );
+      const error = /Field not found in schema/;
+      expect(() => bridgeI.getField('x')).toThrow(error);
+      expect(() => bridgeI.getField('author.x')).toThrow(error);
+      expect(() => bridgeI.getField('author.tags.x')).toThrow(error);
     });
   });
 

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -114,7 +114,7 @@ export default class GraphQLBridge extends Bridge {
     const nameGeneric = nameNormal.replace(/\.\d+/g, '.$');
 
     const { name, type } = this.getField(nameGeneric);
-    const ready = {
+    const result = {
       required: isNonNullType(type),
       ...this.extras[nameGeneric],
       ...this.extras[nameNormal],
@@ -122,24 +122,24 @@ export default class GraphQLBridge extends Bridge {
 
     const fieldType = getNullableType(type);
     if (isScalarType(fieldType) && fieldType.name === 'Float') {
-      ready.decimal = true;
+      result.decimal = true;
     }
 
-    ready.label = extractValue(ready.label, toHumanLabel(name));
+    result.label = extractValue(result.label, toHumanLabel(name));
 
-    const options = props.options || ready.options;
+    const options = props.options || result.options;
     if (options) {
       if (!Array.isArray(options)) {
-        ready.transform = (value: any) => options[value];
-        ready.allowedValues = Object.keys(options);
+        result.transform = (value: any) => options[value];
+        result.allowedValues = Object.keys(options);
       } else {
-        ready.transform = (value: any) =>
+        result.transform = (value: any) =>
           options.find(option => option.value === value).label;
-        ready.allowedValues = options.map(option => option.value);
+        result.allowedValues = options.map(option => option.value);
       }
     }
 
-    return ready;
+    return result;
   }
 
   getSubfields(name = '') {

--- a/reproductions/schema/graphql-schema.tsx
+++ b/reproductions/schema/graphql-schema.tsx
@@ -25,7 +25,6 @@ const args = {
   title: { label: 'Horse A', placeholder: 'Horse B' },
 };
 
-const type = buildASTSchema(parse(schema)).getType('Address');
-if (!(type instanceof GraphQLObjectType)) throw new Error('Invalid type.');
+const type = buildASTSchema(parse(schema)).getType('Address')!;
 
 export const bridge = new GraphQLBridge(type, validator, args);


### PR DESCRIPTION
As reported and discussed in #781, #784, and #786 , current `GraphQLBridge` is not well-typed. It got better with #784, but it was still _weird_. This change reviews this behavior, leading to a cleaner implementation and a clean `GraphQLType` as an input.

There is one breaking change, but I think no one was actually using that - the second argument of `getField` got removed. It means, that `field.type` prop will be `GraphQLNonNull<T>` instead of `T` for non-nullable types.