### PR TITLE
Added error styling for ListField in uniforms-antd (closes #844).

### DIFF
--- a/packages/uniforms-antd/__tests__/ListField.tsx
+++ b/packages/uniforms-antd/__tests__/ListField.tsx
@@ -144,3 +144,19 @@ test('<ListField> - renders correct error style', () => {
     'rgb(255, 85, 0)',
   );
 });
+
+test('<ListField> - renders correct error style (with specified style prop)', () => {
+  const error = new Error();
+  const element = (
+    <ListField name="x" error={error} style={{ marginLeft: '8px' }} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+  );
+
+  expect(wrapper.find('div').at(0).prop('style')).toHaveProperty(
+    'marginLeft',
+    '8px',
+  );
+});

--- a/packages/uniforms-antd/__tests__/ListField.tsx
+++ b/packages/uniforms-antd/__tests__/ListField.tsx
@@ -118,15 +118,16 @@ test('<ListField> - renders children with correct name (value)', () => {
   expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
-test('<ListField> - renders correct error text (specified)', () => {
+test('<ListField> - renders correct error style', () => {
   const error = new Error();
-  const element = (
-    <ListField name="x" error={error} errorMessage="Error" showInlineError />
-  );
+  const element = <ListField name="x" error={error} />;
   const wrapper = mount(
     element,
     createContext({ x: { type: Array }, 'x.$': { type: String } }),
   );
 
-  expect(wrapper.find('div > div').at(0).text()).toBe('Error');
+  expect(wrapper.find('div').at(0).prop('style')).toHaveProperty(
+    'borderColor',
+    'rgb(255, 85, 0)',
+  );
 });

--- a/packages/uniforms-antd/__tests__/ListField.tsx
+++ b/packages/uniforms-antd/__tests__/ListField.tsx
@@ -118,6 +118,19 @@ test('<ListField> - renders children with correct name (value)', () => {
   expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
+test('<ListField> - renders correct error text (specified)', () => {
+  const error = new Error();
+  const element = (
+    <ListField name="x" error={error} errorMessage="Error" showInlineError />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+  );
+
+  expect(wrapper.find('div > div').at(0).text()).toBe('Error');
+});
+
 test('<ListField> - renders correct error style', () => {
   const error = new Error();
   const element = <ListField name="x" error={error} />;

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -1,5 +1,4 @@
 import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
-import Form from 'antd/lib/form';
 import Tooltip from 'antd/lib/tooltip';
 import classNames from 'classnames';
 import React, {
@@ -49,14 +48,14 @@ function List({
   wrapperCol,
   ...props
 }: ListFieldProps) {
-  const borderStyle = error
+  const wrapperStyle = error
     ? { borderColor: 'rgb(255, 85, 0)', ...style }
     : style;
 
   return (
     <div
       {...filterDOMProps(props)}
-      style={borderStyle}
+      style={wrapperStyle}
       className={classNames([className, 'ant-list', 'ant-list-bordered'])}
     >
       {!!label && (
@@ -72,6 +71,7 @@ function List({
           )}
         </div>
       )}
+
       {!!(error && showInlineError) && <div>{errorMessage}</div>}
 
       {value?.map((item, itemIndex) =>

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -32,6 +32,8 @@ const defaultStyle = {
   padding: '10px',
 };
 
+const errorStyle = { borderColor: 'rgb(255, 85, 0)' };
+
 function List({
   children = <ListItemField name="$" />,
   className,
@@ -49,7 +51,9 @@ function List({
   ...props
 }: ListFieldProps) {
   const wrapperStyle = error
-    ? { borderColor: 'rgb(255, 85, 0)', ...style }
+    ? style
+      ? { ...errorStyle, ...style }
+      : errorStyle
     : style;
 
   return (

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -1,13 +1,14 @@
 import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
+import Form from 'antd/lib/form';
 import Tooltip from 'antd/lib/tooltip';
 import classNames from 'classnames';
 import React, {
   Children,
-  ReactNode,
   cloneElement,
   isValidElement,
+  ReactNode,
 } from 'react';
-import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
+import { connectField, filterDOMProps, HTMLFieldProps } from 'uniforms';
 
 import ListAddField from './ListAddField';
 import ListItemField from './ListItemField';
@@ -48,43 +49,57 @@ function List({
   wrapperCol,
   ...props
 }: ListFieldProps) {
+  const labelNode = !!label && (
+    <div>
+      {label}
+      {!!info && (
+        <span>
+          &nbsp;
+          <Tooltip title={info}>
+            <QuestionCircleOutlined />
+          </Tooltip>
+        </span>
+      )}
+    </div>
+  );
+
+  const borderStyle = {
+    ...(error ? { borderColor: 'rgb(255, 85, 0)' } : {}),
+    ...style,
+  };
+
   return (
     <div
       {...filterDOMProps(props)}
-      style={style}
+      style={borderStyle}
       className={classNames([className, 'ant-list', 'ant-list-bordered'])}
     >
-      {label && (
-        <div>
-          {label}
-          {!!info && (
-            <span>
-              &nbsp;
-              <Tooltip title={info}>
-                <QuestionCircleOutlined />
-              </Tooltip>
-            </span>
+      <Form.Item
+        label={labelNode}
+        hasFeedback
+        style={{ marginBottom: 0 }}
+        validateStatus={error ? 'error' : ''}
+      >
+        <div style={{ ...(error ? { marginRight: '32px' } : {}) }}>
+          {!!(error && showInlineError) && <div>{errorMessage}</div>}
+
+          {value?.map((item, itemIndex) =>
+            Children.map(children, (child, childIndex) =>
+              isValidElement(child)
+                ? cloneElement(child, {
+                    key: `${itemIndex}-${childIndex}`,
+                    name: child.props.name?.replace('$', '' + itemIndex),
+                    labelCol,
+                    wrapperCol,
+                    ...itemProps,
+                  })
+                : child,
+            ),
           )}
+
+          <ListAddField name="$" initialCount={initialCount} />
         </div>
-      )}
-
-      {!!(error && showInlineError) && <div>{errorMessage}</div>}
-
-      {value?.map((item, itemIndex) =>
-        Children.map(children, (child, childIndex) =>
-          isValidElement(child)
-            ? cloneElement(child, {
-                key: `${itemIndex}-${childIndex}`,
-                name: child.props.name?.replace('$', '' + itemIndex),
-                labelCol,
-                wrapperCol,
-                ...itemProps,
-              })
-            : child,
-        ),
-      )}
-
-      <ListAddField name="$" initialCount={initialCount} />
+      </Form.Item>
     </div>
   );
 }

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -49,24 +49,9 @@ function List({
   wrapperCol,
   ...props
 }: ListFieldProps) {
-  const labelNode = !!label && (
-    <div>
-      {label}
-      {!!info && (
-        <span>
-          &nbsp;
-          <Tooltip title={info}>
-            <QuestionCircleOutlined />
-          </Tooltip>
-        </span>
-      )}
-    </div>
-  );
-
-  const borderStyle = {
-    ...(error ? { borderColor: 'rgb(255, 85, 0)' } : {}),
-    ...style,
-  };
+  const borderStyle = error
+    ? { borderColor: 'rgb(255, 85, 0)', ...style }
+    : style;
 
   return (
     <div
@@ -74,32 +59,36 @@ function List({
       style={borderStyle}
       className={classNames([className, 'ant-list', 'ant-list-bordered'])}
     >
-      <Form.Item
-        label={labelNode}
-        hasFeedback
-        style={{ marginBottom: 0 }}
-        validateStatus={error ? 'error' : ''}
-      >
-        <div style={{ ...(error ? { marginRight: '32px' } : {}) }}>
-          {!!(error && showInlineError) && <div>{errorMessage}</div>}
-
-          {value?.map((item, itemIndex) =>
-            Children.map(children, (child, childIndex) =>
-              isValidElement(child)
-                ? cloneElement(child, {
-                    key: `${itemIndex}-${childIndex}`,
-                    name: child.props.name?.replace('$', '' + itemIndex),
-                    labelCol,
-                    wrapperCol,
-                    ...itemProps,
-                  })
-                : child,
-            ),
+      {!!label && (
+        <div>
+          {label}
+          {!!info && (
+            <span>
+              &nbsp;
+              <Tooltip title={info}>
+                <QuestionCircleOutlined />
+              </Tooltip>
+            </span>
           )}
-
-          <ListAddField name="$" initialCount={initialCount} />
         </div>
-      </Form.Item>
+      )}
+      {!!(error && showInlineError) && <div>{errorMessage}</div>}
+
+      {value?.map((item, itemIndex) =>
+        Children.map(children, (child, childIndex) =>
+          isValidElement(child)
+            ? cloneElement(child, {
+                key: `${itemIndex}-${childIndex}`,
+                name: child.props.name?.replace('$', '' + itemIndex),
+                labelCol,
+                wrapperCol,
+                ...itemProps,
+              })
+            : child,
+        ),
+      )}
+
+      <ListAddField name="$" initialCount={initialCount} />
     </div>
   );
 }


### PR DESCRIPTION
This PR introduces ListField error stylings in uniforms-antd. 
Based on https://github.com/vazco/uniforms/issues/844.

![image](https://user-images.githubusercontent.com/17573948/106763815-7fe6d200-6637-11eb-83b8-d8c3cc57a047.png)
![image](https://user-images.githubusercontent.com/17573948/106763998-b02e7080-6637-11eb-8be8-584f0d6d79df.png)

No-error styling for comparison:
![image](https://user-images.githubusercontent.com/17573948/106763940-9f7dfa80-6637-11eb-8741-0e57246a2701.png)
![image](https://user-images.githubusercontent.com/17573948/106764281-ef5cc180-6637-11eb-8b65-997dad5102e9.png)

