### PR TITLE
Optimized joinName.

### DIFF
--- a/packages/uniforms/__tests__/joinName.ts
+++ b/packages/uniforms/__tests__/joinName.ts
@@ -10,6 +10,7 @@ describe('joinName', () => {
     expect(joinName(null, 'a')).toEqual(['a']);
     expect(joinName(null, 'a', 'b')).toEqual(['a', 'b']);
     expect(joinName(null, 'a', 'b', null)).toEqual(['a', 'b']);
+    expect(joinName(null, 'a', 'b', null, 0)).toEqual(['a', 'b', '0']);
     expect(joinName(null, 'a', 'b', null, 1)).toEqual(['a', 'b', '1']);
   });
 
@@ -31,6 +32,9 @@ describe('joinName', () => {
   });
 
   it('works with numbers', () => {
+    expect(joinName(0, 'a', 'b')).toBe('0.a.b');
+    expect(joinName('a', 0, 'b')).toBe('a.0.b');
+    expect(joinName('a', 'b', 0)).toBe('a.b.0');
     expect(joinName(1, 'a', 'b')).toBe('1.a.b');
     expect(joinName('a', 1, 'b')).toBe('a.1.b');
     expect(joinName('a', 'b', 1)).toBe('a.b.1');

--- a/packages/uniforms/src/joinName.ts
+++ b/packages/uniforms/src/joinName.ts
@@ -1,13 +1,23 @@
 export function joinName(flag: null, ...parts: unknown[]): string[];
 export function joinName(...parts: unknown[]): string;
 export function joinName(...parts: unknown[]) {
-  const name = parts.reduce(
-    (parts: unknown[], part: unknown) =>
-      part || part === 0
-        ? parts.concat(typeof part === 'string' ? part.split('.') : part)
-        : parts,
-    [],
-  );
+  const name: string[] = [];
+  for (let index = 0; index !== parts.length; ++index) {
+    const part = parts[index];
+    if (part || part === 0) {
+      if (typeof part === 'string') {
+        if (part.indexOf('.') !== -1) {
+          name.push(...part.split('.'));
+        } else {
+          name.push(part);
+        }
+      } else if (Array.isArray(part)) {
+        parts.splice(index--, 1, ...part);
+      } else {
+        name.push('' + part);
+      }
+    }
+  }
 
-  return parts[0] === null ? name.map(part => '' + part) : name.join('.');
+  return parts[0] === null ? name : name.join('.');
 }


### PR DESCRIPTION
This PR optimizes the `joinName` helper without affecting its functionality. On the presented benchmark, the performance improved from 217ms to 79ms (best time out of 25 runs).

<details>
<summary>Benchmark</summary>

```ts
describe('benchmark', () => {
  it.each(Array.from({ length: 25 }, (_, x) => x + 1))('is fast %i', () => {
    expect(true).toBe(true);
    for (let index = 0; index < 5000; ++index) {
      joinName(null);
      joinName(null, 'a');
      joinName(null, 'a', 'b');
      joinName(null, 'a', 'b', null);
      joinName(null, 'a', 'b', null, 0);
      joinName(null, 'a', 'b', null, 1);
      joinName(['a'], 'b');
      joinName('a', ['b']);
      joinName('', 'a', 'b');
      joinName('a', '', 'b');
      joinName('a', 'b', '');
      joinName('a', null, 'b');
      joinName('a', false, 'b');
      joinName('a', undefined, 'b');
      joinName(0, 'a', 'b');
      joinName('a', 0, 'b');
      joinName('a', 'b', 0);
      joinName(1, 'a', 'b');
      joinName('a', 1, 'b');
      joinName('a', 'b', 1);
      joinName('a', 'b.c.d');
      joinName('a.b', 'c.d');
      joinName('a.b.c', 'd');
      joinName(null, 'a', 'b.c.d');
      joinName(null, 'a.b', 'c.d');
      joinName(null, 'a.b.c', 'd');
    }
  });
});
```

</details>