### PR TITLE
Allow passing antd's validateStatus prop to wrapField for custom fields

### DIFF
--- a/packages/uniforms-antd/__tests__/wrapField.tsx
+++ b/packages/uniforms-antd/__tests__/wrapField.tsx
@@ -66,3 +66,10 @@ test('<wrapField> - renders wrapper with extra style', () => {
 
   expect(wrapper.find(Form.Item).prop('style')).toEqual({});
 });
+
+test('<wrapField> - renders wrapper with a custom validateStatus', () => {
+  const element = wrapField({ validateStatus: 'success' }, <div />);
+  const wrapper = mount(element);
+
+  expect(wrapper.find(Form.Item).prop('validateStatus')).toBe('success');
+});

--- a/packages/uniforms-antd/src/wrapField.tsx
+++ b/packages/uniforms-antd/src/wrapField.tsx
@@ -30,6 +30,7 @@ export default function wrapField(
     labelCol,
     required,
     showInlineError,
+    validateStatus,
     wrapperCol,
     wrapperStyle = defaultWrapperStyle,
   }: WrapperProps,
@@ -60,7 +61,7 @@ export default function wrapField(
       labelCol={labelCol}
       required={required}
       style={wrapperStyle}
-      validateStatus={error ? 'error' : undefined}
+      validateStatus={error ? 'error' : validateStatus}
       wrapperCol={wrapperCol}
     >
       {children}
@@ -74,6 +75,7 @@ declare module 'uniforms' {
     colon: never;
     disableItem: never;
     labelCol: never;
+    validateStatus: never;
     wrapperCol: never;
     wrapperStyle: never;
   }
@@ -84,6 +86,7 @@ filterDOMProps.register(
   'colon',
   'disableItem',
   'labelCol',
+  'validateStatus',
   'wrapperCol',
   'wrapperStyle',
 );


### PR DESCRIPTION
I built a custom field that I want to pass validateStatus='success' to AntD's Form.Item so I can give fast feedback when the data is entered in the correct format.  

This pull requests adds a default validateStatus prop to antd's wrapField that the error prop can still override.