### PR TITLE
Fixed handling of white spaces in JSONSchemaBridge (fixes #909).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Fixed:** Handling of `JSONSchemaBridge` errors with top-level fields containing spaces. [\#909](https://github.com/vazco/uniforms/issues/909)
+
 ## [v3.2.1](https://github.com/vazco/uniforms/tree/v3.2.1) (2021-03-10)
 
 - **Fixed:** Incorrect typings of some functions as methods. [\#887](https://github.com/vazco/uniforms/issues/887)

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -222,6 +222,7 @@ describe('JSONSchemaBridge', () => {
         ["a.0.b.c-d.0.f/'g", ".a[0].b['c-d'][0]['f/\\'g']"],
         ['a.0.b.c-d.0.h/"i', ".a[0].b['c-d'][0]['h/\"i']"],
         ['a.0.b.c-d.0.j\'/"k~', ".a[0].b['c-d'][0]['j\\'/\"k~']"],
+        ['a b', '["a b"]'],
       ];
 
       pairs.forEach(([name, dataPath]) => {
@@ -235,6 +236,7 @@ describe('JSONSchemaBridge', () => {
         ["a.0.b.c-d.0.f/'g", "/a/0/b/c-d/0/f~1'g"],
         ['a.0.b.c-d.0.h/"i', '/a/0/b/c-d/0/h~1"i'],
         ['a.0.b.c-d.0.j\'/"k~', '/a/0/b/c-d/0/j\'~1"k~0'],
+        ['a b', '/a b'],
       ];
 
       pairs.forEach(([name, dataPath]) => {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -55,12 +55,12 @@ function extractValue(...xs: (boolean | null | string | undefined)[]) {
 }
 
 function pathToName(path: string) {
-  path = path.startsWith('.')
-    ? path
-        .replace(/\['(.+?)'\]/g, '.$1')
+  path = path.startsWith('/')
+    ? path.replace(/\//g, '.').replace(/~0/g, '~').replace(/~1/g, '/')
+    : path
+        .replace(/\[('|")(.+?)\1\]/g, '.$2')
         .replace(/\[(.+?)\]/g, '.$1')
-        .replace(/\\'/g, "'")
-    : path.replace(/\//g, '.').replace(/~0/g, '~').replace(/~1/g, '/');
+        .replace(/\\'/g, "'");
 
   return path.slice(1);
 }


### PR DESCRIPTION
This PR fixes #909 by handling `JSONSchemaBridge` errors with top-level fields containing spaces.