### PR TITLE
Added success field style in Bootstrap themes (closes #899).

### DIFF
--- a/packages/uniforms-bootstrap3/src/wrapField.tsx
+++ b/packages/uniforms-bootstrap3/src/wrapField.tsx
@@ -8,6 +8,7 @@ import gridClassName from './gridClassName';
 type WrapperProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
+    changed?: boolean;
     error?: unknown;
     errorMessage?: string;
     feedbackable?: boolean;
@@ -25,6 +26,7 @@ type WrapperProps = Override<
 // eslint-disable-next-line complexity
 export default function wrapField(
   {
+    changed = false,
     className,
     disabled,
     error,
@@ -59,6 +61,7 @@ export default function wrapField(
       className={classnames(className, 'field', 'form-group', {
         'has-feedback': error && feedbackable,
         'has-error': error,
+        'has-success': !error && changed,
         disabled,
         required,
       })}

--- a/packages/uniforms-bootstrap3/src/wrapField.tsx
+++ b/packages/uniforms-bootstrap3/src/wrapField.tsx
@@ -26,7 +26,7 @@ type WrapperProps = Override<
 // eslint-disable-next-line complexity
 export default function wrapField(
   {
-    changed = false,
+    changed,
     className,
     disabled,
     error,

--- a/packages/uniforms-bootstrap4/src/BoolField.tsx
+++ b/packages/uniforms-bootstrap4/src/BoolField.tsx
@@ -42,7 +42,6 @@ function Bool({ onChange, ...props }: BoolFieldProps) {
         <input
           checked={value || false}
           className={classnames('form-check-input', {
-            'form-check-input': props.error,
             'is-valid': !props.error && props.changed,
           })}
           disabled={disabled}

--- a/packages/uniforms-bootstrap4/src/BoolField.tsx
+++ b/packages/uniforms-bootstrap4/src/BoolField.tsx
@@ -34,16 +34,13 @@ function Bool({ onChange, ...props }: BoolFieldProps) {
       className={classnames(inputClassName, 'form-check', 'checkbox', {
         'custom-control-inline': inline,
         'text-danger': error,
-        'text-success':
-          !props.error && props.value !== undefined && props.changed,
+        'text-success': !props.error && props.changed,
       })}
     >
       <label htmlFor={props.id} className="form-check-label">
         <input
           checked={value || false}
-          className={classnames('form-check-input', {
-            'is-valid': !props.error && props.changed,
-          })}
+          className="form-check-input"
           disabled={disabled}
           id={props.id}
           name={name}

--- a/packages/uniforms-bootstrap4/src/BoolField.tsx
+++ b/packages/uniforms-bootstrap4/src/BoolField.tsx
@@ -32,14 +32,19 @@ function Bool({ onChange, ...props }: BoolFieldProps) {
     { ...props, label: labelBefore, value: props.value },
     <div
       className={classnames(inputClassName, 'form-check', 'checkbox', {
-        'text-danger': error,
         'custom-control-inline': inline,
+        'text-danger': error,
+        'text-success':
+          !props.error && props.value !== undefined && props.changed,
       })}
     >
       <label htmlFor={props.id} className="form-check-label">
         <input
           checked={value || false}
-          className="form-check-input"
+          className={classnames('form-check-input', {
+            'form-check-input': props.error,
+            'is-valid': !props.error && props.changed,
+          })}
           disabled={disabled}
           id={props.id}
           name={name}

--- a/packages/uniforms-bootstrap4/src/BoolField.tsx
+++ b/packages/uniforms-bootstrap4/src/BoolField.tsx
@@ -34,7 +34,7 @@ function Bool({ onChange, ...props }: BoolFieldProps) {
       className={classnames(inputClassName, 'form-check', 'checkbox', {
         'custom-control-inline': inline,
         'text-danger': error,
-        'text-success': !props.error && props.changed,
+        'text-success': !error && props.changed,
       })}
     >
       <label htmlFor={props.id} className="form-check-label">

--- a/packages/uniforms-bootstrap4/src/DateField.tsx
+++ b/packages/uniforms-bootstrap4/src/DateField.tsx
@@ -39,6 +39,7 @@ function Date({
     <input
       className={classnames(inputClassName, 'form-control', {
         'is-invalid': error,
+        'is-valid': !error && !!value && props.changed,
       })}
       disabled={disabled}
       id={id}

--- a/packages/uniforms-bootstrap4/src/DateField.tsx
+++ b/packages/uniforms-bootstrap4/src/DateField.tsx
@@ -39,7 +39,7 @@ function Date({
     <input
       className={classnames(inputClassName, 'form-control', {
         'is-invalid': error,
-        'is-valid': !error && !!value && props.changed,
+        'is-valid': !error && props.changed,
       })}
       disabled={disabled}
       id={id}

--- a/packages/uniforms-bootstrap4/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap4/src/LongTextField.tsx
@@ -16,7 +16,7 @@ function LongText(props: LongTextFieldProps) {
     <textarea
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
-        'is-valid': !props.error && !!props.value && props.changed,
+        'is-valid': !props.error && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap4/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap4/src/LongTextField.tsx
@@ -16,6 +16,7 @@ function LongText(props: LongTextFieldProps) {
     <textarea
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
+        'is-valid': !props.error && !!props.value && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap4/src/NumField.tsx
+++ b/packages/uniforms-bootstrap4/src/NumField.tsx
@@ -20,6 +20,7 @@ function Num(props: NumFieldProps) {
     <input
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
+        'is-valid': !props.error && !!props.value && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap4/src/NumField.tsx
+++ b/packages/uniforms-bootstrap4/src/NumField.tsx
@@ -20,7 +20,7 @@ function Num(props: NumFieldProps) {
     <input
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
-        'is-valid': !props.error && !!props.value && props.changed,
+        'is-valid': !props.error && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap4/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap4/src/RadioField.tsx
@@ -30,8 +30,7 @@ function Radio(props: RadioFieldProps) {
         className={classnames(props.inputClassName, 'form-check', 'radio', {
           'custom-control-inline': props.inline,
           'text-danger': props.error,
-          'text-success':
-            !props.error && props.value !== undefined && props.changed,
+          'text-success': !props.error && props.changed,
         })}
       >
         <label

--- a/packages/uniforms-bootstrap4/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap4/src/RadioField.tsx
@@ -28,8 +28,10 @@ function Radio(props: RadioFieldProps) {
       <div
         key={item}
         className={classnames(props.inputClassName, 'form-check', 'radio', {
-          'text-danger': props.error,
           'custom-control-inline': props.inline,
+          'text-danger': props.error,
+          'text-success':
+            !props.error && props.value !== undefined && props.changed,
         })}
       >
         <label

--- a/packages/uniforms-bootstrap4/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/src/SelectField.tsx
@@ -86,7 +86,7 @@ function Select({
       <select
         className={classnames(inputClassName, 'c-select form-control', {
           'is-invalid': error,
-          'is-valid': !error && !!value && props.changed,
+          'is-valid': !error && props.changed,
         })}
         disabled={disabled}
         id={id}

--- a/packages/uniforms-bootstrap4/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/src/SelectField.tsx
@@ -86,6 +86,7 @@ function Select({
       <select
         className={classnames(inputClassName, 'c-select form-control', {
           'is-invalid': error,
+          'is-valid': !error && !!value && props.changed,
         })}
         disabled={disabled}
         id={id}

--- a/packages/uniforms-bootstrap4/src/TextField.tsx
+++ b/packages/uniforms-bootstrap4/src/TextField.tsx
@@ -18,6 +18,7 @@ function Text(props: TextFieldProps) {
       autoComplete={props.autoComplete}
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
+        'is-valid': !props.error && !!props.value && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap4/src/TextField.tsx
+++ b/packages/uniforms-bootstrap4/src/TextField.tsx
@@ -18,7 +18,7 @@ function Text(props: TextFieldProps) {
       autoComplete={props.autoComplete}
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
-        'is-valid': !props.error && !!props.value && props.changed,
+        'is-valid': !props.error && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap4/src/wrapField.tsx
+++ b/packages/uniforms-bootstrap4/src/wrapField.tsx
@@ -54,6 +54,7 @@ export default function wrapField(
     <div
       className={classnames(className, 'form-group', {
         'is-invalid': error,
+        'is-valid': !error && !!props.value,
         disabled,
         required,
         row: grid,
@@ -74,6 +75,7 @@ export default function wrapField(
             {
               'col-form-label': grid,
               'text-danger': error,
+              'text-success': !error && props.value !== undefined,
             },
             gridClassName(grid, 'label'),
             labelClassName,

--- a/packages/uniforms-bootstrap4/src/wrapField.tsx
+++ b/packages/uniforms-bootstrap4/src/wrapField.tsx
@@ -8,6 +8,7 @@ import gridClassName from './gridClassName';
 type WrapperProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
+    changed?: boolean;
     error?: unknown;
     errorMessage?: string;
     grid?: number | string | Record<string, number>;
@@ -23,6 +24,7 @@ type WrapperProps = Override<
 
 export default function wrapField(
   {
+    changed = false,
     className,
     disabled,
     error,
@@ -49,12 +51,13 @@ export default function wrapField(
       {help}
     </span>
   );
+  const isValid = !error && changed;
 
   return (
     <div
       className={classnames(className, 'form-group', {
         'is-invalid': error,
-        'is-valid': !error && !!props.value,
+        'is-valid': isValid,
         disabled,
         required,
         row: grid,
@@ -75,7 +78,7 @@ export default function wrapField(
             {
               'col-form-label': grid,
               'text-danger': error,
-              'text-success': !error && props.value !== undefined,
+              'text-success': isValid,
             },
             gridClassName(grid, 'label'),
             labelClassName,

--- a/packages/uniforms-bootstrap4/src/wrapField.tsx
+++ b/packages/uniforms-bootstrap4/src/wrapField.tsx
@@ -24,7 +24,7 @@ type WrapperProps = Override<
 
 export default function wrapField(
   {
-    changed = false,
+    changed,
     className,
     disabled,
     error,

--- a/packages/uniforms-bootstrap5/src/BoolField.tsx
+++ b/packages/uniforms-bootstrap5/src/BoolField.tsx
@@ -32,7 +32,8 @@ function Bool({ onChange, ...props }: BoolFieldProps) {
     { ...props, label: labelBefore, value: props.value },
     <div
       className={classnames(inputClassName, 'form-check', {
-        'is-invalid': error,
+        'text-danger': error,
+        'text-success': !error && props.changed,
         'form-check-inline': inline,
       })}
     >

--- a/packages/uniforms-bootstrap5/src/DateField.tsx
+++ b/packages/uniforms-bootstrap5/src/DateField.tsx
@@ -39,6 +39,7 @@ function Date({
     <input
       className={classnames(inputClassName, 'form-control', {
         'is-invalid': error,
+        'is-valid': !error && props.changed,
       })}
       disabled={disabled}
       id={id}

--- a/packages/uniforms-bootstrap5/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap5/src/LongTextField.tsx
@@ -16,6 +16,7 @@ function LongText(props: LongTextFieldProps) {
     <textarea
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
+        'is-valid': !props.error && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap5/src/NumField.tsx
+++ b/packages/uniforms-bootstrap5/src/NumField.tsx
@@ -20,6 +20,7 @@ function Num(props: NumFieldProps) {
     <input
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
+        'is-valid': !props.error && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap5/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap5/src/RadioField.tsx
@@ -29,6 +29,7 @@ function Radio(props: RadioFieldProps) {
         key={item}
         className={classnames(props.inputClassName, 'form-check', {
           'text-danger': props.error,
+          'text-success': !props.error && props.changed,
           'form-check-inline': props.inline,
         })}
       >

--- a/packages/uniforms-bootstrap5/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap5/src/SelectField.tsx
@@ -86,6 +86,7 @@ function Select({
       <select
         className={classnames(inputClassName, 'form-control', {
           'is-invalid': error,
+          'is-valid': !error && props.changed,
         })}
         disabled={disabled}
         id={id}

--- a/packages/uniforms-bootstrap5/src/TextField.tsx
+++ b/packages/uniforms-bootstrap5/src/TextField.tsx
@@ -18,6 +18,7 @@ function Text(props: TextFieldProps) {
       autoComplete={props.autoComplete}
       className={classnames(props.inputClassName, 'form-control', {
         'is-invalid': props.error,
+        'is-valid': !props.error && props.changed,
       })}
       disabled={props.disabled}
       id={props.id}

--- a/packages/uniforms-bootstrap5/src/wrapField.tsx
+++ b/packages/uniforms-bootstrap5/src/wrapField.tsx
@@ -24,7 +24,7 @@ type WrapperProps = Override<
 
 export default function wrapField(
   {
-    changed = false,
+    changed,
     className,
     disabled,
     error,

--- a/packages/uniforms-bootstrap5/src/wrapField.tsx
+++ b/packages/uniforms-bootstrap5/src/wrapField.tsx
@@ -8,6 +8,7 @@ import gridClassName from './gridClassName';
 type WrapperProps = Override<
   Omit<HTMLProps<HTMLDivElement>, 'onChange'>,
   {
+    changed?: boolean;
     error?: unknown;
     errorMessage?: string;
     grid?: number | string | Record<string, number>;
@@ -23,6 +24,7 @@ type WrapperProps = Override<
 
 export default function wrapField(
   {
+    changed = false,
     className,
     disabled,
     error,
@@ -74,6 +76,7 @@ export default function wrapField(
             {
               'col-form-label': grid,
               'text-danger': error,
+              'text-success': !error && changed,
             },
             gridClassName(grid, 'label'),
             labelClassName,


### PR DESCRIPTION
This PR introduces new style for successfully validated fields in Bootstrap themes (requested in #899)
- [x] uniforms-bootstrap3
- [x] uniforms-bootstrap4
- [x] uniforms-bootstrap5

I tried to stay consistent with current success styles, here are some examples from the playground:
![image](https://user-images.githubusercontent.com/17573948/114418572-edbcf600-9bb2-11eb-9fd1-831b807cbca5.png)
![image](https://user-images.githubusercontent.com/17573948/114418684-0cbb8800-9bb3-11eb-9730-eb66d26cedfe.png)

