### PR TITLE
Added tracking to the uniforms website.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,6 +52,9 @@ module.exports = {
     },
     footer: { links: [] },
     googleAnalytics: { trackingID: 'UA-136559762-4' },
+    gtag: {
+      trackingID: 'GTM-5RFDRMB',
+    },
     hideableSidebar: true,
     hotjar: { hjid: 1434110 },
     navbar: {


### PR DESCRIPTION
Added GTM tracking by [plugin-google-gtag](https://v2.docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag) which is available in previously installed preset `@docusaurus/preset-classic`.