### PR TITLE
Fix warning 'act' warning in uniforms-antd (closes #877).

### DIFF
--- a/packages/uniforms-antd/__tests__/SelectField.tsx
+++ b/packages/uniforms-antd/__tests__/SelectField.tsx
@@ -79,8 +79,7 @@ test('<SelectField> - renders a select with correct name', () => {
 });
 
 test('<SelectField> - renders a select with correct options', () => {
-  // @ts-expect-error Is open a valid prop?
-  const element = <SelectField name="x" open />;
+  const element = <SelectField name="x" />;
   const wrapper = mount(
     element,
     createContext({ x: { type: String, allowedValues: ['a', 'b'] } }),
@@ -100,8 +99,7 @@ test('<SelectField> - renders a select with correct options', () => {
 
 test('<SelectField> - renders a select with correct options (transform)', () => {
   const element = (
-    // @ts-expect-error Is open a valid prop?
-    <SelectField name="x" open transform={x => x.toUpperCase()} />
+    <SelectField name="x" transform={(x: string) => x.toUpperCase()} />
   );
   const wrapper = mount(
     element,


### PR DESCRIPTION
(See #877 - some warning is reported in uniforms tests)
The warning is fired in two tests in SelectField in uniforms-antd, and both of them uses 'open' prop on SelectField. It seems like props like 'open' and 'defaultOpen' trigger state change after the first render, and it causes the warning and further potential problems.
As I don't see any benefits of using 'open'-like props - test results are perfectly the same, and they are not present in other themes, so I want to propose to not use them here.  
The other way is to trigger an 'open' state of the select after mount simulating proper event, but I don't know if it's really necessary.
