### PR TITLE
Cleaned up ESLint rules.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,6 @@
     "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unsafe-return": "off",
-    "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/require-await": "off",
@@ -70,6 +69,7 @@
     "react/prop-types": "off"
   },
   "settings": {
+    "import/core-modules": ["meteor/aldeed:simple-schema", "meteor/check"],
     "import/resolver": {
       "typescript": {}
     },

--- a/packages/uniforms-antd/__tests__/ListAddField.tsx
+++ b/packages/uniforms-antd/__tests__/ListAddField.tsx
@@ -7,7 +7,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: [] } },

--- a/packages/uniforms-antd/__tests__/ListDelField.tsx
+++ b/packages/uniforms-antd/__tests__/ListDelField.tsx
@@ -7,7 +7,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: ['x', 'y', 'z'] } },

--- a/packages/uniforms-antd/__tests__/_createContext.ts
+++ b/packages/uniforms-antd/__tests__/_createContext.ts
@@ -5,7 +5,7 @@ import createSchema from './_createSchema';
 const randomId = randomIds();
 
 export default function createContext(
-  schema?: {},
+  schema?: object,
   context?: Partial<Context<any>>,
 ): { context: Context<any> } {
   return {

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -20,7 +20,7 @@ export type ListFieldProps = HTMLFieldProps<
     children?: ReactNode;
     info?: string;
     initialCount?: number;
-    itemProps?: {};
+    itemProps?: object;
     labelCol?: any;
     wrapperCol?: any;
   }

--- a/packages/uniforms-antd/src/NestField.tsx
+++ b/packages/uniforms-antd/src/NestField.tsx
@@ -16,7 +16,6 @@ function Nest({
   fields,
   itemProps,
   label,
-  name,
   showInlineError,
   ...props
 }: NestFieldProps) {

--- a/packages/uniforms-bootstrap3/__tests__/ListAddField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListAddField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: [] } },

--- a/packages/uniforms-bootstrap3/__tests__/ListDelField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListDelField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: ['x', 'y', 'z'] } },

