### PR TITLE
Added missing sideEffect files (fixes #888).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Fixed:** Invalid `sideEffect` configuration in `uniforms-bridge-simple-schema` and `uniforms-bridge-simple-schema-2`. [\#888](https://github.com/vazco/uniforms/issues/888)
+
 ## [v3.2.0](https://github.com/vazco/uniforms/tree/v3.2.0) (2021-02-17)
 
 - **Added:** Error styling to `ListField` in `uniforms-antd`. [\#844](https://github.com/vazco/uniforms/issues/844)

--- a/packages/uniforms-bridge-simple-schema-2/package.json
+++ b/packages/uniforms-bridge-simple-schema-2/package.json
@@ -5,8 +5,11 @@
   "main": "es5/index.js",
   "module": "es6/index.js",
   "sideEffects": [
+    "es5/index.js",
     "es5/register.js",
+    "es6/index.js",
     "es6/register.js",
+    "src/index.ts",
     "src/register.ts"
   ],
   "description": "SimpleSchema 2 bridge for uniforms.",

--- a/packages/uniforms-bridge-simple-schema/package.json
+++ b/packages/uniforms-bridge-simple-schema/package.json
@@ -5,8 +5,11 @@
   "main": "es5/index.js",
   "module": "es6/index.js",
   "sideEffects": [
+    "es5/index.js",
     "es5/register.js",
+    "es6/index.js",
     "es6/register.js",
+    "src/index.ts",
     "src/register.ts"
   ],
   "description": "SimpleSchema bridge for uniforms.",


### PR DESCRIPTION
As reported in #888, changes made in #870 were _slightly_ incomplete, resulting in an error:

```
Invalid definition for name field: "uniforms" is not a supported property
```

This change adds missing `sideEffect` files.