### PR TITLE
Add 'showInlineError' property to AutoFields (closes #827).

### DIFF
--- a/packages/uniforms-antd/__tests__/AutoFields.tsx
+++ b/packages/uniforms-antd/__tests__/AutoFields.tsx
@@ -98,7 +98,9 @@ test('<AutoFields> - pass props to the children', () => {
     }),
   );
 
-  expect(wrapper.find(AutoField).at(0).prop('showInlineError')).toBeTruthy();
-  expect(wrapper.find(AutoField).at(1).prop('showInlineError')).toBeTruthy();
-  expect(wrapper.find(AutoField).at(2).prop('showInlineError')).toBeTruthy();
+  expect(
+    wrapper
+      .find(AutoField)
+      .every(autoField => autoField.prop('showInlineError')),
+  ).toBeTruthy();
 });

--- a/packages/uniforms-antd/__tests__/AutoFields.tsx
+++ b/packages/uniforms-antd/__tests__/AutoFields.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutoFields } from 'uniforms-antd';
+import { AutoField, AutoFields } from 'uniforms-antd';
 
 import createContext from './_createContext';
 import mount from './_mount';
@@ -85,4 +85,20 @@ test('<AutoFields> - wraps fields in specified element', () => {
   );
 
   expect(wrapper.find('section').find('input')).toHaveLength(3);
+});
+
+test('<AutoFields> - pass props to the children', () => {
+  const element = <AutoFields showInlineError />;
+  const wrapper = mount(
+    element,
+    createContext({
+      x: { type: String },
+      y: { type: String },
+      z: { type: String },
+    }),
+  );
+
+  expect(wrapper.find(AutoField).at(0).prop('showInlineError')).toBeTruthy();
+  expect(wrapper.find(AutoField).at(1).prop('showInlineError')).toBeTruthy();
+  expect(wrapper.find(AutoField).at(2).prop('showInlineError')).toBeTruthy();
 });

--- a/packages/uniforms-antd/__tests__/AutoFields.tsx
+++ b/packages/uniforms-antd/__tests__/AutoFields.tsx
@@ -98,9 +98,9 @@ test('<AutoFields> - pass props to the children', () => {
     }),
   );
 
