### PR TITLE
Added support for objects without properties (closes #934).

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -167,6 +167,7 @@ describe('JSONSchemaBridge', () => {
           },
         ],
       },
+      objectWithoutProperties: { type: 'object' },
     },
     required: ['dateOfBirth', 'nonObjectAnyOfRequired'],
   };
@@ -808,6 +809,7 @@ describe('JSONSchemaBridge', () => {
         'arrayWithAllOf',
         'nonObjectAnyOf',
         'nonObjectAnyOfRequired',
+        'objectWithoutProperties',
       ]);
     });
 
@@ -841,6 +843,10 @@ describe('JSONSchemaBridge', () => {
       );
 
       expect(localBridge.getSubfields()).toEqual(['city', 'state', 'street']);
+    });
+
+    it('works when an object does not have properties', () => {
+      expect(bridge.getSubfields('objectWithoutProperties')).toEqual([]);
     });
 
     it('works on top level when schema does not have properties', () => {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -316,7 +316,7 @@ export default class JSONSchemaBridge extends Bridge {
       properties: fieldProperties = _properties,
     } = this._compiledSchema[name];
 
-    if (fieldType === 'object') {
+    if (fieldType === 'object' && fieldProperties) {
       return Object.keys(fieldProperties);
     }
 

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -79,6 +79,7 @@ export default class JSONSchemaBridge extends Bridge {
     super();
 
     this.schema = distinctSchema(schema);
+    this._compiledSchema[''] = this.schema;
 
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
@@ -301,23 +302,15 @@ export default class JSONSchemaBridge extends Bridge {
     return ready;
   }
 
-  getSubfields(name?: string) {
-    if (!name) {
-      if (this.schema.properties) {
-        return Object.keys(this.schema.properties);
-      }
-
-      return [];
-    }
-
-    const { type: _type, properties: _properties } = this.getField(name);
+  getSubfields(name = '') {
+    const field = this.getField(name);
     const {
-      type: fieldType = _type,
-      properties: fieldProperties = _properties,
+      properties = field.properties,
+      type = field.type,
     } = this._compiledSchema[name];
 
-    if (fieldType === 'object' && fieldProperties) {
-      return Object.keys(fieldProperties);
+    if (type === 'object' && properties) {
+      return Object.keys(properties);
     }
 
     return [];


### PR DESCRIPTION
This PR adds support for `object` fields without `properties` in `JSONSchemaBridge`, closing #934.