### PR TITLE
Improved test coverage

### DIFF
--- a/packages/uniforms-bootstrap3/src/DateField.tsx
+++ b/packages/uniforms-bootstrap3/src/DateField.tsx
@@ -4,6 +4,7 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
+/* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
 

--- a/packages/uniforms-bootstrap3/src/NestField.tsx
+++ b/packages/uniforms-bootstrap3/src/NestField.tsx
@@ -32,7 +32,7 @@ const Nest = ({
     )}
 
     {children ||
-      fields?.map(field => (
+      fields.map(field => (
         <AutoField key={field} name={field} {...itemProps} />
       ))}
   </div>

--- a/packages/uniforms-bootstrap3/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap3/src/RadioField.tsx
@@ -4,10 +4,10 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = HTMLFieldProps<

--- a/packages/uniforms-bootstrap3/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap3/src/SelectField.tsx
@@ -5,10 +5,10 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type SelectFieldProps = HTMLFieldProps<

--- a/packages/uniforms-bootstrap4/src/DateField.tsx
+++ b/packages/uniforms-bootstrap4/src/DateField.tsx
@@ -4,6 +4,7 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
+/* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
 

--- a/packages/uniforms-bootstrap4/src/NestField.tsx
+++ b/packages/uniforms-bootstrap4/src/NestField.tsx
@@ -33,7 +33,7 @@ function Nest({
       )}
 
       {children ||
-        fields?.map(field => (
+        fields.map(field => (
           <AutoField key={field} name={field} {...itemProps} />
         ))}
     </div>

--- a/packages/uniforms-bootstrap4/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap4/src/RadioField.tsx
@@ -4,10 +4,10 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = HTMLFieldProps<

--- a/packages/uniforms-bootstrap4/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap4/src/SelectField.tsx
@@ -5,10 +5,10 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type SelectFieldProps = HTMLFieldProps<

--- a/packages/uniforms-bootstrap5/src/DateField.tsx
+++ b/packages/uniforms-bootstrap5/src/DateField.tsx
@@ -4,6 +4,7 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
+/* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
 

--- a/packages/uniforms-bootstrap5/src/NestField.tsx
+++ b/packages/uniforms-bootstrap5/src/NestField.tsx
@@ -33,7 +33,7 @@ function Nest({
       )}
 
       {children ||
-        fields?.map(field => (
+        fields.map(field => (
           <AutoField key={field} name={field} {...itemProps} />
         ))}
     </div>

--- a/packages/uniforms-bootstrap5/src/RadioField.tsx
+++ b/packages/uniforms-bootstrap5/src/RadioField.tsx
@@ -4,10 +4,10 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = HTMLFieldProps<

--- a/packages/uniforms-bootstrap5/src/SelectField.tsx
+++ b/packages/uniforms-bootstrap5/src/SelectField.tsx
@@ -5,10 +5,10 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type SelectFieldProps = HTMLFieldProps<

--- a/packages/uniforms-material/src/DateField.tsx
+++ b/packages/uniforms-material/src/DateField.tsx
@@ -2,6 +2,7 @@ import TextField, { StandardTextFieldProps } from '@material-ui/core/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
+/* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 const dateFormat = (value?: Date) => value && value.toISOString().slice(0, -8);
 const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {

--- a/packages/uniforms-material/src/NestField.tsx
+++ b/packages/uniforms-material/src/NestField.tsx
@@ -25,7 +25,7 @@ function Nest({
     { ...props, component: undefined, fullWidth, margin },
     label && <FormLabel component="legend">{label}</FormLabel>,
     children ||
-      fields?.map(field => (
+      fields.map(field => (
         <AutoField key={field} name={field} {...itemProps} />
       )),
   );

--- a/packages/uniforms-material/src/SelectField.tsx
+++ b/packages/uniforms-material/src/SelectField.tsx
@@ -49,10 +49,10 @@ type SelectProps = FieldProps<
 export type SelectFieldProps = (CheckboxesProps | SelectProps) &
   SelectFieldCommonProps;
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 // eslint-disable-next-line complexity

--- a/packages/uniforms-semantic/src/DateField.tsx
+++ b/packages/uniforms-semantic/src/DateField.tsx
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import React, { Ref } from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 
+/* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
 

--- a/packages/uniforms-semantic/src/NestField.tsx
+++ b/packages/uniforms-semantic/src/NestField.tsx
@@ -39,7 +39,7 @@ function Nest({
       )}
 
       {children ||
-        fields?.map(field => (
+        fields.map(field => (
           <AutoField key={field} name={field} {...itemProps} />
         ))}
     </div>

--- a/packages/uniforms-semantic/src/RadioField.tsx
+++ b/packages/uniforms-semantic/src/RadioField.tsx
@@ -3,10 +3,10 @@ import omit from 'lodash/omit';
 import React from 'react';
 import { connectField, filterDOMProps, HTMLFieldProps } from 'uniforms';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = HTMLFieldProps<

--- a/packages/uniforms-semantic/src/SelectField.tsx
+++ b/packages/uniforms-semantic/src/SelectField.tsx
@@ -3,10 +3,10 @@ import xor from 'lodash/xor';
 import React, { Ref } from 'react';
 import { connectField, filterDOMProps, HTMLFieldProps } from 'uniforms';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 const selectStyle = { paddingBottom: 0, paddingTop: 0 };

--- a/packages/uniforms-unstyled/src/DateField.tsx
+++ b/packages/uniforms-unstyled/src/DateField.tsx
@@ -1,6 +1,7 @@
 import React, { Ref } from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 
+/* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
 

--- a/packages/uniforms-unstyled/src/RadioField.tsx
+++ b/packages/uniforms-unstyled/src/RadioField.tsx
@@ -2,10 +2,10 @@ import omit from 'lodash/omit';
 import React from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 
-const base64 =
-  typeof btoa !== 'undefined'
-    ? btoa
-    : (x: string) => Buffer.from(x).toString('base64');
+const base64: typeof btoa =
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type RadioFieldProps = HTMLFieldProps<

--- a/packages/uniforms-unstyled/src/SelectField.tsx
+++ b/packages/uniforms-unstyled/src/SelectField.tsx
@@ -3,7 +3,9 @@ import React, { Ref } from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 
 const base64: typeof btoa =
-  typeof btoa !== 'undefined' ? btoa : x => Buffer.from(x).toString('base64');
+  typeof btoa === 'undefined'
+    ? /* istanbul ignore next */ x => Buffer.from(x).toString('base64')
+    : btoa;
 const escape = (x: string) => base64(encodeURIComponent(x)).replace(/=+$/, '');
 
 export type SelectFieldProps = HTMLFieldProps<