-  expect(
-    wrapper
-      .find(AutoField)
-      .every(autoField => autoField.prop('showInlineError')),
-  ).toBeTruthy();
+  const hasShowInlineErrorMap = wrapper
+    .find(AutoField)
+    .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toHaveLength(3);
+  expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-antd/src/AutoFields.tsx
+++ b/packages/uniforms-antd/src/AutoFields.tsx
@@ -8,6 +8,7 @@ export type AutoFieldsProps = {
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
+  showInlineError?: boolean;
 };
 
 export default function AutoFields({
@@ -15,6 +16,7 @@ export default function AutoFields({
   element = 'div',
   fields,
   omitFields = [],
+  showInlineError,
   ...props
 }: AutoFieldsProps) {
   const { schema } = useForm();
@@ -24,6 +26,12 @@ export default function AutoFields({
     props,
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
-      .map(field => createElement(autoField, { key: field, name: field })),
+      .map(field =>
+        createElement(autoField, {
+          key: field,
+          name: field,
+          ...(showInlineError !== null ? { showInlineError } : {}),
+        }),
+      ),
   );
 }

--- a/packages/uniforms-antd/src/AutoFields.tsx
+++ b/packages/uniforms-antd/src/AutoFields.tsx
@@ -27,11 +27,13 @@ export default function AutoFields({
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
       .map(field =>
-        createElement(autoField, {
-          key: field,
-          name: field,
-          ...(showInlineError !== null ? { showInlineError } : {}),
-        }),
+        createElement(
+          autoField,
+          Object.assign(
+            { key: field, name: field },
+            showInlineError === undefined ? null : { showInlineError },
+          ),
+        ),
       ),
   );
 }

--- a/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AutoField } from 'uniforms-antd';
 import { AutoFields } from 'uniforms-bootstrap3';
 
 import createContext from './_createContext';
@@ -85,4 +86,22 @@ test('<AutoFields> - wraps fields in specified element', () => {
   );
 
   expect(wrapper.find('section').find('input')).toHaveLength(3);
+});
+
+test('<AutoFields> - pass props to the children', () => {
+  const element = <AutoFields showInlineError />;
+  const wrapper = mount(
+    element,
+    createContext({
+      x: { type: String },
+      y: { type: String },
+      z: { type: String },
+    }),
+  );
+
+  expect(
+    wrapper
+      .find(AutoField)
+      .every(autoField => autoField.prop('showInlineError')),
+  ).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { AutoField } from 'uniforms-antd';
-import { AutoFields } from 'uniforms-bootstrap3';
+import { AutoFields, AutoField } from 'uniforms-bootstrap3';
 
 import createContext from './_createContext';
 import mount from './_mount';
@@ -99,9 +98,8 @@ test('<AutoFields> - pass props to the children', () => {
     }),
   );
 
-  expect(
-    wrapper
-      .find(AutoField)
-      .every(autoField => autoField.prop('showInlineError')),
-  ).toBeTruthy();
+  const hasShowInlineErrorMap = wrapper
+    .find(AutoField)
+    .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
@@ -101,5 +101,6 @@ test('<AutoFields> - pass props to the children', () => {
   const hasShowInlineErrorMap = wrapper
     .find(AutoField)
     .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toHaveLength(3);
   expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap3/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap3/src/AutoFields.tsx
@@ -8,6 +8,7 @@ export type AutoFieldsProps = {
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
+  showInlineError?: boolean;
 };
 
 export default function AutoFields({
@@ -15,6 +16,7 @@ export default function AutoFields({
   element = 'div',
   fields,
   omitFields = [],
+  showInlineError,
   ...props
 }: AutoFieldsProps) {
   const { schema } = useForm();
@@ -24,6 +26,12 @@ export default function AutoFields({
     props,
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
-      .map(field => createElement(autoField, { key: field, name: field })),
+      .map(field =>
+        createElement(autoField, {
+          key: field,
+          name: field,
+          ...(showInlineError !== null ? { showInlineError } : {}),
+        }),
+      ),
   );
 }

--- a/packages/uniforms-bootstrap3/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap3/src/AutoFields.tsx
@@ -27,11 +27,13 @@ export default function AutoFields({
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
       .map(field =>
-        createElement(autoField, {
-          key: field,
-          name: field,
-          ...(showInlineError !== null ? { showInlineError } : {}),
-        }),
+        createElement(
+          autoField,
+          Object.assign(
+            { key: field, name: field },
+            showInlineError === undefined ? null : { showInlineError },
+          ),
+        ),
       ),
   );
 }

--- a/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AutoField } from 'uniforms-antd';
 import { AutoFields } from 'uniforms-bootstrap4';
 
 import createContext from './_createContext';
@@ -85,4 +86,22 @@ test('<AutoFields> - wraps fields in specified element', () => {
   );
 
   expect(wrapper.find('section').find('input')).toHaveLength(3);
+});
+
+test('<AutoFields> - pass props to the child AutoField', () => {
+  const element = <AutoFields showInlineError />;
+  const wrapper = mount(
+    element,
+    createContext({
+      x: { type: String },
+      y: { type: Number },
+      z: { type: Date },
+    }),
+  );
+
+  expect(
+    wrapper
+      .find(AutoField)
+      .every(autoField => autoField.prop('showInlineError')),
+  ).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
@@ -93,8 +93,8 @@ test('<AutoFields> - pass props to the child AutoField', () => {
     element,
     createContext({
       x: { type: String },
-      y: { type: Number },
-      z: { type: Date },
+      y: { type: String },
+      z: { type: String },
     }),
   );
 

--- a/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
@@ -101,5 +101,6 @@ test('<AutoFields> - pass props to the child AutoField', () => {
   const hasShowInlineErrorMap = wrapper
     .find(AutoField)
     .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toHaveLength(3);
   expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { AutoField } from 'uniforms-antd';
-import { AutoFields } from 'uniforms-bootstrap4';
+import { AutoFields, AutoField } from 'uniforms-bootstrap4';
 
 import createContext from './_createContext';
 import mount from './_mount';
@@ -99,9 +98,8 @@ test('<AutoFields> - pass props to the child AutoField', () => {
     }),
   );
 
-  expect(
-    wrapper
-      .find(AutoField)
-      .every(autoField => autoField.prop('showInlineError')),
-  ).toBeTruthy();
+  const hasShowInlineErrorMap = wrapper
+    .find(AutoField)
+    .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap4/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/src/AutoFields.tsx
@@ -8,6 +8,7 @@ export type AutoFieldsProps = {
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
+  showInlineError?: boolean;
 };
 
 export default function AutoFields({
@@ -15,6 +16,7 @@ export default function AutoFields({
   element = 'div',
   fields,
   omitFields = [],
+  showInlineError,
   ...props
 }: AutoFieldsProps) {
   const { schema } = useForm();
@@ -24,6 +26,12 @@ export default function AutoFields({
     props,
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
-      .map(field => createElement(autoField, { key: field, name: field })),
+      .map(field =>
+        createElement(autoField, {
+          key: field,
+          name: field,
+          ...(showInlineError !== null ? { showInlineError } : {}),
+        }),
+      ),
   );
 }

--- a/packages/uniforms-bootstrap4/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/src/AutoFields.tsx
@@ -27,11 +27,13 @@ export default function AutoFields({
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
       .map(field =>
-        createElement(autoField, {
-          key: field,
-          name: field,
-          ...(showInlineError !== null ? { showInlineError } : {}),
-        }),
+        createElement(
+          autoField,
+          Object.assign(
+            { key: field, name: field },
+            showInlineError === undefined ? null : { showInlineError },
+          ),
+        ),
       ),
   );
 }

--- a/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AutoField } from 'uniforms-antd';
 import { AutoFields } from 'uniforms-bootstrap5';
 
 import createContext from './_createContext';
@@ -85,4 +86,22 @@ test('<AutoFields> - wraps fields in specified element', () => {
   );
 
   expect(wrapper.find('section').find('input')).toHaveLength(3);
+});
+
+test('<AutoFields> - pass props to the children', () => {
+  const element = <AutoFields showInlineError />;
+  const wrapper = mount(
+    element,
+    createContext({
+      x: { type: String },
+      y: { type: String },
+      z: { type: String },
+    }),
+  );
+
+  expect(
+    wrapper
+      .find(AutoField)
+      .every(autoField => autoField.prop('showInlineError')),
+  ).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { AutoField } from 'uniforms-antd';
-import { AutoFields } from 'uniforms-bootstrap5';
+import { AutoFields, AutoField } from 'uniforms-bootstrap5';
 
 import createContext from './_createContext';
 import mount from './_mount';
@@ -99,9 +98,8 @@ test('<AutoFields> - pass props to the children', () => {
     }),
   );
 
-  expect(
-    wrapper
-      .find(AutoField)
-      .every(autoField => autoField.prop('showInlineError')),
-  ).toBeTruthy();
+  const hasShowInlineErrorMap = wrapper
+    .find(AutoField)
+    .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
@@ -101,5 +101,6 @@ test('<AutoFields> - pass props to the children', () => {
   const hasShowInlineErrorMap = wrapper
     .find(AutoField)
     .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toHaveLength(3);
   expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-bootstrap5/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap5/src/AutoFields.tsx
@@ -8,6 +8,7 @@ export type AutoFieldsProps = {
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
+  showInlineError?: boolean;
 };
 
 export default function AutoFields({
@@ -15,6 +16,7 @@ export default function AutoFields({
   element = 'div',
   fields,
   omitFields = [],
+  showInlineError,
   ...props
 }: AutoFieldsProps) {
   const { schema } = useForm();
@@ -24,6 +26,12 @@ export default function AutoFields({
     props,
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
-      .map(field => createElement(autoField, { key: field, name: field })),
+      .map(field =>
+        createElement(autoField, {
+          key: field,
+          name: field,
+          ...(showInlineError !== null ? { showInlineError } : {}),
+        }),
+      ),
   );
 }

--- a/packages/uniforms-bootstrap5/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap5/src/AutoFields.tsx
@@ -27,11 +27,13 @@ export default function AutoFields({
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
       .map(field =>
-        createElement(autoField, {
-          key: field,
-          name: field,
-          ...(showInlineError !== null ? { showInlineError } : {}),
-        }),
+        createElement(
+          autoField,
+          Object.assign(
+            { key: field, name: field },
+            showInlineError === undefined ? null : { showInlineError },
+          ),
+        ),
       ),
   );
 }

--- a/packages/uniforms-material/__tests__/AutoFields.tsx
+++ b/packages/uniforms-material/__tests__/AutoFields.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { AutoField } from 'uniforms-antd';
-import { AutoFields } from 'uniforms-material';
+import { AutoField, AutoFields } from 'uniforms-material';
 
 import createContext from './_createContext';
 import mount from './_mount';

--- a/packages/uniforms-material/__tests__/AutoFields.tsx
+++ b/packages/uniforms-material/__tests__/AutoFields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AutoField } from 'uniforms-antd';
 import { AutoFields } from 'uniforms-material';
 
 import createContext from './_createContext';
@@ -85,4 +86,22 @@ test('<AutoFields> - wraps fields in specified element', () => {
   );
 
   expect(wrapper.find('section').find('input')).toHaveLength(3);
+});
+
+test('<AutoFields> - pass props to the children', () => {
+  const element = <AutoFields showInlineError />;
+  const wrapper = mount(
+    element,
+    createContext({
+      x: { type: String },
+      y: { type: String },
+      z: { type: String },
+    }),
+  );
+
+  expect(
+    wrapper
+      .find(AutoField)
+      .every(autoField => autoField.prop('showInlineError')),
+  ).toBeTruthy();
 });

--- a/packages/uniforms-material/__tests__/AutoFields.tsx
+++ b/packages/uniforms-material/__tests__/AutoFields.tsx
@@ -98,9 +98,9 @@ test('<AutoFields> - pass props to the children', () => {
     }),
   );
 
-  expect(
-    wrapper
-      .find(AutoField)
-      .every(autoField => autoField.prop('showInlineError')),
-  ).toBeTruthy();
+  const hasShowInlineErrorMap = wrapper
+    .find(AutoField)
+    .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toHaveLength(3);
+  expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-material/src/AutoFields.tsx
+++ b/packages/uniforms-material/src/AutoFields.tsx
@@ -8,6 +8,7 @@ export type AutoFieldsProps = {
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
+  showInlineError?: boolean;
 };
 
 export default function AutoFields({
@@ -15,6 +16,7 @@ export default function AutoFields({
   element = 'div',
   fields,
   omitFields = [],
+  showInlineError,
   ...props
 }: AutoFieldsProps) {
   const { schema } = useForm();
@@ -24,6 +26,12 @@ export default function AutoFields({
     props,
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
-      .map(field => createElement(autoField, { key: field, name: field })),
+      .map(field =>
+        createElement(autoField, {
+          key: field,
+          name: field,
+          ...(showInlineError !== null ? { showInlineError } : {}),
+        }),
+      ),
   );
 }

--- a/packages/uniforms-material/src/AutoFields.tsx
+++ b/packages/uniforms-material/src/AutoFields.tsx
@@ -27,11 +27,13 @@ export default function AutoFields({
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
       .map(field =>
-        createElement(autoField, {
-          key: field,
-          name: field,
-          ...(showInlineError !== null ? { showInlineError } : {}),
-        }),
+        createElement(
+          autoField,
+          Object.assign(
+            { key: field, name: field },
+            showInlineError === undefined ? null : { showInlineError },
+          ),
+        ),
       ),
   );
 }

--- a/packages/uniforms-semantic/__tests__/AutoFields.tsx
+++ b/packages/uniforms-semantic/__tests__/AutoFields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AutoField } from 'uniforms-antd';
 import { AutoFields } from 'uniforms-semantic';
 
 import createContext from './_createContext';
@@ -85,4 +86,22 @@ test('<AutoFields> - wraps fields in specified element', () => {
   );
 
   expect(wrapper.find('section').find('input')).toHaveLength(3);
+});
+
+test('<AutoFields> - pass props to the children', () => {
+  const element = <AutoFields showInlineError />;
+  const wrapper = mount(
+    element,
+    createContext({
+      x: { type: String },
+      y: { type: String },
+      z: { type: String },
+    }),
+  );
+
+  expect(
+    wrapper
+      .find(AutoField)
+      .every(autoField => autoField.prop('showInlineError')),
+  ).toBeTruthy();
 });

--- a/packages/uniforms-semantic/__tests__/AutoFields.tsx
+++ b/packages/uniforms-semantic/__tests__/AutoFields.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { AutoField } from 'uniforms-antd';
-import { AutoFields } from 'uniforms-semantic';
+import { AutoField, AutoFields } from 'uniforms-semantic';
 
 import createContext from './_createContext';
 import mount from './_mount';

--- a/packages/uniforms-semantic/__tests__/AutoFields.tsx
+++ b/packages/uniforms-semantic/__tests__/AutoFields.tsx
@@ -98,9 +98,9 @@ test('<AutoFields> - pass props to the children', () => {
     }),
   );
 
-  expect(
-    wrapper
-      .find(AutoField)
-      .every(autoField => autoField.prop('showInlineError')),
-  ).toBeTruthy();
+  const hasShowInlineErrorMap = wrapper
+    .find(AutoField)
+    .map(node => node.prop('showInlineError'));
+  expect(hasShowInlineErrorMap).toHaveLength(3);
+  expect(hasShowInlineErrorMap).toBeTruthy();
 });

--- a/packages/uniforms-semantic/src/AutoFields.tsx
+++ b/packages/uniforms-semantic/src/AutoFields.tsx
@@ -8,6 +8,7 @@ export type AutoFieldsProps = {
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
+  showInlineError?: boolean;
 };
 
 export default function AutoFields({
@@ -15,6 +16,7 @@ export default function AutoFields({
   element = 'div',
   fields,
   omitFields = [],
+  showInlineError,
   ...props
 }: AutoFieldsProps) {
   const { schema } = useForm();
@@ -24,6 +26,12 @@ export default function AutoFields({
     props,
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
-      .map(field => createElement(autoField, { key: field, name: field })),
+      .map(field =>
+        createElement(autoField, {
+          key: field,
+          name: field,
+          ...(showInlineError !== null ? { showInlineError } : {}),
+        }),
+      ),
   );
 }

--- a/packages/uniforms-semantic/src/AutoFields.tsx
+++ b/packages/uniforms-semantic/src/AutoFields.tsx
@@ -27,11 +27,13 @@ export default function AutoFields({
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
       .map(field =>
-        createElement(autoField, {
-          key: field,
-          name: field,
-          ...(showInlineError !== null ? { showInlineError } : {}),
-        }),
+        createElement(
+          autoField,
+          Object.assign(
+            { key: field, name: field },
+            showInlineError === undefined ? null : { showInlineError },
+          ),
+        ),
       ),
   );
 }


### PR DESCRIPTION
Added a possibility to pass 'showInlineError' to `AutoFields` in all themes except uniforms-unstyled, which was requested in #827.

I didn't come up with the idea of how to provide the possibility to pass all (or most) props to children `AutoField`. We just have to move them to a common property object and pass them to children, which precludes nice UX mentioned by @Floriferous because the interface differs from the `AutoField`. On the other hand, we have to provide an API to configure the `AutoFields` container component, so we have a override with the child `AutoField`, or we have to move this API to a common prop object - which is breaking change.

Therefore I introduce a minimal change in `AutoFields` allowing you to pass 'showInlineError' prop, and I want you to share your thoughts.