### PR TITLE
Added `submitted` context data documentation (closes #914).

### DIFF
--- a/docs/api-context-data.md
+++ b/docs/api-context-data.md
@@ -136,6 +136,10 @@ The state properties are:
 |    `readOnly`     |       Indicates whether the form is read-only.       |
 | `showInlineError` | Indicates whether the inline errors should be shown. |
 
+### `submitted`
+
+Indicates whether the form was submitted.
+
 ### `submitting`
 
 Indicates whether the form is in the `submitting` state. Helpful when handling asynchronous submission.

--- a/docs/api-helpers.md
+++ b/docs/api-helpers.md
@@ -24,7 +24,6 @@ The table below lists all of the **guaranteed** props that will be passed to the
 |    `onChange`     | `func(value, [name])` |          Change field value.           |
 |   `placeholder`   |       `string`        |           Field placeholder.           |
 |    `readOnly`     |       `boolean`       |          Is field read-only?           |
-|    `submitted`    |       `boolean`       |     Has the field been submitted?      |
 | `showInlineError` |       `boolean`       |           Show inline error?           |
 |      `value`      |         `any`         |              Field value.              |
 

--- a/docs/api-helpers.md
+++ b/docs/api-helpers.md
@@ -24,6 +24,7 @@ The table below lists all of the **guaranteed** props that will be passed to the
 |    `onChange`     | `func(value, [name])` |          Change field value.           |
 |   `placeholder`   |       `string`        |           Field placeholder.           |
 |    `readOnly`     |       `boolean`       |          Is field read-only?           |
+|    `submitted`    |       `boolean`       |     Has the field been submitted?      |
 | `showInlineError` |       `boolean`       |           Show inline error?           |
 |      `value`      |         `any`         |              Field value.              |
 


### PR DESCRIPTION
Added `submitted` context data documentation Context data and Helpers page in API Reference.