--- a/packages/uniforms-bootstrap3/__tests__/_createContext.ts
+++ b/packages/uniforms-bootstrap3/__tests__/_createContext.ts
@@ -5,7 +5,7 @@ import createSchema from './_createSchema';
 const randomId = randomIds();
 
 export default function createContext(
-  schema?: {},
+  schema?: object,
   context?: Partial<Context<any>>,
 ): { context: Context<any> } {
   return {

--- a/packages/uniforms-bootstrap3/src/DateField.tsx
+++ b/packages/uniforms-bootstrap3/src/DateField.tsx
@@ -31,9 +31,7 @@ function Date({
   name,
   onChange,
   placeholder,
-  showInlineError,
   value,
-  wrapClassName,
   ...props
 }: DateFieldProps) {
   return wrapField(

--- a/packages/uniforms-bootstrap3/src/ListField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListField.tsx
@@ -16,7 +16,7 @@ export type ListFieldProps = HTMLFieldProps<
   {
     addIcon?: ReactNode;
     initialCount?: number;
-    itemProps?: {};
+    itemProps?: object;
     removeIcon?: ReactNode;
   }
 >;

--- a/packages/uniforms-bootstrap3/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap3/src/LongTextField.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import omit from 'lodash/omit';
 import React, { Ref } from 'react';
 import { connectField, HTMLFieldProps } from 'uniforms';
 

--- a/packages/uniforms-bootstrap3/src/NestField.tsx
+++ b/packages/uniforms-bootstrap3/src/NestField.tsx
@@ -18,7 +18,6 @@ const Nest = ({
   fields,
   itemProps,
   label,
-  name,
   showInlineError,
   ...props
 }: NestFieldProps) => (

--- a/packages/uniforms-bootstrap3/src/NumField.tsx
+++ b/packages/uniforms-bootstrap3/src/NumField.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import omit from 'lodash/omit';
 import React, { Ref } from 'react';
 import { connectField, HTMLFieldProps } from 'uniforms';
 

--- a/packages/uniforms-bootstrap3/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap3/src/SelectField.tsx
@@ -28,11 +28,9 @@ export type SelectFieldProps = HTMLFieldProps<
 function Select({
   allowedValues,
   checkboxes,
-  className,
   disableItem,
   disabled,
   error,
-  errorMessage,
   fieldType,
   id,
   inline,
@@ -43,7 +41,6 @@ function Select({
   onChange,
   placeholder,
   required,
-  showInlineError,
   transform,
   value,
   ...props

--- a/packages/uniforms-bootstrap4/__tests__/ListAddField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListAddField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: [] } },

--- a/packages/uniforms-bootstrap4/__tests__/ListDelField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListDelField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: ['x', 'y', 'z'] } },

--- a/packages/uniforms-bootstrap4/__tests__/_createContext.ts
+++ b/packages/uniforms-bootstrap4/__tests__/_createContext.ts
@@ -5,7 +5,7 @@ import createSchema from './_createSchema';
 const randomId = randomIds();
 
 export default function createContext(
-  schema?: {},
+  schema?: object,
   context?: Partial<Context<any>>,
 ): { context: Context<any> } {
   return {

--- a/packages/uniforms-bootstrap4/src/BaseForm.tsx
+++ b/packages/uniforms-bootstrap4/src/BaseForm.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import omit from 'lodash/omit';
 import { BaseForm } from 'uniforms';
 
 function Bootstrap4(parent: any): any {
@@ -8,24 +9,16 @@ function Bootstrap4(parent: any): any {
     static displayName = `Bootstrap4${parent.displayName}`;
 
     getContextState() {
-      return {
-        ...super.getContextState(),
-        grid: this.props.grid,
-      };
+      return { ...super.getContextState(), grid: this.props.grid };
     }
 
     getNativeFormProps() {
       const error = this.getContextError();
-      const {
-        className,
-        grid, // eslint-disable-line no-unused-vars
-
-        ...props
-      } = super.getNativeFormProps();
+      const props = super.getNativeFormProps();
 
       return {
-        ...props,
-        className: classnames('form', { error }, className),
+        ...omit(props, ['grid']),
+        className: classnames('form', { error }, props.className),
       };
     }
   }

--- a/packages/uniforms-bootstrap4/src/DateField.tsx
+++ b/packages/uniforms-bootstrap4/src/DateField.tsx
@@ -30,9 +30,7 @@ function Date({
   name,
   onChange,
   placeholder,
-  showInlineError,
   value,
-  wrapClassName,
   ...props
 }: DateFieldProps) {
   return wrapField(

--- a/packages/uniforms-bootstrap4/src/ListField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListField.tsx
@@ -16,7 +16,7 @@ export type ListFieldProps = HTMLFieldProps<
   {
     addIcon?: ReactNode;
     initialCount?: number;
-    itemProps?: {};
+    itemProps?: object;
     removeIcon?: ReactNode;
   }
 >;

--- a/packages/uniforms-bootstrap4/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListItemField.tsx
@@ -14,7 +14,6 @@ export type ListItemFieldProps = {
 function ListItem({
   children = <AutoField className="col-11" label={null} name="" />,
   removeIcon,
-  ...props
 }: ListItemFieldProps) {
   return (
     <div className="row">

--- a/packages/uniforms-bootstrap4/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap4/src/LongTextField.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import omit from 'lodash/omit';
 import React, { Ref } from 'react';
 import { connectField, HTMLFieldProps } from 'uniforms';
 

--- a/packages/uniforms-bootstrap4/src/NestField.tsx
+++ b/packages/uniforms-bootstrap4/src/NestField.tsx
@@ -18,7 +18,6 @@ function Nest({
   fields,
   itemProps,
   label,
-  name,
   showInlineError,
   ...props
 }: NestFieldProps) {

--- a/packages/uniforms-bootstrap4/src/NumField.tsx
+++ b/packages/uniforms-bootstrap4/src/NumField.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import omit from 'lodash/omit';
 import React, { Ref } from 'react';
 import { connectField, HTMLFieldProps } from 'uniforms';
 

--- a/packages/uniforms-bootstrap4/src/SubmitField.tsx
+++ b/packages/uniforms-bootstrap4/src/SubmitField.tsx
@@ -18,7 +18,6 @@ function SubmitField({
   disabled,
   inputClassName,
   inputRef,
-  name,
   value,
   wrapClassName,
   ...props

--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -1,10 +1,4 @@
-import {
-  GraphQLInputObjectType,
-  GraphQLObjectType,
-  GraphQLString,
-  buildASTSchema,
-  parse,
-} from 'graphql';
+import { GraphQLString, buildASTSchema, parse } from 'graphql';
 import { GraphQLBridge } from 'uniforms-bridge-graphql';
 
 describe('GraphQLBridge', () => {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -93,9 +93,9 @@ export default class SimpleSchema2Bridge extends Bridge {
   // eslint-disable-next-line complexity
   getProps(name: string, props: Record<string, any> = {}) {
     // eslint-disable-next-line prefer-const
-    let { optional, type, uniforms, ...field } = this.getField(name);
+    const { optional, type, uniforms, ...contextField } = this.getField(name);
 
-    field = { ...field, required: !optional };
+    const field = { ...contextField, required: !optional };
 
     if (uniforms) {
       if (typeof uniforms === 'string' || typeof uniforms === 'function') {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -92,10 +92,8 @@ export default class SimpleSchema2Bridge extends Bridge {
 
   // eslint-disable-next-line complexity
   getProps(name: string, props: Record<string, any> = {}) {
-    // eslint-disable-next-line prefer-const
     const { optional, type, uniforms, ...contextField } = this.getField(name);
-
-    const field = { ...contextField, required: !optional };
+    let field = { ...contextField, required: !optional };
 
     if (uniforms) {
       if (typeof uniforms === 'string' || typeof uniforms === 'function') {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -92,8 +92,7 @@ export default class SimpleSchema2Bridge extends Bridge {
 
   // eslint-disable-next-line complexity
   getProps(name: string, props: Record<string, any> = {}) {
-    // Type should be omitted.
-    // eslint-disable-next-line no-unused-vars, prefer-const
+    // eslint-disable-next-line prefer-const
     let { optional, type, uniforms, ...field } = this.getField(name);
 
     field = { ...field, required: !optional };

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -1,9 +1,9 @@
 import invariant from 'invariant';
 import cloneDeep from 'lodash/cloneDeep';
 import memoize from 'lodash/memoize';
-import { Bridge, joinName } from 'uniforms';
 // @ts-ignore
-import { SimpleSchema } from 'meteor/aldeed:simple-schema'; // eslint-disable-line
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { Bridge, joinName } from 'uniforms';
 
 export default class SimpleSchemaBridge extends Bridge {
   constructor(public schema: SimpleSchema) {
@@ -85,8 +85,7 @@ export default class SimpleSchemaBridge extends Bridge {
 
   // eslint-disable-next-line complexity
   getProps(name: string, props: Record<string, any> = {}) {
-    // Type should be omitted.
-    // eslint-disable-next-line no-unused-vars, prefer-const
+    // eslint-disable-next-line prefer-const
     let { optional, type, uniforms, ...field } = this.getField(name);
 
     field = { ...field, required: !optional };

--- a/packages/uniforms-bridge-simple-schema/src/register.ts
+++ b/packages/uniforms-bridge-simple-schema/src/register.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
-import { Match } from 'meteor/check'; // eslint-disable-line
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 // @ts-ignore
-import { SimpleSchema } from 'meteor/aldeed:simple-schema'; // eslint-disable-line
+import { Match } from 'meteor/check';
 import { filterDOMProps } from 'uniforms';
 
 // Register custom property.

--- a/packages/uniforms-material/__tests__/ListAddField.tsx
+++ b/packages/uniforms-material/__tests__/ListAddField.tsx
@@ -8,7 +8,7 @@ import mount from './_mount';
 
 const Icon = () => <i />;
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: [] } },

--- a/packages/uniforms-material/__tests__/ListDelField.tsx
+++ b/packages/uniforms-material/__tests__/ListDelField.tsx
@@ -8,7 +8,7 @@ import mount from './_mount';
 
 const Icon = () => <i />;
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: ['x', 'y', 'z'] } },

--- a/packages/uniforms-material/__tests__/_createContext.ts
+++ b/packages/uniforms-material/__tests__/_createContext.ts
@@ -5,7 +5,7 @@ import createSchema from './_createSchema';
 const randomId = randomIds();
 
 export default function createContext(
-  schema?: {},
+  schema?: object,
   context?: Partial<Context<any>>,
 ): { context: Context<any> } {
   return {

--- a/packages/uniforms-material/src/BoolField.tsx
+++ b/packages/uniforms-material/src/BoolField.tsx
@@ -3,6 +3,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormLabel from '@material-ui/core/FormLabel';
 import Switch, { SwitchProps } from '@material-ui/core/Switch';
+import omit from 'lodash/omit';
 import React, { Ref } from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
@@ -52,7 +53,7 @@ function Bool(props: BoolFieldProps) {
             }
             ref={inputRef as Ref<HTMLButtonElement>}
             value={name}
-            {...filterDOMProps(props)}
+            {...omit(filterDOMProps(props), ['helperText'])}
           />
         }
         label={transform ? transform(label as string) : label}

--- a/packages/uniforms-material/src/ListField.tsx
+++ b/packages/uniforms-material/src/ListField.tsx
@@ -14,7 +14,7 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = FieldProps<
   unknown[],
   ListProps,
-  { addIcon?: ReactNode; initialCount?: number; itemProps?: {} }
+  { addIcon?: ReactNode; initialCount?: number; itemProps?: object }
 >;
 
 function List({
@@ -23,7 +23,6 @@ function List({
   initialCount,
   itemProps,
   label,
-  name,
   value,
   ...props
 }: ListFieldProps) {

--- a/packages/uniforms-material/src/LongTextField.tsx
+++ b/packages/uniforms-material/src/LongTextField.tsx
@@ -1,5 +1,5 @@
 import TextField, { StandardTextFieldProps } from '@material-ui/core/TextField';
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
 export type LongTextFieldProps = FieldProps<string, StandardTextFieldProps>;

--- a/packages/uniforms-material/src/NestField.tsx
+++ b/packages/uniforms-material/src/NestField.tsx
@@ -19,7 +19,6 @@ function Nest({
   itemProps,
   label,
   margin = 'dense',
-  name,
   ...props
 }: NestFieldProps) {
   return wrapField(

--- a/packages/uniforms-material/src/RadioField.tsx
+++ b/packages/uniforms-material/src/RadioField.tsx
@@ -2,6 +2,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormLabel from '@material-ui/core/FormLabel';
 import RadioMaterial, { RadioProps } from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
+import omit from 'lodash/omit';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
@@ -23,7 +24,6 @@ export type RadioFieldProps = FieldProps<
 
 function Radio({
   allowedValues,
-  checkboxes,
   disabled,
   fullWidth = true,
   id,
@@ -54,7 +54,11 @@ function Radio({
     >
       {allowedValues?.map(item => (
         <FormControlLabel
-          control={<RadioMaterial {...filterDOMProps(props)} />}
+          control={
+            <RadioMaterial
+              {...omit(filterDOMProps(props), ['checkboxes', 'helperText'])}
+            />
+          }
           key={item}
           label={transform ? transform(item) : item}
           value={`${item}`}

--- a/packages/uniforms-material/src/SelectField.tsx
+++ b/packages/uniforms-material/src/SelectField.tsx
@@ -10,7 +10,7 @@ import Switch, { SwitchProps } from '@material-ui/core/Switch';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import omit from 'lodash/omit';
 import xor from 'lodash/xor';
-import React, { ReactNode, Ref } from 'react';
+import React, { Ref } from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
 import wrapField from './wrapField';

--- a/packages/uniforms-semantic/__tests__/ListAddField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListAddField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: [] } },

--- a/packages/uniforms-semantic/__tests__/ListDelField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListDelField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: ['x', 'y', 'z'] } },

--- a/packages/uniforms-semantic/__tests__/_createContext.ts
+++ b/packages/uniforms-semantic/__tests__/_createContext.ts
@@ -5,7 +5,7 @@ import createSchema from './_createSchema';
 const randomId = randomIds();
 
 export default function createContext(
-  schema?: {},
+  schema?: object,
   context?: Partial<Context<any>>,
 ): { context: Context<any> } {
   return {

--- a/packages/uniforms-semantic/src/ListField.tsx
+++ b/packages/uniforms-semantic/src/ListField.tsx
@@ -8,7 +8,7 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = HTMLFieldProps<
   unknown[],
   HTMLDivElement,
-  { initialCount?: number; itemProps?: {} }
+  { initialCount?: number; itemProps?: object }
 >;
 
 function List({
@@ -20,7 +20,6 @@ function List({
   initialCount,
   itemProps,
   label,
-  name,
   required,
   showInlineError,
   value,

--- a/packages/uniforms-semantic/src/NestField.tsx
+++ b/packages/uniforms-semantic/src/NestField.tsx
@@ -20,7 +20,6 @@ function Nest({
   grouped,
   itemProps,
   label,
-  name,
   showInlineError,
   ...props
 }: NestFieldProps) {

--- a/packages/uniforms-semantic/src/RadioField.tsx
+++ b/packages/uniforms-semantic/src/RadioField.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import omit from 'lodash/omit';
 import React from 'react';
 import { connectField, filterDOMProps, HTMLFieldProps } from 'uniforms';
 
@@ -20,7 +21,6 @@ export type RadioFieldProps = HTMLFieldProps<
 
 function Radio({
   allowedValues,
-  checkboxes, // eslint-disable-line no-unused-vars
   className,
   disabled,
   error,
@@ -38,7 +38,7 @@ function Radio({
   return (
     <div
       className={classnames(className, { disabled, error }, 'grouped fields')}
-      {...filterDOMProps(props)}
+      {...omit(filterDOMProps(props), ['checkboxes'])}
     >
       {label && (
         <div className={classnames({ required }, 'field')}>

--- a/packages/uniforms-semantic/src/SubmitField.tsx
+++ b/packages/uniforms-semantic/src/SubmitField.tsx
@@ -11,7 +11,6 @@ export default function SubmitField({
   className,
   disabled,
   inputRef,
-  name,
   value,
   ...props
 }: SubmitFieldProps) {

--- a/packages/uniforms-unstyled/__tests__/ListAddField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListAddField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: [] } },

--- a/packages/uniforms-unstyled/__tests__/ListDelField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListDelField.tsx
@@ -6,7 +6,7 @@ import createContext from './_createContext';
 import mount from './_mount';
 
 const onChange = jest.fn();
-const context = (schema?: {}) =>
+const context = (schema?: object) =>
   createContext(
     merge({ x: { type: Array, maxCount: 3 }, 'x.$': String }, schema),
     { onChange, model: { x: ['x', 'y', 'z'] } },

--- a/packages/uniforms-unstyled/__tests__/_createContext.ts
+++ b/packages/uniforms-unstyled/__tests__/_createContext.ts
@@ -5,7 +5,7 @@ import createSchema from './_createSchema';
 const randomId = randomIds();
 
 export default function createContext(
-  schema?: {},
+  schema?: object,
   context?: Partial<Context<any>>,
 ): { context: Context<any> } {
   return {

--- a/packages/uniforms-unstyled/src/NestField.tsx
+++ b/packages/uniforms-unstyled/src/NestField.tsx
@@ -14,7 +14,6 @@ function Nest({
   fields,
   itemProps,
   label,
-  name,
   ...props
 }: NestFieldProps) {
   return (

--- a/packages/uniforms-unstyled/src/RadioField.tsx
+++ b/packages/uniforms-unstyled/src/RadioField.tsx
@@ -1,3 +1,4 @@
+import omit from 'lodash/omit';
 import React from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 
@@ -19,7 +20,6 @@ export type RadioFieldProps = HTMLFieldProps<
 
 function Radio({
   allowedValues,
-  checkboxes, // eslint-disable-line no-unused-vars
   disabled,
   id,
   label,
@@ -30,7 +30,7 @@ function Radio({
   ...props
 }: RadioFieldProps) {
   return (
-    <div {...filterDOMProps(props)}>
+    <div {...omit(filterDOMProps(props), ['checkboxes'])}>
       {label && <label>{label}</label>}
 
       {allowedValues?.map(item => (

--- a/packages/uniforms/__tests__/ValidatedForm.tsx
+++ b/packages/uniforms/__tests__/ValidatedForm.tsx
@@ -1,4 +1,3 @@
-import { ReactWrapper } from 'enzyme';
 import React from 'react';
 import { ValidatedForm } from 'uniforms';
 import { SimpleSchemaBridge } from 'uniforms-bridge-simple-schema';

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -4,6 +4,7 @@ import omit from 'lodash/omit';
 import setWith from 'lodash/setWith';
 
 // FIXME: This import is needed to correctly build AutoForm.d.ts file.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { BaseForm } from './BaseForm';
 import {
   ValidatedQuickForm,
@@ -53,6 +54,7 @@ export function Auto<Base extends typeof ValidatedQuickForm>(Base: Base) {
       return omit(super.getNativeFormProps(), ['onChangeModel']);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getModel(mode: ModelTransformMode) {
       return this.state.model;
     }

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -1,6 +1,5 @@
 import clone from 'lodash/clone';
 import get from 'lodash/get';
-import isFunction from 'lodash/isFunction';
 import omit from 'lodash/omit';
 import setWith from 'lodash/setWith';
 import React, { Component, SyntheticEvent } from 'react';
@@ -84,6 +83,7 @@ export class BaseForm<
     this.mounted = true;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   componentDidUpdate(prevProps: Props, prevState: State, snapshot: never) {}
 
   componentWillUnmount() {

--- a/packages/uniforms/src/types.ts
+++ b/packages/uniforms/src/types.ts
@@ -2,7 +2,7 @@ import { HTMLProps, ReactNode, SyntheticEvent } from 'react';
 
 import { Bridge } from './Bridge';
 
-export type ChangedMap<T> = T extends {}
+export type ChangedMap<T> = T extends object
   ? { [P in keyof T]?: ChangedMap<T[P]> }
   : Record<string, void>;
 
@@ -27,10 +27,10 @@ export type Context<Model> = {
 };
 
 export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends {} ? DeepPartial<T[P]> : T[P];
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
-export type FieldProps<Value, Base, Extension = {}> = Override<
+export type FieldProps<Value, Base, Extension = object> = Override<
   Base,
   GuaranteedProps<Value> & Extension
 >;
@@ -55,7 +55,7 @@ export type GuaranteedProps<Value> = {
   value?: Value;
 };
 
-export type HTMLFieldProps<Value, Element, Extension = {}> = FieldProps<
+export type HTMLFieldProps<Value, Element, Extension = object> = FieldProps<
   Value,
   HTMLProps<Element>,
   Extension

--- a/website/components/Button.tsx
+++ b/website/components/Button.tsx
@@ -1,6 +1,6 @@
 import Link from '@docusaurus/Link';
 import classNames from 'classnames';
-import React, { ElementType, ReactNode } from 'react';
+import React from 'react';
 
 import styles from '../index.module.css';
 

--- a/website/components/Heading.tsx
+++ b/website/components/Heading.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { HTMLProps } from 'react';
+import React from 'react';
 
 import styles from '../index.module.css';
 

--- a/website/components/Playground.tsx
+++ b/website/components/Playground.tsx
@@ -156,7 +156,7 @@ class PlaygroundPreview extends Component<any, any> {
         });
     }
     if (asyncOnValidate) {
-      props.onValidate = (model: {}, error: Error) =>
+      props.onValidate = (model: object, error: Error) =>
         new Promise(resolve => {
           setTimeout(() => {
             resolve(error);

--- a/website/docusaurus.d.ts
+++ b/website/docusaurus.d.ts
@@ -11,7 +11,7 @@ declare module '@theme/*' {
 declare module '*.md' {
   // eslint-disable-next-line import/order
   import { ComponentType } from 'react';
-  const Component: ComponentType<{}>;
+  const Component: ComponentType<object>;
   export = Component;
 }
 

--- a/website/lib/autoresize.ts
+++ b/website/lib/autoresize.ts
@@ -1,11 +1,5 @@
 import get from 'lodash/get';
-import React, {
-  RefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
 function handleResize(
   ref: RefObject<HTMLIFrameElement | undefined>,

--- a/website/lib/stats.ts
+++ b/website/lib/stats.ts
@@ -14,7 +14,7 @@ function cacheGet(key: string) {
   }
 }
 
-function cacheSet(key: string, data: {}, expires: number) {
+function cacheSet(key: string, data: unknown, expires: number) {
   try {
     localStorage.setItem(cacheKey(key), JSON.stringify({ data, expires }));
   } catch (error) {

--- a/website/lib/utils.ts
+++ b/website/lib/utils.ts
@@ -12,7 +12,7 @@ const compress = (string: string) =>
 const decompress = (string: string) =>
   LZString.decompressFromBase64(string.replace(/-/g, '+').replace(/_/g, '/'));
 
-export function updateQuery(state: {}) {
+export function updateQuery(state: object) {
   try {
     const query = pick(state, URL_KEYS);
     const serialized = JSON.stringify(query);

--- a/website/pages-parts/LandingPage/CommercialServices.tsx
+++ b/website/pages-parts/LandingPage/CommercialServices.tsx
@@ -1,4 +1,3 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -8,9 +7,6 @@ import { Subtitle } from '../../components/Subtitle';
 import styles from '../../index.module.css';
 
 export function CommercialServices() {
-  const context = useDocusaurusContext();
-  const { email } = context.siteConfig.customFields;
-
   return (
     <div
       className={classNames(

--- a/website/pages-parts/LandingPage/OpenSource.tsx
+++ b/website/pages-parts/LandingPage/OpenSource.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { ComponentType } from 'react';
+import React from 'react';
 import { Download, GitBranch, Star } from 'react-feather';
 
 import { Badge } from '../../components/Badge';

--- a/website/plugins/docusaurus-plugin-hotjar/src/index.js
+++ b/website/plugins/docusaurus-plugin-hotjar/src/index.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
 
+// eslint-disable-next-line func-names
 module.exports = function () {
   return {
     name: 'docusaurus-plugin-hotjar',


### PR DESCRIPTION
This change reenables `@typescript-eslint/no-unused-vars`, makes a step towards `@typescript-eslint/ban-types` (I still consider `object` fine in most of our code), and gets rid of some other ESLint related warnings.