### PR TITLE
Optimized `changedKeys`.

### DIFF
--- a/packages/uniforms/src/changedKeys.ts
+++ b/packages/uniforms/src/changedKeys.ts
@@ -1,24 +1,36 @@
 import isEqual from 'lodash/isEqual';
-import xorWith from 'lodash/xorWith';
 
 import { joinName } from './joinName';
 
+// eslint-disable-next-line complexity
 export function changedKeys<T>(root: string, valueA?: T, valueB?: T) {
   if (!valueA || valueA !== Object(valueA) || valueA instanceof Date) {
     return isEqual(valueA, valueB) ? [] : [root];
   }
-  if (!valueB) {
-    return [root, ...Object.keys(valueA).map(key => joinName(root, key))];
+
+  const changed = [root];
+  if (valueB) {
+    for (const key in valueA) {
+      if (!(key in valueB) || !isEqual(valueA[key], valueB[key])) {
+        changed.push(joinName(root, key));
+      }
+    }
+
+    for (const key in valueB) {
+      if (!(key in valueA)) {
+        changed.push(joinName(root, key));
+      }
+    }
+
+    if (changed.length === 1) {
+      changed.pop();
+    }
+  } else {
+    // eslint-disable-next-line guard-for-in
+    for (const key in valueA) {
+      changed.push(joinName(root, key));
+    }
   }
 
-  const changed = xorWith(
-    Object.entries(valueA),
-    Object.entries(valueB),
-    isEqual,
-  ).map(pair => joinName(root, pair[0]));
-
-  if (changed.length) {
-    changed.unshift(root);
-  }
   return changed;
 }


### PR DESCRIPTION
This is the third and probably the last PR focused on optimizing one hottest functions, at least for now. Here I focused on `changedKeys`. On the benchmark I prepared, the time dropped from 626ms down to 247ms, which makes almost 60% improvement. Additionally, we no longer rely on `xorWith`, making the bundle _slightly_ smaller.

The only downside is that the implementation is now _slightly_ more complex, but I find it more verbose than the current one.

<details>
<summary>Benchmark</summary>

```tsx
describe('benchmark', () => {
  it.each(Array.from({ length: 25 }, (_, x) => x + 1))('is fast %i', () => {
    expect(true).toBe(true);
    for (let index = 0; index < 5000; ++index) {
      changedKeys('a', [], []);
      changedKeys('a', [1], [1]);
      changedKeys('a', [1, 2], [1, 2]);
      changedKeys('a', new Date(10), new Date(10));
      changedKeys('a', new Date(20), new Date(20));
      changedKeys('a', new Date(30), new Date(30));
      changedKeys('a', {}, {});
      changedKeys('a', { a: 1 }, { a: 1 });
      changedKeys('a', { a: 1, b: 2 }, { a: 1, b: 2 });
      changedKeys('a', 1, 1);
      changedKeys('a', null, null);
      changedKeys('a', true, true);
      changedKeys('a', 'no', 'no');
      changedKeys('a', [], [1]);
      changedKeys('a', [1], [1, 2]);
      changedKeys('a', [1, 2], [1, 2, 3]);
      changedKeys('a', new Date(10), new Date(20));
      changedKeys('a', new Date(20), new Date(30));
      changedKeys('a', new Date(30), new Date(40));
      changedKeys('a', {}, { a: 1 });
      changedKeys('a', { a: 1 }, { a: 1, b: 2 });
      changedKeys('a', { a: 1, b: 2 }, { a: 1, b: 2, c: 3 });
      changedKeys('a', 1, 2);
      changedKeys('a', null, true);
      changedKeys('a', true, null);
      changedKeys('a', 'no', 'pe');
      changedKeys('a', [1]);
      changedKeys('a', [1], []);
      changedKeys('a', [1, 2], [1]);
      changedKeys('a', [1, 2, 3], [1, 2]);
      changedKeys('a', new Date(20));
      changedKeys('a', new Date(20), new Date(10));
      changedKeys('a', new Date(30), new Date(20));
      changedKeys('a', new Date(40), new Date(30));
      changedKeys('a', { a: 1 });
      changedKeys('a', { a: 1 }, {});
      changedKeys('a', { a: 1, b: 2 }, { a: 1 });
      changedKeys('a', { a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
      changedKeys('a', 2);
      changedKeys('a', 2, 1);
      changedKeys('a', true, null);
      changedKeys('a', null, true);
      changedKeys('a', 'pe', 'no');
    }
  });
});
```

</details>