### PR TITLE
Improved types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,7 +62,6 @@
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/restrict-plus-operands": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
-    "@typescript-eslint/unbound-method": "off",
     "import/default": "off",
     "jsx-a11y/alt-text": "off",
     "jsx-a11y/anchor-is-valid": "off",

--- a/packages/uniforms-antd/__tests__/DateField.tsx
+++ b/packages/uniforms-antd/__tests__/DateField.tsx
@@ -66,7 +66,7 @@ test('<DateField> - renders an input with correct readOnly state', () => {
   );
 
   expect(wrapper.find(DatePicker)).toHaveLength(1);
-  // @ts-ignore
+  // @ts-expect-error
   expect(wrapper.find(DatePicker).prop('onChange')(now)).toBeFalsy();
   expect(onChange).not.toHaveBeenCalled();
 });
@@ -119,7 +119,7 @@ test('<DateField> - renders a input which correctly reacts on change', () => {
   );
 
   expect(wrapper.find(DatePicker)).toHaveLength(1);
-  // @ts-ignore
+  // @ts-expect-error
   expect(wrapper.find(DatePicker).prop('onChange')(now)).toBeFalsy();
   expect(onChange).toHaveBeenLastCalledWith('x', now.toDate());
 });
@@ -134,7 +134,7 @@ test('<DateField> - renders a input which correctly reacts on change (empty)', (
   );
 
   expect(wrapper.find(DatePicker)).toHaveLength(1);
-  // @ts-ignore
+  // @ts-expect-error
   expect(wrapper.find(DatePicker).prop('onChange')(undefined)).toBeFalsy();
   expect(onChange).toHaveBeenLastCalledWith('x', undefined);
 });

