### PR TITLE
Add Ajv v8 support in uniforms-bridge-json-schema (closes #923).

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -182,11 +182,34 @@ describe('JSONSchemaBridge', () => {
       expect(bridge.getError('y', error)).toEqual(null);
     });
 
+    it('works with correct error (instance path)', () => {
+      const error = { details: [{ instancePath: '.x' }] };
+      expect(bridge.getError('x', error)).toEqual(error.details[0]);
+      expect(bridge.getError('y', error)).toEqual(null);
+    });
+
     it('works with correct error (data path at root)', () => {
       const error = {
         details: [
           {
             dataPath: '',
+            keyword: 'required',
+            message: "should have required property 'x'",
+            params: { missingProperty: 'x' },
+            schemaPath: '#/required',
+          },
+        ],
+      };
+
+      expect(bridge.getError('x', error)).toEqual(error.details[0]);
+      expect(bridge.getError('y', error)).toEqual(null);
+    });
+
+    it('works with correct error (instance path at root)', () => {
+      const error = {
+        details: [
+          {
+            instancePath: '',
             keyword: 'required',
             message: "should have required property 'x'",
             params: { missingProperty: 'x' },
@@ -217,6 +240,24 @@ describe('JSONSchemaBridge', () => {
       expect(bridge.getError('y.x', error)).toEqual(null);
     });
 
+    it('works with correct error (instance path of parent)', () => {
+      const error = {
+        details: [
+          {
+            instancePath: '.x',
+            keyword: 'required',
+            message: "should have required property 'y'",
+            params: { missingProperty: 'y' },
+            schemaPath: '#/properties/x/required',
+          },
+        ],
+      };
+
+      expect(bridge.getError('x.x', error)).toEqual(null);
+      expect(bridge.getError('x.y', error)).toEqual(error.details[0]);
+      expect(bridge.getError('y.x', error)).toEqual(null);
+    });
+
     it('works with correct error (complex data paths)', () => {
       const pairs = [
         ["a.0.b.c-d.0.f/'g", ".a[0].b['c-d'][0]['f/\\'g']"],
@@ -231,6 +272,20 @@ describe('JSONSchemaBridge', () => {
       });
     });
 
+    it('works with correct error (complex instance paths)', () => {
+      const pairs = [
+        ["a.0.b.c-d.0.f/'g", ".a[0].b['c-d'][0]['f/\\'g']"],
+        ['a.0.b.c-d.0.h/"i', ".a[0].b['c-d'][0]['h/\"i']"],
+        ['a.0.b.c-d.0.j\'/"k~', ".a[0].b['c-d'][0]['j\\'/\"k~']"],
+        ['a b', '["a b"]'],
+      ];
+
+      pairs.forEach(([name, instancePath]) => {
+        const error = { details: [{ instancePath }] };
+        expect(bridge.getError(name, error)).toEqual(error.details[0]);
+      });
+    });
+
     it('works with correct error (complex data paths - JSON pointers)', () => {
       const pairs = [
         ["a.0.b.c-d.0.f/'g", "/a/0/b/c-d/0/f~1'g"],
@@ -241,6 +296,20 @@ describe('JSONSchemaBridge', () => {
 
       pairs.forEach(([name, dataPath]) => {
         const error = { details: [{ dataPath }] };
+        expect(bridge.getError(name, error)).toEqual(error.details[0]);
+      });
+    });
+
+    it('works with correct error (complex instance paths - JSON pointers)', () => {
+      const pairs = [
+        ["a.0.b.c-d.0.f/'g", "/a/0/b/c-d/0/f~1'g"],
+        ['a.0.b.c-d.0.h/"i', '/a/0/b/c-d/0/h~1"i'],
+        ['a.0.b.c-d.0.j\'/"k~', '/a/0/b/c-d/0/j\'~1"k~0'],
+        ['a b', '/a b'],
+      ];
+
+      pairs.forEach(([name, instancePath]) => {
+        const error = { details: [{ instancePath }] };
         expect(bridge.getError(name, error)).toEqual(error.details[0]);
       });
     });
@@ -265,6 +334,19 @@ describe('JSONSchemaBridge', () => {
       expect(
         bridge.getErrorMessage('age', {
           details: [{ dataPath: '.field', message: 'Ignore!' }],
+        }),
+      ).toBe('');
+    });
+
+    it('works with correct error (instance path)', () => {
+      expect(
+        bridge.getErrorMessage('age', {
+          details: [{ instancePath: '.age', message: 'Zing!' }],
+        }),
+      ).toBe('Zing!');
+      expect(
+        bridge.getErrorMessage('age', {
+          details: [{ instancePath: '.field', message: 'Ignore!' }],
         }),
       ).toBe('');
     });
@@ -295,6 +377,19 @@ describe('JSONSchemaBridge', () => {
       expect(
         bridge.getErrorMessages({
           details: [{ dataPath: '.field', message: 'Ignore!' }],
+        }),
+      ).toEqual(['Ignore!']);
+    });
+
+    it('works with ValidationError (instance path)', () => {
+      expect(
+        bridge.getErrorMessages({
+          details: [{ instancePath: '.age', message: 'Zing!' }],
+        }),
+      ).toEqual(['Zing!']);
+      expect(
+        bridge.getErrorMessages({
+          details: [{ instancePath: '.field', message: 'Ignore!' }],
         }),
       ).toEqual(['Ignore!']);
     });

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -94,7 +94,7 @@ export default class JSONSchemaBridge extends Bridge {
     return (
       // FIXME: Correct type for `error`.
       error?.details?.find?.((detail: any) => {
-        const path = pathToName(detail.dataPath);
+        const path = pathToName(detail.instancePath);
 
         return (
           name === path ||

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -94,7 +94,7 @@ export default class JSONSchemaBridge extends Bridge {
     return (
       // FIXME: Correct type for `error`.
       error?.details?.find?.((detail: any) => {
-        const path = pathToName(detail.instancePath);
+        const path = pathToName(detail.instancePath ?? detail.dataPath);
 
         return (
           name === path ||


### PR DESCRIPTION
As mentioned in #923 in the newest version of Ajv the JSON Schema errors structure has been changed, so I adjusted the error `dataPath` with the fallback for previous Ajv versions.