### PR TITLE
#785 class name for select field

### DIFF
--- a/packages/uniforms-bootstrap4/__tests__/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/SelectField.tsx
@@ -247,6 +247,15 @@ test('<SelectField> - renders a label', () => {
   );
 });
 
+test('<SelectField> - renders a select with class "bg-red" beside "form-group"', () => {
+  const element = <SelectField name="x" className="bg-red" />;
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: String, allowedValues: ['a', 'b'] } }),
+  );
+  expect(wrapper.find('.bg-red.form-group')).toHaveLength(1);
+});
+
 test('<SelectField> - renders a wrapper with unknown props', () => {
   const element = <SelectField name="x" data-x="x" data-y="y" data-z="z" />;
   const wrapper = mount(

--- a/packages/uniforms-bootstrap4/__tests__/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/SelectField.tsx
@@ -256,6 +256,40 @@ test('<SelectField> - renders a select with class "bg-red" beside "form-group"',
   expect(wrapper.find('.bg-red.form-group')).toHaveLength(1);
 });
 
+test('<SelectField> - renders a disabled select', () => {
+  const element = <SelectField name="x" disabled />;
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: String, allowedValues: ['a', 'b'] } }),
+  );
+  expect(wrapper.find('select').prop('disabled')).toEqual(true);
+});
+
+test('<SelectField> - renders a required select', () => {
+  const element = <SelectField name="x" required />;
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: String, allowedValues: ['a', 'b'] } }),
+  );
+  expect(wrapper.find('.form-group.required')).toHaveLength(1);
+});
+
+test('<SelectField> - renders am error massge in select', () => {
+  const element = (
+    <SelectField
+      name="x"
+      showInlineError
+      error={new Error()}
+      errorMessage="Error"
+    />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: String, allowedValues: ['a', 'b'] } }),
+  );
+  expect(wrapper.find('.form-text.text-danger')).toHaveLength(1);
+});
+
 test('<SelectField> - renders a wrapper with unknown props', () => {
   const element = <SelectField name="x" data-x="x" data-y="y" data-z="z" />;
   const wrapper = mount(

--- a/packages/uniforms-bootstrap4/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/src/SelectField.tsx
@@ -24,28 +24,34 @@ export type SelectFieldProps = HTMLFieldProps<
   }
 >;
 
-function Select(props: SelectFieldProps) {
-  const {
-    allowedValues,
-    checkboxes,
-    disabled,
-    error,
-    fieldType,
-    id,
-    inline,
-    inputClassName,
-    inputRef,
-    label,
-    name,
-    onChange,
-    placeholder,
-    required,
-    transform,
-    value,
-  } = props;
-
+function Select({
+  allowedValues,
+  checkboxes,
+  disabled,
+  error,
+  fieldType,
+  id,
+  inline,
+  inputClassName,
+  inputRef,
+  label,
+  name,
+  onChange,
+  placeholder,
+  required,
+  transform,
+  value,
+  ...props
+}: SelectFieldProps) {
   return wrapField(
-    props,
+    {
+      ...props,
+      disabled,
+      error,
+      id,
+      label,
+      required,
+    },
     checkboxes || fieldType === Array ? (
       allowedValues?.map(item => (
         <div

--- a/packages/uniforms-bootstrap4/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/src/SelectField.tsx
@@ -24,30 +24,28 @@ export type SelectFieldProps = HTMLFieldProps<
   }
 >;
 
-function Select({
-  allowedValues,
-  checkboxes,
-  className,
-  disabled,
-  error,
-  errorMessage,
-  fieldType,
-  id,
-  inline,
-  inputClassName,
-  inputRef,
-  label,
-  name,
-  onChange,
-  placeholder,
-  required,
-  showInlineError,
-  transform,
-  value,
-  ...props
-}: SelectFieldProps) {
+function Select(props: SelectFieldProps) {
+  const {
+    allowedValues,
+    checkboxes,
+    disabled,
+    error,
+    fieldType,
+    id,
+    inline,
+    inputClassName,
+    inputRef,
+    label,
+    name,
+    onChange,
+    placeholder,
+    required,
+    transform,
+    value,
+  } = props;
+
   return wrapField(
-    { ...props, id, label },
+    props,
     checkboxes || fieldType === Array ? (
       allowedValues?.map(item => (
         <div


### PR DESCRIPTION
#785
This PR will fix issue #785 and probably #793, the problem was in a [Spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) in the ``SelectField`` for bootstrap4, before pass props to ``wrapField`` few properties were removed from props, that is why in ``wrapField`` there were undefined.