--- a/packages/uniforms-antd/__tests__/RadioField.tsx
+++ b/packages/uniforms-antd/__tests__/RadioField.tsx
@@ -40,7 +40,7 @@ test('<RadioField> - renders a set of checkboxes with correct readOnly state', (
 
   expect(wrapper.find(Radio.Group)).toHaveLength(1);
   expect(
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(Radio.Group).prop('onChange')({ target: { value: 'b' } }),
   ).toBeFalsy();
   expect(onChange).not.toHaveBeenCalled();
@@ -153,7 +153,7 @@ test('<RadioField> - renders a set of checkboxes which correctly reacts on chang
 
   expect(wrapper.find(Radio.Group)).toHaveLength(1);
   expect(
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(Radio.Group).prop('onChange')({ target: { value: 'b' } }),
   ).toBeFalsy();
   expect(onChange).toHaveBeenLastCalledWith('x', 'b');
@@ -173,7 +173,7 @@ test('<RadioField> - renders a set of checkboxes which correctly reacts on chang
 
   expect(wrapper.find(Radio.Group)).toHaveLength(1);
   expect(
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.find(Radio.Group).prop('onChange')({ target: { value: 'a' } }),
   ).toBeFalsy();
   expect(onChange).toHaveBeenLastCalledWith('x', 'a');

--- a/packages/uniforms-antd/__tests__/SelectField.tsx
+++ b/packages/uniforms-antd/__tests__/SelectField.tsx
@@ -79,7 +79,7 @@ test('<SelectField> - renders a select with correct name', () => {
 });
 
 test('<SelectField> - renders a select with correct options', () => {
-  // @ts-ignore Is open a valid prop?
+  // @ts-expect-error Is open a valid prop?
   const element = <SelectField name="x" open />;
   const wrapper = mount(
     element,
@@ -88,19 +88,19 @@ test('<SelectField> - renders a select with correct options', () => {
 
   expect(wrapper.find(Select)).toHaveLength(1);
   expect(wrapper.find(Select).prop('children')).toHaveLength(2);
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[0].props.value).toBe('a');
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[0].props.children).toBe('a');
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[1].props.value).toBe('b');
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[1].props.children).toBe('b');
 });
 
 test('<SelectField> - renders a select with correct options (transform)', () => {
   const element = (
-    // @ts-ignore Is open a valid prop?
+    // @ts-expect-error Is open a valid prop?
     <SelectField name="x" open transform={x => x.toUpperCase()} />
   );
   const wrapper = mount(
@@ -110,13 +110,13 @@ test('<SelectField> - renders a select with correct options (transform)', () => 
 
   expect(wrapper.find(Select)).toHaveLength(1);
   expect(wrapper.find(Select).prop('children')).toHaveLength(2);
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[0].props.value).toBe('a');
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[0].props.children).toBe('A');
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[1].props.value).toBe('b');
-  // @ts-ignore Check children type.
+  // @ts-expect-error Check children type.
   expect(wrapper.find(Select).prop('children')[1].props.children).toBe('B');
 });
 

--- a/packages/uniforms-antd/__tests__/wrapField.tsx
+++ b/packages/uniforms-antd/__tests__/wrapField.tsx
@@ -9,7 +9,7 @@ test('<wrapField> - renders wrapper with label', () => {
   const element = wrapField({ label: 'Label' }, <div />);
   const wrapper = mount(element);
 
-  // @ts-ignore Correct label type.
+  // @ts-expect-error Correct label type.
   expect(wrapper.find(Form.Item).prop('label').props.children[0]).toBe('Label');
 });
 

--- a/packages/uniforms-antd/src/DateField.tsx
+++ b/packages/uniforms-antd/src/DateField.tsx
@@ -31,7 +31,7 @@ function Date({
         }
       }}
       placeholder={props.placeholder}
-      // @ts-ignore: `DatePicker` is an intersection.
+      // @ts-expect-error: `DatePicker` is an intersection.
       ref={props.inputRef}
       showTime={showTime}
       style={style}

--- a/packages/uniforms-antd/src/RadioField.tsx
+++ b/packages/uniforms-antd/src/RadioField.tsx
@@ -7,7 +7,7 @@ import wrapField from './wrapField';
 export type RadioFieldProps = FieldProps<
   string,
   RadioProps,
-  { allowedValues?: string[]; transform?(value: string): string }
+  { allowedValues?: string[]; transform?: (value: string) => string }
 >;
 
 const radioStyle = { display: 'block' };

--- a/packages/uniforms-antd/src/SelectField.tsx
+++ b/packages/uniforms-antd/src/SelectField.tsx
@@ -47,7 +47,7 @@ function Select(props: SelectFieldProps) {
   return wrapField(
     props,
     props.checkboxes ? (
-      // @ts-ignore: Incorrect `value` type.
+      // @ts-expect-error: Incorrect `value` type.
       <Group
         disabled={props.disabled}
         name={props.name}
@@ -81,7 +81,7 @@ function Select(props: SelectFieldProps) {
           }
         }}
         placeholder={props.placeholder}
-        // @ts-ignore: Incorrect `inputRef` type.
+        // @ts-expect-error: Incorrect `inputRef` type.
         ref={props.inputRef}
         value={
           props.fieldType === Array

--- a/packages/uniforms-antd/src/SelectField.tsx
+++ b/packages/uniforms-antd/src/SelectField.tsx
@@ -11,30 +11,34 @@ import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 import wrapField from './wrapField';
 
 type CheckboxesProps = FieldProps<
-  CheckboxValueType,
+  SelectFieldValue,
   CheckboxGroupProps | RadioGroupProps,
   {
     allowedValues?: CheckboxValueType[];
     checkboxes: true;
-    disableItem?(value: CheckboxValueType): boolean;
+    disableItem?: (value: CheckboxValueType) => boolean;
     inputRef?: Ref<typeof CheckboxGroup | typeof RadioGroup>;
     required?: boolean;
-    transform?(value: CheckboxValueType): string;
+    transform?: (value: CheckboxValueType) => string;
   }
 >;
 
 type SelectProps = FieldProps<
-  string | (string | undefined)[],
+  SelectFieldValue,
   SelectAntDProps<string | string[]>,
   {
     allowedValues?: string[];
     checkboxes?: false;
-    disableItem?(value: CheckboxValueType): boolean;
+    disableItem?: (value: CheckboxValueType) => boolean;
     inputRef?: Ref<typeof SelectAntD>;
     required?: boolean;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
+
+// This type is needed for the `SelectFieldProps` union to be a proper subtype
+// of `Partial<GuaranteedProps<Value>>` - otherwise `connectField` goes wild.
+type SelectFieldValue = CheckboxValueType | (string | undefined)[];
 
 export type SelectFieldProps = CheckboxesProps | SelectProps;
 

--- a/packages/uniforms-bootstrap3/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap3/src/RadioField.tsx
@@ -17,7 +17,7 @@ export type RadioFieldProps = HTMLFieldProps<
     allowedValues?: string[];
     inline?: boolean;
     inputClassName?: string;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-bootstrap3/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap3/src/SelectField.tsx
@@ -21,7 +21,7 @@ export type SelectFieldProps = HTMLFieldProps<
     inline?: boolean;
     inputClassName?: string;
     inputRef?: Ref<HTMLSelectElement>;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-bootstrap4/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap4/src/RadioField.tsx
@@ -17,7 +17,7 @@ export type RadioFieldProps = HTMLFieldProps<
     allowedValues?: string[];
     inline?: boolean;
     inputClassName?: string;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-bootstrap4/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/src/SelectField.tsx
@@ -21,7 +21,7 @@ export type SelectFieldProps = HTMLFieldProps<
     inline?: boolean;
     inputClassName?: string;
     inputRef?: Ref<HTMLSelectElement>;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-bootstrap4/src/gridClassName.ts
+++ b/packages/uniforms-bootstrap4/src/gridClassName.ts
@@ -44,7 +44,7 @@ export default function gridClassName(
     return (
       (Object.keys(grid) as GridSize[])
         .sort(compareSizeClass)
-        // @ts-ignore Weird type refinement problem.
+        // @ts-expect-error Weird type refinement problem.
         .map(size => gridClassNamePart(size, grid[size], side))
         .join(' ')
     );

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -31,9 +31,9 @@ export default class GraphQLBridge extends Bridge {
     super();
 
     // Memoize for performance and referential equality.
-    this.getField = memoize(this.getField);
-    this.getSubfields = memoize(this.getSubfields);
-    this.getType = memoize(this.getType);
+    this.getField = memoize(this.getField.bind(this));
+    this.getSubfields = memoize(this.getSubfields.bind(this));
+    this.getType = memoize(this.getType.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -81,9 +81,9 @@ export default class JSONSchemaBridge extends Bridge {
     this.schema = distinctSchema(schema);
 
     // Memoize for performance and referential equality.
-    this.getField = memoize(this.getField);
-    this.getSubfields = memoize(this.getSubfields);
-    this.getType = memoize(this.getType);
+    this.getField = memoize(this.getField.bind(this));
+    this.getSubfields = memoize(this.getSubfields.bind(this));
+    this.getType = memoize(this.getType.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -9,9 +9,9 @@ export default class SimpleSchema2Bridge extends Bridge {
     super();
 
     // Memoize for performance and referential equality.
-    this.getField = memoize(this.getField);
-    this.getSubfields = memoize(this.getSubfields);
-    this.getType = memoize(this.getType);
+    this.getField = memoize(this.getField.bind(this));
+    this.getSubfields = memoize(this.getSubfields.bind(this));
+    this.getType = memoize(this.getType.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -21,7 +21,7 @@ export default class SimpleSchema2Bridge extends Bridge {
 
   getErrorMessage(name: string, error: any) {
     const scopedError = this.getError(name, error);
-    // @ts-ignore: `messageForError` has incorrect typing.
+    // @ts-expect-error: `messageForError` has incorrect typing.
     return !scopedError ? '' : this.schema.messageForError(scopedError);
   }
 
@@ -30,7 +30,7 @@ export default class SimpleSchema2Bridge extends Bridge {
       if (Array.isArray(error.details)) {
         // FIXME: Correct type for `error`.
         return (error.details as any[]).map(error =>
-          // @ts-ignore: `messageForError` has incorrect typing.
+          // @ts-expect-error: `messageForError` has incorrect typing.
           this.schema.messageForError(error),
         );
       }
@@ -146,7 +146,7 @@ export default class SimpleSchema2Bridge extends Bridge {
   }
 
   getSubfields(name?: string) {
-    // @ts-ignore: Typing for `_makeGeneric` is missing.
+    // @ts-expect-error: Typing for `_makeGeneric` is missing.
     return this.schema.objectKeys(SimpleSchema._makeGeneric(name));
   }
 

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -10,7 +10,7 @@ describe('SimpleSchemaBridge', () => {
       // Simulate SimpleSchema.
       name = name.replace(/\d+/g, '$');
 
-      // @ts-ignore: Dynamic `name`.
+      // @ts-expect-error: Dynamic `name`.
       const field = {
         a: { type: Object, label: name },
         'a.b': { type: Object, label: name },

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -1,7 +1,7 @@
 import invariant from 'invariant';
 import cloneDeep from 'lodash/cloneDeep';
 import memoize from 'lodash/memoize';
-// @ts-ignore
+// @ts-expect-error
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { Bridge, joinName } from 'uniforms';
 

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -10,9 +10,9 @@ export default class SimpleSchemaBridge extends Bridge {
     super();
 
     // Memoize for performance and referential equality.
-    this.getField = memoize(this.getField);
-    this.getSubfields = memoize(this.getSubfields);
-    this.getType = memoize(this.getType);
+    this.getField = memoize(this.getField.bind(this));
+    this.getSubfields = memoize(this.getSubfields.bind(this));
+    this.getType = memoize(this.getType.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -1,7 +1,7 @@
 import invariant from 'invariant';
 import cloneDeep from 'lodash/cloneDeep';
 import memoize from 'lodash/memoize';
-// @ts-expect-error
+// @ts-ignore
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { Bridge, joinName } from 'uniforms';
 

--- a/packages/uniforms-bridge-simple-schema/src/register.ts
+++ b/packages/uniforms-bridge-simple-schema/src/register.ts
@@ -1,6 +1,6 @@
-// @ts-expect-error
+// @ts-ignore
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-// @ts-expect-error
+// @ts-ignore
 import { Match } from 'meteor/check';
 import { filterDOMProps } from 'uniforms';
 

--- a/packages/uniforms-bridge-simple-schema/src/register.ts
+++ b/packages/uniforms-bridge-simple-schema/src/register.ts
@@ -1,6 +1,6 @@
-// @ts-ignore
+// @ts-expect-error
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-// @ts-ignore
+// @ts-expect-error
 import { Match } from 'meteor/check';
 import { filterDOMProps } from 'uniforms';
 

--- a/packages/uniforms-material/__tests__/DateField.tsx
+++ b/packages/uniforms-material/__tests__/DateField.tsx
@@ -97,7 +97,7 @@ test('<DateField> - renders a Input which correctly reacts on change', () => {
     createContext({ x: { type: Date } }, { onChange }),
   );
 
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(Input).props().onChange!({ target: { valueAsNumber: now } });
   expect(onChange).toHaveBeenLastCalledWith('x', now);
 });
@@ -112,7 +112,7 @@ test('<DateField> - renders a Input which correctly reacts on change (empty)', (
   );
 
   wrapper.find(Input).props().onChange!({
-    // @ts-ignore Provide a valid EventTarget.
+    // @ts-expect-error Provide a valid EventTarget.
     target: { valueAsNumber: undefined },
   });
   expect(onChange).toHaveBeenLastCalledWith('x', undefined);
@@ -128,7 +128,7 @@ test('<DateField> - renders a Input which correctly reacts on change (overflow)'
     createContext({ x: { type: Date } }, { onChange }),
   );
 
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(Input).props().onChange!({ target: { valueAsNumber: now } });
   expect(onChange).not.toHaveBeenCalled();
 });

--- a/packages/uniforms-material/__tests__/LongTextField.tsx
+++ b/packages/uniforms-material/__tests__/LongTextField.tsx
@@ -97,7 +97,7 @@ test('<LongTextField> - renders a TextField which correctly reacts on change', (
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: 'y' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 'y');
 });
@@ -112,7 +112,7 @@ test('<LongTextField> - renders a TextField which correctly reacts on change (em
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '' } });
   expect(onChange).toHaveBeenLastCalledWith('x', '');
 });
@@ -127,7 +127,7 @@ test('<LongTextField> - renders a TextField which correctly reacts on change (sa
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: 'y' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 'y');
 });

--- a/packages/uniforms-material/__tests__/NumField.tsx
+++ b/packages/uniforms-material/__tests__/NumField.tsx
@@ -176,7 +176,7 @@ test('<NumField> - renders a TextField which correctly reacts on change', () => 
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '1' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 1);
 });
@@ -191,7 +191,7 @@ test('<NumField> - renders a TextField which correctly reacts on change (decimal
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '2.5' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 2.5);
 });
@@ -206,7 +206,7 @@ test('<NumField> - renders a TextField which correctly reacts on change (decimal
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '2.5' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 2);
 });
@@ -221,7 +221,7 @@ test('<NumField> - renders a TextField which correctly reacts on change (empty)'
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '' } });
   expect(onChange).toHaveBeenLastCalledWith('x', undefined);
 });
