### PR TITLE
Unified `getErrorMessages` across bridges (fixes #950).

### DIFF
--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -135,6 +135,7 @@ describe('GraphQLBridge', () => {
 
   describe('#getErrorMessages', () => {
     it('works without error', () => {
+      expect(bridgeI.getErrorMessages(null)).toEqual([]);
       expect(bridgeI.getErrorMessages(undefined)).toEqual([]);
     });
 

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -49,22 +49,14 @@ export default class GraphQLBridge extends Bridge {
   }
 
   getErrorMessages(error: any) {
-    if (error) {
-      if (Array.isArray(error.details)) {
-        // FIXME: Correct type for `error`.
-        return (error.details as any[]).map(error => error.message);
-      }
-
-      if (error.message) {
-        return [error.message];
-      }
+    if (!error) {
+      return [];
     }
 
-    if (error !== undefined) {
-      return [error];
-    }
-
-    return [];
+    const { details } = error;
+    return Array.isArray(details)
+      ? details.map(error => error.message)
+      : [error.message || error];
   }
 
   getField(name: string) {

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -387,6 +387,7 @@ describe('JSONSchemaBridge', () => {
 
   describe('#getErrorMessages', () => {
     it('works without error', () => {
+      expect(bridge.getErrorMessages(null)).toEqual([]);
       expect(bridge.getErrorMessages(undefined)).toEqual([]);
     });
 

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -111,19 +111,14 @@ export default class JSONSchemaBridge extends Bridge {
   }
 
   getErrorMessages(error: any) {
-    if (error) {
-      if (Array.isArray(error.details)) {
-        // FIXME: Correct type for `error`.
-        return (error.details as any[]).reduce(
-          (acc, { message }) => acc.concat(message),
-          [],
-        );
-      }
-
-      return [error.message || error];
+    if (!error) {
+      return [];
     }
 
-    return [];
+    const { details } = error;
+    return Array.isArray(details)
+      ? details.map(error => error.message)
+      : [error.message || error];
   }
 
   getField(name: string) {

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -87,6 +87,7 @@ describe('SimpleSchema2Bridge', () => {
 
   describe('#getErrorMessages', () => {
     it('works without error', () => {
+      expect(bridge.getErrorMessages(null)).toEqual([]);
       expect(bridge.getErrorMessages(undefined)).toEqual([]);
     });
 

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -26,25 +26,15 @@ export default class SimpleSchema2Bridge extends Bridge {
   }
 
   getErrorMessages(error: any) {
-    if (error) {
-      if (Array.isArray(error.details)) {
-        // FIXME: Correct type for `error`.
-        return (error.details as any[]).map(error =>
-          // @ts-expect-error: `messageForError` has incorrect typing.
-          this.schema.messageForError(error),
-        );
-      }
-
-      if (error.message) {
-        return [error.message];
-      }
+    if (!error) {
+      return [];
     }
 
-    if (error !== undefined) {
-      return [error];
-    }
-
-    return [];
+    const { details } = error;
+    return Array.isArray(details)
+      ? // @ts-expect-error: `messageForError` has incorrect typing.
+        details.map(error => this.schema.messageForError(error))
+      : [error.message || error];
   }
 
   getField(name: string) {

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -120,6 +120,7 @@ describe('SimpleSchemaBridge', () => {
 
   describe('#getErrorMessages', () => {
     it('works without error', () => {
+      expect(bridge.getErrorMessages(null)).toEqual([]);
       expect(bridge.getErrorMessages(undefined)).toEqual([]);
     });
 

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -33,29 +33,21 @@ export default class SimpleSchemaBridge extends Bridge {
   }
 
   getErrorMessages(error: any) {
-    if (error) {
-      if (Array.isArray(error.details)) {
-        // FIXME: Correct type for `error`.
-        return (error.details as any[]).map(error =>
+    if (!error) {
+      return [];
+    }
+
+    const { details } = error;
+    return Array.isArray(details)
+      ? details.map(error =>
           this.schema.messageForError(
             error.type,
             error.name,
             null,
             error.details && error.details.value,
           ),
-        );
-      }
-
-      if (error.message) {
-        return [error.message];
-      }
-    }
-
-    if (error !== undefined) {
-      return [error];
-    }
-
-    return [];
+        )
+      : [error.message || error];
   }
 
   getField(name: string) {


### PR DESCRIPTION
This PR fixes #950 as well as unifies the implementations of `getErrorMessages` across all bridges.