### PR TITLE
Unified NumField behavior (fixes #856).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next:
+## Next
 
 - **Fixed:** Missing `step` prop in `NumField` in `uniforms-material`. [\#855](https://github.com/vazco/uniforms/issues/855)
 - **Fixed:** Unified `NumField` behavior across themes. [\#856](https://github.com/vazco/uniforms/issues/856)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next:
+
+- **Fixed:** Unified `NumField` behavior across themes. [\#856](https://github.com/vazco/uniforms/issues/856)
+
 ## [v3.0.0](https://github.com/vazco/uniforms/tree/v3.0.0) (2021-01-14)
 
 ## [v3.0.0-rc.8](https://github.com/vazco/uniforms/tree/v3.0.0-rc.8) (2020-12-05)

--- a/packages/uniforms-antd/__tests__/NumField.tsx
+++ b/packages/uniforms-antd/__tests__/NumField.tsx
@@ -156,9 +156,7 @@ test('<NumField> - renders an InputNumber which correctly reacts on change (deci
   expect(
     wrapper.find('input').simulate('change', { target: { value: '2.5' } }),
   ).toBeTruthy();
-
-  // That's how AntD is doing it.
-  expect(onChange).toHaveBeenLastCalledWith('x', 2.5);
+  expect(onChange).toHaveBeenLastCalledWith('x', 2);
 });
 
 test('<NumField> - renders an InputNumber which correctly reacts on change (empty)', () => {
@@ -173,24 +171,6 @@ test('<NumField> - renders an InputNumber which correctly reacts on change (empt
   expect(wrapper.find('input')).toHaveLength(1);
   expect(
     wrapper.find('input').simulate('change', { target: { value: '' } }),
-  ).toBeTruthy();
-
-  // That's how AntD is doing it.
-  expect(onChange).toHaveBeenLastCalledWith('x', '');
-});
-
-test('<NumField> - renders an InputNumber which correctly reacts on change (incorrect)', () => {
-  const onChange = jest.fn();
-
-  const element = <NumField name="x" />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Number } }, { onChange }),
-  );
-
-  expect(wrapper.find('input')).toHaveLength(1);
-  expect(
-    wrapper.find('input').simulate('change', { target: { value: 'xyz' } }),
   ).toBeTruthy();
   expect(onChange).toHaveBeenLastCalledWith('x', undefined);
 });

--- a/packages/uniforms-antd/src/NumField.tsx
+++ b/packages/uniforms-antd/src/NumField.tsx
@@ -4,8 +4,6 @@ import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
-const noneIfNaN = (x: number) => (isNaN(x) ? undefined : x);
-
 export type NumFieldProps = FieldProps<
   number,
   // FIXME: Why `onReset` fails with `wrapField`?
@@ -21,7 +19,11 @@ function Num(props: NumFieldProps) {
       max={props.max}
       min={props.min}
       name={props.name}
-      onChange={value => props.onChange(noneIfNaN(value as number))}
+      onChange={event => {
+        const parse = props.decimal ? parseFloat : parseInt;
+        const value = parse('' + event);
+        props.onChange(isNaN(value) ? undefined : value);
+      }}
       placeholder={props.placeholder}
       ref={props.inputRef}
       step={props.step || (props.decimal ? 0.01 : 1)}


### PR DESCRIPTION
This change solves #856, unifying `NumField` behavior across themes. In short, `NumField` in `uniforms-antd` uses the `InputNumber` component, which keeps input value in an internal state, syncing it back on blur. It stays like this, but now it'll revert to the default value on blur (the value will be removed from `model`).