@@ -236,7 +236,7 @@ test('<NumField> - renders a TextField which correctly reacts on change (same va
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '1' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 1);
 });
@@ -251,7 +251,7 @@ test('<NumField> - renders a TextField which correctly reacts on change (zero)',
   );
 
   expect(wrapper.find(TextField)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '0' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 0);
 });

--- a/packages/uniforms-material/__tests__/RadioField.tsx
+++ b/packages/uniforms-material/__tests__/RadioField.tsx
@@ -147,7 +147,7 @@ test('<RadioField> - renders a RadioGroup which correctly reacts on change', () 
   );
 
   expect(wrapper.find(RadioGroup)).toHaveLength(1);
-  // @ts-ignore Provide a valid value.
+  // @ts-expect-error Provide a valid value.
   wrapper.find(RadioGroup).props().onChange!({ target: { value: 'b' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 'b');
 });
@@ -165,7 +165,7 @@ test('<RadioField> - renders a RadioGroup which correctly reacts on change (same
   );
 
   expect(wrapper.find(RadioGroup)).toHaveLength(1);
-  // @ts-ignore Provide a valid value.
+  // @ts-expect-error Provide a valid value.
   wrapper.find(RadioGroup).props().onChange!({ target: { value: 'a' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 'a');
 });

--- a/packages/uniforms-material/__tests__/SelectField.tsx
+++ b/packages/uniforms-material/__tests__/SelectField.tsx
@@ -36,7 +36,6 @@ test('<SelectField> - renders a Select with correct disabled state', () => {
 });
 
 test('<SelectField> - renders a Select with correct required state', () => {
-  // @ts-ignore Fix SelectFieldProps.
   const element = <SelectField name="x" required />;
   const wrapper = mount(
     element,
@@ -84,7 +83,6 @@ test('<SelectField> - renders a Select with correct name', () => {
 });
 
 test('<SelectField> - renders a Select with correct options', () => {
-  // @ts-ignore Fix SelectFieldProps.
   const element = <SelectField name="x" native />;
   const wrapper = mount(
     element,
@@ -106,7 +104,6 @@ test('<SelectField> - renders a Select with correct options', () => {
 
 test('<SelectField> - renders a Select with correct options (transform)', () => {
   const element = (
-    // @ts-ignore Fix SelectFieldProps.
     <SelectField name="x" transform={x => x.toUpperCase()} native />
   );
   const wrapper = mount(
@@ -128,7 +125,6 @@ test('<SelectField> - renders a Select with correct options (transform)', () => 
 });
 
 test('<SelectField> - renders a Select with correct placeholder (implicit)', () => {
-  // @ts-ignore Fix SelectFieldProps.
   const element = <SelectField name="x" placeholder="y" native />;
   const wrapper = mount(
     element,
@@ -197,7 +193,7 @@ test('<SelectField> - renders a Select which correctly reacts on change', () => 
   );
 
   expect(wrapper.find(Select)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: 'b' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 'b');
 });
@@ -215,7 +211,7 @@ test('<SelectField> - renders a Select which correctly reacts on change (empty)'
   );
 
   expect(wrapper.find(Select)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: '' } });
   expect(onChange).toHaveBeenLastCalledWith('x', undefined);
 });
@@ -233,7 +229,7 @@ test('<SelectField> - renders a Select which correctly reacts on change (same va
   );
 
   expect(wrapper.find(Select)).toHaveLength(1);
-  // @ts-ignore Provide a valid EventTarget.
+  // @ts-expect-error Provide a valid EventTarget.
   wrapper.find(TextField).props().onChange!({ target: { value: 'b' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 'b');
 });
@@ -312,7 +308,7 @@ test('<SelectField> - disabled items (options) based on predicate', () => {
 
 test('<SelectField> - renders with correct classnames', () => {
   const wrapper = mount(
-    // @ts-ignore Fix SelectFieldProps.
+    // @ts-expect-error Fix SelectFieldProps.
     <SelectField name="x" textFieldProps={{ className: 'select-class' }} />,
     createContext({ x: { type: String, allowedValues: ['a', 'b'] } }),
   );
@@ -503,7 +499,7 @@ test('<SelectField checkboxes> - renders a set of Radio buttons which correctly 
   );
 
   expect(wrapper.find(Radio)).toHaveLength(2);
-  // @ts-ignore Provide a valid value.
+  // @ts-expect-error Provide a valid value.
   wrapper.find(RadioGroup).props().onChange!({ target: { value: 'b' } });
   expect(onChange).toHaveBeenLastCalledWith('x', 'b');
 });
@@ -549,7 +545,6 @@ test('<SelectField checkboxes> - renders a set of Checkboxes which correctly rea
 
 test('<SelectField checkboxes> - renders a set of Checkboxes with correct labels', () => {
   const onChange = jest.fn();
-  // @ts-ignore Fix SelectFieldProps.
   const element = <SelectField checkboxes name="x" />;
   const wrapper = mount(
     element,
@@ -602,7 +597,7 @@ test('<SelectField checkboxes> - renders a set of Radio buttons which correctly 
 
   expect(wrapper.find(Radio)).toHaveLength(2);
 
-  // @ts-ignore Provide a valid value.
+  // @ts-expect-error Provide a valid value.
   wrapper.find(RadioGroup).props().onChange!({ target: { value: 'a' } });
 
   expect(onChange).toHaveBeenLastCalledWith('x', 'a');

--- a/packages/uniforms-material/src/BoolField.tsx
+++ b/packages/uniforms-material/src/BoolField.tsx
@@ -16,7 +16,7 @@ export type BoolFieldProps = FieldProps<
     appearance?: 'checkbox' | 'switch';
     helperText?: string;
     legend?: string;
-    transform?(label: string): string;
+    transform?: (label: string) => string;
   }
 >;
 

--- a/packages/uniforms-material/src/RadioField.tsx
+++ b/packages/uniforms-material/src/RadioField.tsx
@@ -18,7 +18,7 @@ export type RadioFieldProps = FieldProps<
     helperText?: string;
     margin?: any;
     row?: boolean;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-material/src/SelectField.tsx
+++ b/packages/uniforms-material/src/SelectField.tsx
@@ -19,11 +19,11 @@ type SelectFieldCommonProps = {
   allowedValues?: string[];
   appearance?: 'checkbox' | 'switch';
   checkboxes?: boolean;
-  disableItem?(value: string): boolean;
+  disableItem?: (value: string) => boolean;
   inputRef?: Ref<HTMLButtonElement>;
   native?: boolean;
   required?: boolean;
-  transform?(value: string): string;
+  transform?: (value: string) => string;
 };
 
 type CheckboxesProps = FieldProps<

--- a/packages/uniforms-semantic/src/RadioField.tsx
+++ b/packages/uniforms-semantic/src/RadioField.tsx
@@ -15,7 +15,7 @@ export type RadioFieldProps = HTMLFieldProps<
   {
     allowedValues?: string[];
     checkboxes?: boolean;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-semantic/src/SelectField.tsx
+++ b/packages/uniforms-semantic/src/SelectField.tsx
@@ -17,7 +17,7 @@ export type SelectFieldProps = HTMLFieldProps<
     checkboxes?: boolean;
     disableItem?: (value: string) => boolean;
     inputRef?: Ref<HTMLSelectElement>;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-unstyled/src/RadioField.tsx
+++ b/packages/uniforms-unstyled/src/RadioField.tsx
@@ -14,7 +14,7 @@ export type RadioFieldProps = HTMLFieldProps<
   {
     allowedValues?: string[];
     checkboxes?: boolean;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms-unstyled/src/SelectField.tsx
+++ b/packages/uniforms-unstyled/src/SelectField.tsx
@@ -12,9 +12,9 @@ export type SelectFieldProps = HTMLFieldProps<
   {
     allowedValues?: string[];
     checkboxes?: boolean;
-    disableItem?(value: string): boolean;
+    disableItem?: (value: string) => boolean;
     inputRef?: Ref<HTMLSelectElement>;
-    transform?(value: string): string;
+    transform?: (value: string) => string;
   }
 >;
 

--- a/packages/uniforms/__tests__/BaseForm.tsx
+++ b/packages/uniforms/__tests__/BaseForm.tsx
@@ -133,7 +133,7 @@ describe('BaseForm', () => {
       expect(context2).toHaveProperty('changedMap.$');
       expect(context2.changedMap.$).toBeTruthy();
       expect(context2).toHaveProperty('changedMap.$.1');
-      // @ts-ignore: Dynamic `changedMap` structure.
+      // @ts-expect-error: Dynamic `changedMap` structure.
       expect(context2.changedMap.$?.[1]).toBeTruthy();
     });
 

--- a/packages/uniforms/__tests__/QuickForm.tsx
+++ b/packages/uniforms/__tests__/QuickForm.tsx
@@ -8,7 +8,7 @@ jest.mock('meteor/aldeed:simple-schema');
 jest.mock('meteor/check');
 
 describe('QuickForm', () => {
-  // @ts-ignore QuickForm is not a valid Component.
+  // @ts-expect-error QuickForm is not a valid Component.
   class TestForm extends QuickForm<any> {
     // eslint-disable-next-line react/display-name
     getAutoField = () => () => <i className="auto" />;

--- a/packages/uniforms/__tests__/filterDOMProps.ts
+++ b/packages/uniforms/__tests__/filterDOMProps.ts
@@ -11,7 +11,7 @@ describe('joinName', () => {
   });
 
   it('removes registered props', () => {
-    // @ts-ignore: Do not register its type not to pollute it.
+    // @ts-expect-error: Do not register its type not to pollute it.
     filterDOMProps.register('__special__');
 
     expect(filterDOMProps({ __special__: true })).toEqual({});

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -23,7 +23,7 @@ export type AutoFormState<Model> = ValidatedQuickFormState<Model> & {
 };
 
 export function Auto<Base extends typeof ValidatedQuickForm>(Base: Base) {
-  // @ts-ignore: Mixin class problem.
+  // @ts-expect-error: Mixin class problem.
   class AutoForm<
     Model,
     Props extends AutoFormProps<Model> = AutoFormProps<Model>,

--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -14,7 +14,7 @@ import {
 import { DeepPartial, ModelTransformMode } from './types';
 
 export type AutoFormProps<Model> = ValidatedQuickFormProps<Model> & {
-  onChangeModel?(model: DeepPartial<Model>): void;
+  onChangeModel?: (model: DeepPartial<Model>) => void;
 };
 
 export type AutoFormState<Model> = ValidatedQuickFormState<Model> & {

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -23,8 +23,8 @@ export type BaseFormProps<Model> = {
     model: DeepPartial<Model>,
   ) => DeepPartial<Model>;
   noValidate: boolean;
-  onChange?(key: string, value: any): void;
-  onSubmit(model: DeepPartial<Model>): void | Promise<any>;
+  onChange?: (key: string, value: any) => void;
+  onSubmit: (model: DeepPartial<Model>) => void | Promise<any>;
   placeholder?: boolean;
   readOnly?: boolean;
   schema: Bridge;
@@ -142,10 +142,14 @@ export class BaseForm<
   }
 
   getContextOnChange(): Context<Model>['onChange'] {
+    // It's bound in constructor.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     return this.onChange;
   }
 
   getContextOnSubmit(): Context<Model>['onSubmit'] {
+    // It's bound in constructor.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     return this.onSubmit;
   }
 
@@ -175,6 +179,8 @@ export class BaseForm<
 
     return {
       ...props,
+      // It's bound in constructor.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       onSubmit: this.onSubmit,
       key: `reset-${this.state.resetCount}`,
     };
@@ -235,6 +241,8 @@ export class BaseForm<
 
   onReset() {
     // @ts-ignore
+    // It's bound in constructor.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     this.setState(this.__reset);
   }
 

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -57,7 +57,7 @@ export class BaseForm<
   constructor(props: Props) {
     super(props);
 
-    // @ts-ignore: State may be bigger, but it'll be covered by the subclasses.
+    // @ts-expect-error: State may be bigger, but it'll be covered by the subclasses.
     this.state = {
       changed: false,
       changedMap: Object.create(null),
@@ -240,7 +240,7 @@ export class BaseForm<
   }
 
   onReset() {
-    // @ts-ignore
+    // @ts-expect-error
     // It's bound in constructor.
     // eslint-disable-next-line @typescript-eslint/unbound-method
     this.setState(this.__reset);

--- a/packages/uniforms/src/QuickForm.tsx
+++ b/packages/uniforms/src/QuickForm.tsx
@@ -11,7 +11,7 @@ export type QuickFormProps<Model> = BaseFormProps<Model> & {
 export type QuickFormState<Model> = BaseFormState<Model>;
 
 export function Quick<Base extends typeof BaseForm>(Base: Base) {
-  // @ts-ignore: Mixin class problem.
+  // @ts-expect-error: Mixin class problem.
   class QuickForm<
     Model,
     Props extends QuickFormProps<Model> = QuickFormProps<Model>,

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -10,7 +10,7 @@ import { BaseForm, BaseFormProps, BaseFormState } from './BaseForm';
 import { Context, DeepPartial, ValidateMode } from './types';
 
 export type ValidatedFormProps<Model> = BaseFormProps<Model> & {
-  onValidate(model: DeepPartial<Model>, error: any): any;
+  onValidate: (model: DeepPartial<Model>, error: any) => any;
   validate: ValidateMode;
   validator?: any;
 };
@@ -19,7 +19,7 @@ export type ValidatedFormState<Model> = BaseFormState<Model> & {
   error: any;
   validate: boolean;
   validating: boolean;
-  validator(model: DeepPartial<Model>): any;
+  validator: (model: DeepPartial<Model>) => any;
 };
 
 export function Validated<Base extends typeof BaseForm>(Base: Base) {

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -23,7 +23,7 @@ export type ValidatedFormState<Model> = BaseFormState<Model> & {
 };
 
 export function Validated<Base extends typeof BaseForm>(Base: Base) {
-  // @ts-ignore: Mixin class problem.
+  // @ts-expect-error: Mixin class problem.
   class ValidatedForm<
     Model,
     Props extends ValidatedFormProps<Model> = ValidatedFormProps<Model>,

--- a/packages/uniforms/src/connectField.tsx
+++ b/packages/uniforms/src/connectField.tsx
@@ -31,7 +31,7 @@ export function connectField<
     const hasChainName = props.name !== '';
     const anyFlowingPropertySet = some(
       context.state,
-      // @ts-ignore: `props` has no index signature.
+      // @ts-expect-error: `props` has no index signature.
       (_, key) => props[key] !== null && props[key] !== undefined,
     );
 
@@ -42,7 +42,7 @@ export function connectField<
     const nextContext = { ...context };
     if (anyFlowingPropertySet) {
       nextContext.state = mapValues(nextContext.state, (value, key) =>
-        // @ts-ignore: `props` has no index signature.
+        // @ts-expect-error: `props` has no index signature.
         props[key] !== null && props[key] !== undefined ? !!props[key] : value,
       );
     }

--- a/packages/uniforms/src/types.ts
+++ b/packages/uniforms/src/types.ts
@@ -12,9 +12,9 @@ export type Context<Model> = {
   error: any;
   model: DeepPartial<Model>;
   name: string[];
-  onChange(key: string, value?: any): void;
-  onSubmit(event?: SyntheticEvent): any | Promise<any>;
-  randomId(): string;
+  onChange: (key: string, value?: any) => void;
+  onSubmit: (event?: SyntheticEvent) => any | Promise<any>;
+  randomId: () => string;
   schema: Bridge;
   state: {
     disabled: boolean;
@@ -50,7 +50,7 @@ export type GuaranteedProps<Value> = {
   id: string;
   label: ReactNode;
   name: string;
-  onChange(value?: Value | null, name?: string): void;
+  onChange: (value?: Value | null, name?: string) => void;
   placeholder: string;
   readOnly: boolean;
   showInlineError: boolean;

--- a/packages/uniforms/src/types.ts
+++ b/packages/uniforms/src/types.ts
@@ -12,7 +12,7 @@ export type Context<Model> = {
   error: any;
   model: DeepPartial<Model>;
   name: string[];
-  onChange: (key: string, value?: any) => void;
+  onChange: (key: string, value: any) => void;
   onSubmit: (event?: SyntheticEvent) => any | Promise<any>;
   randomId: () => string;
   schema: Bridge;
@@ -50,7 +50,7 @@ export type GuaranteedProps<Value> = {
   id: string;
   label: ReactNode;
   name: string;
-  onChange: (value?: Value | null, name?: string) => void;
+  onChange: (value: any, name?: string) => void;
   placeholder: string;
   readOnly: boolean;
   showInlineError: boolean;

--- a/packages/uniforms/src/types.ts
+++ b/packages/uniforms/src/types.ts
@@ -50,11 +50,16 @@ export type GuaranteedProps<Value> = {
   id: string;
   label: ReactNode;
   name: string;
-  onChange: (value: any, name?: string) => void;
+  onChange: OnChange<Value | undefined>;
   placeholder: string;
   readOnly: boolean;
   showInlineError: boolean;
   value?: Value;
+};
+
+type OnChange<Value> = {
+  (value: Value): void;
+  (value: any, name: string): void;
 };
 
 export type HTMLFieldProps<Value, Element, Extension = object> = FieldProps<

--- a/website/components/Playground.tsx
+++ b/website/components/Playground.tsx
@@ -2,7 +2,7 @@ import ConfigProvider from 'antd/lib/config-provider';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
 import React, { Component } from 'react';
-// @ts-ignore
+// @ts-expect-error
 import Frame, { FrameContextConsumer } from 'react-frame-component';
 import { ValidatedForm, connectField, context, useForm } from 'uniforms';
 
@@ -19,7 +19,7 @@ export class Playground extends Component<any, any> {
   }
 
   constructor() {
-    // @ts-ignore: Types.
+    // @ts-expect-error: Types.
     super(...arguments);
 
     const state = schema.clean(parseQuery());
@@ -60,7 +60,7 @@ export class Playground extends Component<any, any> {
 
   render() {
     return (
-      // @ts-ignore: Types.
+      // @ts-expect-error: Types.
       <PlaygroundForm
         className={playgroundStyles['playground']}
         model={this.state}
@@ -119,7 +119,7 @@ const PlaygroundModelDebug = () => {
 
 class PlaygroundPreview extends Component<any, any> {
   constructor() {
-    // @ts-ignore: Types.
+    // @ts-expect-error: Types.
     super(...arguments);
 
     this._schema = eval(`(${this.props.value.schema})`);

--- a/website/components/Playground.tsx
+++ b/website/components/Playground.tsx
@@ -34,8 +34,6 @@ export class Playground extends Component<any, any> {
     }
 
     this.state = state;
-
-    this.onChange = this.onChange.bind(this);
   }
 
   componentDidMount() {
@@ -46,7 +44,7 @@ export class Playground extends Component<any, any> {
     updateQuery(this.state);
   }
 
-  onChange(key: string, value: unknown) {
+  onChange = (key: string, value: unknown) => {
     if (key === 'preset') {
       // FIXME: Types.
       this.setState((state: any) => ({
@@ -58,7 +56,7 @@ export class Playground extends Component<any, any> {
     }
 
     this.setState({ error: undefined, [key]: value });
-  }
+  };
 
   render() {
     return (

--- a/website/components/Tabs.tsx
+++ b/website/components/Tabs.tsx
@@ -11,7 +11,7 @@ export type TabsItem = {
 export type TabsHeaderProps<T extends TabsItem> = {
   activeTab: number;
   items: T[];
-  onTab(tab: number): void;
+  onTab: (tab: number) => void;
 };
 
 export function TabsHeader<T extends TabsItem>({
@@ -37,7 +37,7 @@ export function TabsHeader<T extends TabsItem>({
 export type TabsHeaderItemProps = {
   active: boolean;
   children: ReactNode;
-  onClick(): void;
+  onClick: () => void;
 };
 
 export function TabsHeaderItem({
@@ -56,7 +56,7 @@ export function TabsHeaderItem({
 }
 
 export type TabsProps<T extends TabsItem> = {
-  children(tab: T): ReactNode;
+  children: (tab: T) => ReactNode;
   group: string;
   tabs: T[];
 };

--- a/website/components/Toggler.tsx
+++ b/website/components/Toggler.tsx
@@ -38,7 +38,7 @@ export function TogglerHeaderItem({
 export type TogglerHeaderProps<T extends TogglerItem> = {
   activeToggle: number;
   items: T[];
-  onClick(tab: number): () => void;
+  onClick: (tab: number) => () => void;
 };
 
 export function TogglerHeader<T extends TogglerItem>({

--- a/website/components/TogglerTabs.tsx
+++ b/website/components/TogglerTabs.tsx
@@ -6,7 +6,7 @@ import { TabsHeader, TabsItem } from './Tabs';
 import { TogglerHeader, TogglerItem } from './Toggler';
 
 export type TogglerTabsProps<T extends TabsItem, U extends TogglerItem> = {
-  children(args: { tab: T; toggle: U }): ReactNode;
+  children: (args: { tab: T; toggle: U }) => ReactNode;
   group: string;
   tabsItems: T[];
   togglerItems: U[];

--- a/website/lib/schema.ts
+++ b/website/lib/schema.ts
@@ -1,6 +1,6 @@
 import Ajv from 'ajv';
 import { buildASTSchema, parse } from 'graphql';
-// @ts-ignore: Typings.
+// @ts-expect-error: Typings.
 import MessageBox from 'message-box';
 import SimpleSchema from 'simpl-schema';
 import { GraphQLBridge } from 'uniforms-bridge-graphql';
@@ -89,13 +89,13 @@ export const schema = new SimpleSchema({
       asyncOnSubmit: false,
       asyncOnValidate: false,
     },
-    // @ts-ignore: SimpleSchema extensibility.
+    // @ts-expect-error: SimpleSchema extensibility.
     uniforms: { schema: propsBridge },
   },
 
   theme: {
     type: String,
-    // @ts-ignore: SimpleSchema extensibility.
+    // @ts-expect-error: SimpleSchema extensibility.
     uniforms: { transform: (theme: string) => `uniforms-${theme}` },
     defaultValue: Object.keys(themes)[0],
     allowedValues: Object.keys(themes),

--- a/website/pages-parts/CustomFields/CycleField.tsx
+++ b/website/pages-parts/CustomFields/CycleField.tsx
@@ -33,7 +33,7 @@ function Cycle({
             ? allowedValues.indexOf(value) === allowedValues.length - 1
               ? required
                 ? allowedValues[0]
-                : null
+                : undefined
               : allowedValues[allowedValues.indexOf(value) + 1]
             : allowedValues[0],
         )

--- a/website/pages-parts/CustomFields/DisplayIf.tsx
+++ b/website/pages-parts/CustomFields/DisplayIf.tsx
@@ -6,7 +6,7 @@ import { bridge as schema } from './DisplayIfSchema';
 
 type DisplayIfProps<T> = {
   children: ReactElement;
-  condition(context: Context<T>): boolean;
+  condition: (context: Context<T>) => boolean;
 };
 
 // We have to ensure that there's only one child, because returning an array

--- a/website/pages-parts/CustomFields/RatingField.tsx
+++ b/website/pages-parts/CustomFields/RatingField.tsx
@@ -22,7 +22,8 @@ function Rating({
           style={{ fontSize: 40, cursor: 'pointer' }}
           key={index}
           onClick={() =>
-            disabled || onChange(!required && value === index ? null : index)
+            disabled ||
+            onChange(!required && value === index ? undefined : index)
           }
         >
           {index <= value ? '★' : '☆'}


### PR DESCRIPTION
This PR is composed of three parts:
* b0101cf Switched from bound to unbound methods. It allowed re-enabling of `@typescript-eslint/unbound-method`.
* 12e88a1 Improved `onChange` type. Switch from `Value | null` into `any` was needed, to make it possible to use `onChange(otherFieldValue, 'otherField')`. Additionally, the `value` argument is not optional anymore. Ideally, it should be something like this:
    ```ts
    type OnChange<Value> = {
      (value: Value): void;
      (value: any, name: string): void;
    };
    ```
    However, this breaks a lot of inferred types.
* 94d48fc Replaced `ts-ignore` with `ts-expect-error`. These are strictly better, letting us know that it's no longer needed.

**EDIT:**
* 63e4bac I managed to make the `onChange` typed as planned.
* 57c0242 I had to revert 94d48fc for Meteor modules as it broke with our internal declarations. It'll require further investigation.