### PR TITLE
Configured sideEffects (closes #843).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Added:** The [`sideEffects`](https://webpack.js.org/guides/tree-shaking/) flag to let bundlers do better at tree shaking. [\#843](https://github.com/vazco/uniforms/issues/843)
+
 ## [v3.1.0](https://github.com/vazco/uniforms/tree/v3.1.0) (2021-02-03)
 
 - **Added:** New `readOnly` prop in all form and field components. [\#674](https://github.com/vazco/uniforms/issues/674)

--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -4,6 +4,11 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": [
+    "es5/wrapField.js",
+    "es6/wrapField.js",
+    "src/wrapField.tsx"
+  ],
   "description": "Ant Design UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-antd",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bootstrap3/package.json
+++ b/packages/uniforms-bootstrap3/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": false,
   "description": "Bootstrap3 UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bootstrap3",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bootstrap4/package.json
+++ b/packages/uniforms-bootstrap4/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": false,
   "description": "Bootstrap4 UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bootstrap4",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-graphql/package.json
+++ b/packages/uniforms-bridge-graphql/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": false,
   "description": "GraphQL schema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-graphql",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-json-schema/package.json
+++ b/packages/uniforms-bridge-json-schema/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": false,
   "description": "JSONSchema schema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-json-schema",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-simple-schema-2/package.json
+++ b/packages/uniforms-bridge-simple-schema-2/package.json
@@ -4,6 +4,11 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": [
+    "es5/register.js",
+    "es6/register.js",
+    "src/register.ts"
+  ],
   "description": "SimpleSchema 2 bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-simple-schema-2",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-simple-schema/package.json
+++ b/packages/uniforms-bridge-simple-schema/package.json
@@ -4,6 +4,11 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": [
+    "es5/register.js",
+    "es6/register.js",
+    "src/register.ts"
+  ],
   "description": "SimpleSchema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-simple-schema",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-material/package.json
+++ b/packages/uniforms-material/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": false,
   "description": "Material UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-material",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-semantic/package.json
+++ b/packages/uniforms-semantic/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": false,
   "description": "Semantic UI components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-semantic",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-unstyled/package.json
+++ b/packages/uniforms-unstyled/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": false,
   "description": "Unstyled components for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-unstyled",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -4,6 +4,14 @@
   "license": "MIT",
   "main": "es5/index.js",
   "module": "es6/index.js",
+  "sideEffects": [
+    "es5/filterDOMProps.js",
+    "es5/randomIds.js",
+    "es6/filterDOMProps.js",
+    "es6/randomIds.js",
+    "src/filterDOMProps.ts",
+    "src/randomIds.ts"
+  ],
   "description": "Core package of uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms",
   "bugs": "https://github.com/vazco/uniforms/issues",


### PR DESCRIPTION
This change configures [`sideEffects`](https://webpack.js.org/guides/tree-shaking/) in all packaged in order to let bundlers do better at tree shaking.