### PR TITLE
Adds row support to uniforms-material RadioField

### DIFF
--- a/packages/uniforms-material/src/RadioField.tsx
+++ b/packages/uniforms-material/src/RadioField.tsx
@@ -1,7 +1,7 @@
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormLabel from '@material-ui/core/FormLabel';
 import RadioMaterial, { RadioProps } from '@material-ui/core/Radio';
-import RadioGroup from '@material-ui/core/RadioGroup';
+import RadioGroup, { RadioGroupProps } from '@material-ui/core/RadioGroup';
 import React, { ReactNode } from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
@@ -9,7 +9,7 @@ import wrapField from './wrapField';
 
 export type RadioFieldProps = FieldProps<
   string,
-  RadioProps,
+  RadioProps & RadioGroupProps,
   {
     allowedValues?: string[];
     checkboxes?: boolean;
@@ -31,6 +31,7 @@ function Radio({
   margin = 'dense',
   name,
   onChange,
+  row,
   transform,
   value,
   ...props
@@ -48,6 +49,7 @@ function Radio({
       onChange={(event: any) => disabled || onChange(event.target.value)}
       ref={inputRef}
       value={value ?? ''}
+      row={row}
     >
       {allowedValues?.map(item => (
         <FormControlLabel

--- a/packages/uniforms-material/src/RadioField.tsx
+++ b/packages/uniforms-material/src/RadioField.tsx
@@ -1,21 +1,22 @@
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormLabel from '@material-ui/core/FormLabel';
 import RadioMaterial, { RadioProps } from '@material-ui/core/Radio';
-import RadioGroup, { RadioGroupProps } from '@material-ui/core/RadioGroup';
-import React, { ReactNode } from 'react';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
 export type RadioFieldProps = FieldProps<
   string,
-  RadioProps & RadioGroupProps,
+  RadioProps,
   {
     allowedValues?: string[];
     checkboxes?: boolean;
     fullWidth?: boolean;
     helperText?: string;
     margin?: any;
+    row?: boolean;
     transform?(value: string): string;
   }
 >;
@@ -48,8 +49,8 @@ function Radio({
       name={name}
       onChange={(event: any) => disabled || onChange(event.target.value)}
       ref={inputRef}
-      value={value ?? ''}
       row={row}
+      value={value ?? ''}
     >
       {allowedValues?.map(item => (
         <FormControlLabel


### PR DESCRIPTION
<!-- Before you open a pull request, please check if a similar one already exists or has been closed before. -->

Since `RadioField` is using Material's `RadioGroup` this change would allow users to specify the `row` property for the group (changing the orientation from vertical to horizontal).

From Material's [RadioGroup API](https://material-ui.com/components/radio-buttons/):
> To lay out the buttons horizontally, set the row prop: <RadioGroup row />.