### PR TITLE
Updated contributing guidelines.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,36 +1,35 @@
 # How to contribute
 
-Third-party patches are essential for keeping every project great. We simply can't access the huge number of use cases. We want to keep it as easy as possible to contribute changes that get things working in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+Third-party patches are essential for keeping every project great. We simply can't access the huge number of use cases. We want to keep it as easy as possible to contribute changes that get things working in your environment. There are a few guidelines that we need contributors to follow to have a chance of keeping on top of things.
+
+Our kanban board is public and available [here](https://github.com/orgs/vazco/projects/1).
 
 ## Getting started
 
-- Make sure you have a [GitHub account](https://github.com/signup/free)
+- Make sure you have a [GitHub account](https://github.com/signup/free).
 - Submit a ticket for your issue, assuming one does not already exist.
-  - Clearly describe the issue including steps to reproduce if it is a bug.
-  - Make sure you fill in the earliest version that you know has the issue.
+  - It is OK to comment an already closed issue or review already merged PR.
+    - If needed, we'll reopen it or open a new one.
+  - Clearly describe the issue, including steps to reproduce if it is a bug.
+    - If possible, include a reproduction using our [playground](https://uniforms.tools/playground) or [CodeSandbox template](https://codesandbox.io/s/github/vazco/uniforms/tree/master/reproductions).
+  - Affected versions of the core, bridge, and theme packages you are aware of.
+    - Include other versions as well, if you think it may help (React, browser, etc.).
 
 ## Making changes
 
 - Create a fork from where you want to base your work.
-- Make commits of logical units.
+- Clone the repo and run `npm ci` **in the top-level only**.
+  - Make sure you are using `npm` that understands the `package-lock.json` format. At the moment, it's at least v7.
 - Make sure your commit messages are in the proper format:
-  - Bugfix:
-    - `Asynchronous validation (closes #17).`
-    - `Skip onSubmit until rendered (closes #15).`
+  - Bugfix or feature:
+    - `Implemented asynchronous validation (closes #17).`
+    - `Disabled onSubmit until first render (closes #15).`
   - Other changes:
-    - `Refactoring core package.`
-    - `Updated README.`
-- Make sure you have added the necessary tests for your changes.
-- Make sure your code passes _all_ tests:
-  - `npm test`
+    - `Refactored joinName tests.`
+    - `Updated README.md.`
+- Make sure you have added the necessary tests for your changes. Do not worry though, the Codecov bot will report it in the pull request.
+- Make sure your code passes _all_ tests: `npm test`.
 
-## Styling
+## _Work in progress_ PRs are also welcome
 
-- If you submit a PR with any code, passing ESLint should be enough _(everything else will be reported in your PR review)_.
-- If you submit a PR with any documentation, code blocks should pass ESLint and code comments should be wrapped at 80 characters.
-
-<br>
-
-# _Work in progress_ PRs are also welcome
-
-If you can't/couldn't/won't finish your PR, submit it anyway - maybe someone else will continue your work. Also, if you don't know how to achieve your desired feature - file an issue for it - maybe someone else will implement it.
+If you can't or won't finish your PR, submit it anyway - maybe someone else will continue your work. If you don't know how to achieve your desired feature - file an issue for it - maybe someone else will implement it.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Our kanban board is public and available [here](https://github.com/orgs/vazco/pr
     - If needed, we'll reopen it or open a new one.
   - Clearly describe the issue, including steps to reproduce if it is a bug.
     - If possible, include a reproduction using our [playground](https://uniforms.tools/playground) or [CodeSandbox template](https://codesandbox.io/s/github/vazco/uniforms/tree/master/reproductions).
-  - Affected versions of the core, bridge, and theme packages you are aware of.
+  - Add a list of affected versions of the core, bridge, and theme packages you are aware of.
     - Include other versions as well, if you think it may help (React, browser, etc.).
 
 ## Making changes

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-<!--
-  Before you open an issue, please check if a similar one already exists or has been closed before.
-  We will be grateful for using our reproduction sandbox available at
-  https://codesandbox.io/s/github/vazco/uniforms/tree/master/reproductions
-  whenever a code sample is presented for debugging purposes.
--->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,13 @@
+---
+name: Bug report
+about: Found a bug? Tell us about it!
+---
+
+Before you open an issue, please check if a similar one already exists or has been closed before. Detailed information about the process of contributing can be found in [CONTRIBUTING.md](https://github.com/vazco/uniforms/blob/master/.github/CONTRIBUTING.md).
+
+Let us know what is happening. Do provide us with:
+
+- Affected versions of the core, bridge, and theme packages you are aware of.
+  - Include other versions as well, if you think it may help (React, browser, etc.).
+- Steps to reproduce. If possible, include a reproduction using our [playground](https://uniforms.tools/playground) or [CodeSandbox template](https://codesandbox.io/s/github/vazco/uniforms/tree/master/reproductions).
+- Possible workarounds, if you've found any.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,6 +7,6 @@ Before you open an issue, please check if a similar one already exists or has be
 
 Let us know what you'd like to see. Do provide us with:
 
-- Some motivation why you'd like to see this in uniforms.
+- Motivation why you'd like to see this in uniforms.
 - Examples of how others could use this feature.
 - Possible workarounds, if applicable.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,12 @@
+---
+name: Feature request
+about: Have an idea? Let's talk!
+---
+
+Before you open an issue, please check if a similar one already exists or has been closed before. Detailed information about the process of contributing can be found in [CONTRIBUTING.md](https://github.com/vazco/uniforms/blob/master/.github/CONTRIBUTING.md).
+
+Let us know what you'd like to see. Do provide us with:
+
+- Some motivation why you'd like to see this in uniforms.
+- Examples of how others could use this feature.
+- Possible workarounds, if applicable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,3 @@
-<!-- Before you open a pull request, please check if a similar one already exists or has been closed before. -->
+Before you open a pull request, please check if a similar one already exists or has been closed before. Detailed information about the process of contributing can be found in [CONTRIBUTING.md](https://github.com/vazco/uniforms/blob/master/.github/CONTRIBUTING.md).
+
+Do link all relevant issues and pull requests. If there is none, please do file an issue first to discuss it upfront.


### PR DESCRIPTION
As @michael-vasyliv mentioned in #880, our [`CONTRIBUTING.md`](https://github.com/vazco/uniforms/blob/master/.github/CONTRIBUTING.md) did not mention how to set up the project locally. I updated all of the relevant files: contributing guidelines, pull request template, and issue templates (including the new UX of it).