### PR TITLE
Fixed SelectField style in uniforms-semantic (fixes #873).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Fixed:** Styling of `SelectField` in `uniforms-semantic`. [\#873](https://github.com/vazco/uniforms/issues/873)
+
 ## [v3.2.0](https://github.com/vazco/uniforms/tree/v3.2.0) (2021-02-17)
 
 - **Added:** Error styling to `ListField` in `uniforms-antd`. [\#844](https://github.com/vazco/uniforms/issues/844)

--- a/packages/uniforms-semantic/src/SelectField.tsx
+++ b/packages/uniforms-semantic/src/SelectField.tsx
@@ -9,6 +9,8 @@ const base64 =
     : (x: string) => Buffer.from(x).toString('base64');
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
+const selectStyle = { paddingBottom: 0, paddingTop: 0 };
+
 export type SelectFieldProps = HTMLFieldProps<
   string | string[],
   HTMLDivElement,
@@ -94,6 +96,7 @@ function Select({
             }
           }}
           ref={inputRef}
+          style={selectStyle}
           value={value ?? ''}
         >
           {(!!placeholder || !required || value === undefined) && !multiple && (


### PR DESCRIPTION
This change implements variant 2. of fixing SelectField styling issue reported and described in https://github.com/vazco/uniforms/issues/873#issuecomment-784039502.