### PR TITLE
fix(Playground): JSONSchema example does allow `uniforms` property

### DIFF
--- a/website/lib/presets.ts
+++ b/website/lib/presets.ts
@@ -63,7 +63,7 @@ const presets = {
 
   'Address (JSONSchema)': preset`
     (() => {
-      const ajv = new Ajv({ allErrors: true, useDefaults: true });
+      const ajv = new Ajv({ allErrors: true, useDefaults: true, keywords: ["uniforms"] });
       const schema = {
         title: 'Address',
         type: 'object',


### PR DESCRIPTION
AJV has a new "strict" mode and therefore complains on unknown properties on the schema. Luckily, you can specify additional kewords with `keywords: string[]`
or with

`ajv.addKeyword('uniforms');`

Before you open a pull request, please check if a similar one already exists or has been closed before. Detailed information about the process of contributing can be found in [CONTRIBUTING.md](https://github.com/vazco/uniforms/blob/master/.github/CONTRIBUTING.md).

Do link all relevant issues and pull requests. If there is none, please do file an issue first to discuss it upfront.