--- a/packages/uniforms/__tests__/randomIds.ts
+++ b/packages/uniforms/__tests__/randomIds.ts
@@ -9,6 +9,11 @@ describe('randomIds', () => {
     expect(randomIds()).toBeInstanceOf(Function);
   });
 
+  it('accepts custom prefix', () => {
+    const generator = randomIds('my-id-generator');
+    expect(generator()).toMatch(/^my-id-generator/);
+  });
+
   it('generate random id', () => {
     const amount = 100;
 

--- a/packages/uniforms/__tests__/useField.tsx
+++ b/packages/uniforms/__tests__/useField.tsx
@@ -1,0 +1,55 @@
+import React, { ReactNode } from 'react';
+import { BaseForm, useField } from 'uniforms';
+import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
+
+import mount from './_mount';
+
+describe('useField', () => {
+  const bridge = new JSONSchemaBridge(
+    {
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'object', properties: { c: { type: 'string' } } },
+      },
+    },
+    () => {},
+  );
+
+  function Test(rawProps: {
+    children?: ReactNode;
+    name: string;
+    options?: Parameters<typeof useField>[2];
+  }) {
+    const [props] = useField(rawProps.name, rawProps, rawProps.options);
+    return <>{props.children}</>;
+  }
+
+  it('is a function', () => {
+    expect(useField).toBeInstanceOf(Function);
+  });
+
+  describe('when called with `absoluteName`', () => {
+    it('works on top-level', () => {
+      mount(
+        <BaseForm schema={bridge}>
+          <Test name="a" options={{ absoluteName: true }} />
+          <Test name="b" options={{ absoluteName: true }} />
+          <Test name="b.c" options={{ absoluteName: true }} />
+        </BaseForm>,
+      );
+    });
+
+    it('works nested', () => {
+      mount(
+        <BaseForm schema={bridge}>
+          <Test name="b">
+            <Test name="a" options={{ absoluteName: true }} />
+            <Test name="b" options={{ absoluteName: true }} />
+            <Test name="b.c" options={{ absoluteName: true }} />
+          </Test>
+        </BaseForm>,
+      );
+    });
+  });
+});

--- a/packages/uniforms/src/useField.tsx
+++ b/packages/uniforms/src/useField.tsx
@@ -19,6 +19,7 @@ function propagate(
   const value =
     prop === '' ||
     prop === false ||
+    prop === null ||
     (forcedFallbackInProp && (forcedFallbackInSchema || !state))
       ? ''
       : forcedFallbackInProp

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "paths": { "uniforms": ["uniforms/src"], "uniforms-*": ["uniforms-*/src"] },
-    "strict": true
+    "strict": true,
+    "target": "ESNext"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "moduleResolution": "node",
     "paths": { "uniforms": ["uniforms/src"], "uniforms-*": ["uniforms-*/src"] },
     "strict": true,
-    "target": "ESNext"
+    "target": "ES6"
   }
 }


### PR DESCRIPTION
This PR targets to improve our test coverage. Hopefully, we'll reach 100% once again! To do so, I:
* Added `/* istanbul ignore next */` to our `btoa` and `global` polyfills.
* Configured `tsconfig.json` for `target: 'ESNext'` due to https://github.com/istanbuljs/nyc/issues/727.
* Added and/or updated unit tests.
    * This actually highlighted a slight regression with handling `label={null}`. Nice!
* Removed unnecessary optional chaining.