### PR TITLE
Added conditional properties and required field assignment in uniforms-bridge-json-schema (closing #919).

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -728,10 +728,17 @@ describe('JSONSchemaBridge', () => {
       });
     });
 
-    it('works with anyOf for a non-object computed property', () => {
+    it('works with anyOf for a non-object computed property (required default value)', () => {
       expect(bridge.getProps('nonObjectAnyOf')).toHaveProperty(
         'required',
         false,
+      );
+    });
+
+    it('works with anyOf for a non-object computed property (properties not defined)', () => {
+      expect(bridge.getProps('nonObjectAnyOf')).toHaveProperty(
+        'properties',
+        undefined,
       );
     });
 

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -166,10 +166,9 @@ describe('JSONSchemaBridge', () => {
             minimum: 0,
           },
         ],
-        required: true,
       },
     },
-    required: ['dateOfBirth'],
+    required: ['dateOfBirth', 'nonObjectAnyOfRequired'],
   };
 
   const validator = jest.fn();

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -135,6 +135,22 @@ describe('JSONSchemaBridge', () => {
         maxItems: 3,
         minItems: 1,
       },
+      nonObjectAnyOf: {
+        anyOf: [
+          {
+            const: 'alphabetic',
+            type: 'string',
+          },
+          {
+            enum: ['top', 'middle', 'bottom'],
+            type: 'string',
+          },
+          {
+            type: 'number',
+            minimum: 0,
+          },
+        ],
+      },
     },
     required: ['dateOfBirth'],
   };
@@ -712,6 +728,13 @@ describe('JSONSchemaBridge', () => {
       });
     });
 
+    it('works with anyOf for a non-object computed property', () => {
+      expect(bridge.getProps('nonObjectAnyOf')).toHaveProperty(
+        'required',
+        false,
+      );
+    });
+
     it('works with maxItems in props', () => {
       expect(bridge.getProps('arrayWithAllOf')).toHaveProperty('maxCount', 3);
     });
@@ -753,6 +776,7 @@ describe('JSONSchemaBridge', () => {
         'passwordNumeric',
         'recursive',
         'arrayWithAllOf',
+        'nonObjectAnyOf',
       ]);
     });
 

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -151,6 +151,23 @@ describe('JSONSchemaBridge', () => {
           },
         ],
       },
+      nonObjectAnyOfRequired: {
+        anyOf: [
+          {
+            const: 'alphabetic',
+            type: 'string',
+          },
+          {
+            enum: ['top', 'middle', 'bottom'],
+            type: 'string',
+          },
+          {
+            type: 'number',
+            minimum: 0,
+          },
+        ],
+        required: true,
+      },
     },
     required: ['dateOfBirth'],
   };
@@ -735,6 +752,13 @@ describe('JSONSchemaBridge', () => {
       );
     });
 
+    it('works with anyOf for a non-object computed property (required)', () => {
+      expect(bridge.getProps('nonObjectAnyOfRequired')).toHaveProperty(
+        'required',
+        true,
+      );
+    });
+
     it('works with anyOf for a non-object computed property (properties not defined)', () => {
       expect(bridge.getProps('nonObjectAnyOf')).toHaveProperty(
         'properties',
@@ -784,6 +808,7 @@ describe('JSONSchemaBridge', () => {
         'recursive',
         'arrayWithAllOf',
         'nonObjectAnyOf',
+        'nonObjectAnyOfRequired',
       ]);
     });
 

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -198,9 +198,7 @@ export default class JSONSchemaBridge extends Bridge {
           ? { ...definition.properties }
           : {};
         const localRequired = definition.required
-          ? Array.isArray(definition.required)
-            ? definition.required.slice()
-            : definition.required
+          ? definition.required.slice()
           : [];
 
         combinedPartials.forEach(({ properties, required, type }) => {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -194,8 +194,8 @@ export default class JSONSchemaBridge extends Bridge {
         .filter(Boolean);
 
       if (combinedPartials.length) {
-        const localProperties = definition.properties ?? {};
-        const localRequired = definition.required ?? [];
+        const localProperties = definition.properties ? { ...definition.properties } : {};
+        const localRequired = definition.required ? definition.required.slice() : [];
 
         combinedPartials.forEach(({ properties, required, type }) => {
           if (properties) {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -194,8 +194,14 @@ export default class JSONSchemaBridge extends Bridge {
         .filter(Boolean);
 
       if (combinedPartials.length) {
-        const localProperties = definition.properties ? { ...definition.properties } : {};
-        const localRequired = definition.required ? definition.required.slice() : [];
+        const localProperties = definition.properties
+          ? { ...definition.properties }
+          : {};
+        const localRequired = definition.required
+          ? Array.isArray(definition.required)
+            ? definition.required.slice()
+            : definition.required
+          : [];
 
         combinedPartials.forEach(({ properties, required, type }) => {
           if (properties) {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -194,20 +194,27 @@ export default class JSONSchemaBridge extends Bridge {
         .filter(Boolean);
 
       if (combinedPartials.length) {
-        _definition.properties = definition.properties ?? {};
-        _definition.required = definition.required ?? [];
+        const localProperties = definition.properties ?? {};
+        const localRequired = definition.required ?? [];
 
         combinedPartials.forEach(({ properties, required, type }) => {
           if (properties) {
-            Object.assign(_definition.properties, properties);
+            Object.assign(localProperties, properties);
           }
           if (required) {
-            _definition.required.push(...required);
+            localRequired.push(...required);
           }
           if (type && !_definition.type) {
             _definition.type = type;
           }
         });
+
+        if (Object.keys(localProperties).length > 0) {
+          _definition.properties = localProperties;
+        }
+        if (localRequired.length > 0) {
+          _definition.required = localRequired;
+        }
       }
 
       this._compiledSchema[_key] = Object.assign(_definition, { isRequired });


### PR DESCRIPTION
Fixed a bug where a field with no computed required subfields gets an empty 'required' prop. The same situation occurs with the 'properties'.