### PR TITLE
Optimized and unified bridges logic.

### DIFF
--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -227,7 +227,7 @@ describe('GraphQLBridge', () => {
           it('should use AST field name', () => {
             expect(bridgeT.getProps('title')).toEqual({
               allowedValues: ['a', 'b', 'Some Title'],
-              label: '',
+              label: false,
               required: false,
               transform: expect.any(Function),
               options: [
@@ -271,7 +271,7 @@ describe('GraphQLBridge', () => {
         it('should use label from props', () => {
           expect(bridgeT.getProps('title', { label: 'Overriden' })).toEqual({
             allowedValues: ['a', 'b', 'Some Title'],
-            label: '',
+            label: false,
             required: false,
             transform: expect.any(Function),
             options: [
@@ -283,7 +283,7 @@ describe('GraphQLBridge', () => {
           });
           expect(bridgeT.getProps('title', { label: '' })).toEqual({
             allowedValues: ['a', 'b', 'Some Title'],
-            label: '',
+            label: false,
             required: false,
             transform: expect.any(Function),
             options: [
@@ -395,10 +395,10 @@ describe('GraphQLBridge', () => {
       });
     });
 
-    it('works with placeholder (extra.placeholedr === undefined)', () => {
+    it('works with placeholder (extra.placeholder === undefined)', () => {
       expect(bridgeI.getProps('title', { placeholder: true })).toEqual({
         allowedValues: ['a', 'b', 'Some Title'],
-        label: '',
+        label: false,
         required: false,
         transform: expect.any(Function),
         options: [

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -4,6 +4,8 @@ import memoize from 'lodash/memoize';
 import SimpleSchema from 'simpl-schema';
 import { Bridge, joinName } from 'uniforms';
 
+const propsToRemove = ['optional', 'type', 'uniforms'];
+
 export default class SimpleSchema2Bridge extends Bridge {
   constructor(public schema: SimpleSchema) {
     super();
@@ -15,8 +17,12 @@ export default class SimpleSchema2Bridge extends Bridge {
   }
 
   getError(name: string, error: any) {
-    // FIXME: Correct type for `error`.
-    return error?.details?.find?.((error: any) => error.name === name) || null;
+    const details = error?.details;
+    if (!Array.isArray(details)) {
+      return null;
+    }
+
+    return details.find(error => error.name === name) || null;
   }
 
   getErrorMessage(name: string, error: any) {
@@ -63,13 +69,12 @@ export default class SimpleSchema2Bridge extends Bridge {
     return merged;
   }
 
-  getInitialValue(name: string, props: Record<string, any> = {}): any {
+  getInitialValue(name: string, props?: Record<string, any>): any {
     const field = this.getField(name);
 
     if (field.type === Array) {
       const item = this.getInitialValue(joinName(name, '0'));
-      const items = Math.max(props.initialCount || 0, field.minCount || 0);
-
+      const items = Math.max(props?.initialCount || 0, field.minCount || 0);
       return Array.from({ length: items }, () => item);
     }
 
@@ -81,58 +86,62 @@ export default class SimpleSchema2Bridge extends Bridge {
   }
 
   // eslint-disable-next-line complexity
-  getProps(name: string, props: Record<string, any> = {}) {
-    const { optional, type, uniforms, ...contextField } = this.getField(name);
-    let field = { ...contextField, required: !optional };
+  getProps(name: string, fieldProps?: Record<string, any>) {
+    const props = Object.assign({}, this.getField(name));
+    props.required = !props.optional;
 
-    if (uniforms) {
-      if (typeof uniforms === 'string' || typeof uniforms === 'function') {
-        field = { ...field, component: uniforms };
-      } else {
-        field = { ...field, ...uniforms };
-      }
+    if (
+      typeof props.uniforms === 'function' ||
+      typeof props.uniforms === 'string'
+    ) {
+      props.component = props.uniforms;
+    } else {
+      Object.assign(props, props.uniforms);
     }
 
-    if (type === Array) {
-      try {
-        const itemProps = this.getProps(`${name}.$`, props);
-        if (itemProps.allowedValues && !props.allowedValues) {
-          field.allowedValues = itemProps.allowedValues;
-        }
-
-        if (itemProps.transform && !props.transform) {
-          field.transform = itemProps.transform;
-        }
-      } catch (_) {
-        /* ignore it */
-      }
-    } else if (type === Number) {
-      field = { ...field, decimal: true };
+    if (props.type === Number) {
+      props.decimal = true;
     }
 
-    let options = props.options || field.options;
+    type OptionDict = Record<string, string>;
+    type OptionList = { label: string; value: unknown }[];
+    type Options = OptionDict | OptionList | (() => OptionDict | OptionList);
+    let options: Options = fieldProps?.options || props.options;
     if (options) {
       if (typeof options === 'function') {
         options = options();
       }
 
-      if (!Array.isArray(options)) {
-        field = {
-          ...field,
-          transform: (value: any) => options[value],
-          allowedValues: Object.keys(options),
-        };
+      if (Array.isArray(options)) {
+        props.allowedValues = options.map(option => option.value);
+        props.transform = (value: unknown) =>
+          (options as OptionList).find(option => option.value === value)!.label;
       } else {
-        field = {
-          ...field,
-          transform: (value: any) =>
-            (options as any[]).find(option => option.value === value).label,
-          allowedValues: options.map(option => option.value),
-        };
+        props.allowedValues = Object.keys(options);
+        props.transform = (value: string) => (options as OptionDict)[value];
+      }
+    } else if (props.type === Array) {
+      try {
+        const itemProps = this.getProps(`${name}.$`, fieldProps);
+        if (itemProps.allowedValues && !fieldProps?.allowedValues) {
+          props.allowedValues = itemProps.allowedValues;
+        }
+
+        if (itemProps.transform && !fieldProps?.transform) {
+          props.transform = itemProps.transform;
+        }
+      } catch (_) {
+        // It's fine.
       }
     }
 
-    return field;
+    propsToRemove.forEach(key => {
+      if (key in props) {
+        delete props[key];
+      }
+    });
+
+    return props;
   }
 
   getSubfields(name?: string) {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -62,7 +62,7 @@ export default class SimpleSchema2Bridge extends Bridge {
       try {
         merged.defaultValue = merged.autoValue.call({ operator: null });
       } catch (_) {
-        /* ignore it */
+        // It's fine.
       }
     }
 


### PR DESCRIPTION
Encouraged by the previous performance-oriented PRs (#935, #939, ad #953) as well as the one with unifying bridges logic (#956), I went one step further and done it for all the bridges. Now, this not only brings better performance but also simplifies and unifies their code. Bundles are also a little bit smaller than before.

Performance-wise, I focused on `JSONSchemaBridge`, as it has the most complex `getProps` of all the bridges. As I changed the `getField` as well, I measured `getProps` both with and without `memoize`ing `getField`. Overall, the new implementation is faster without cache than the old one with caching!
|     | with `memoize`  | without `memoize` |
| - | - | - |
| old | 523ms | 834ms |
| new | 195ms | 404ms |

<details>
<summary>Benchmark</summary>

```ts
import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';

const schema = {
  $schema: 'http://json-schema.org/draft-06/schema#',
  definitions: {
    address: {
      type: 'object',
      properties: {
        city: { type: 'string', uniforms: { label: false, required: false } },
        state: {
          type: 'string',
          options: [
            { label: 'Alabama', value: 'AL' },
            { label: 'Alaska', value: 'AK' },
            { label: 'Arkansas', value: 'AR' },
          ],
        },
        street: { type: 'string' },
      },
      required: ['street', 'city', 'state'],
    },
    personalData: {
      type: 'object',
      properties: {
        firstName: { $ref: '#/definitions/firstName' },
        lastName: { $ref: '#/definitions/firstName' },
      },
      required: ['lastName'],
    },
    firstName: { type: 'string', default: 'John' },
    lastName: { type: 'string' },
    recursive: {
      type: 'object',
      properties: {
        field: { type: 'string' },
        recursive: { $ref: '#/definitions/recursive' },
      },
    },
  },
  type: 'object',
  properties: {
    age: { type: 'integer', uniforms: { component: 'span' }, default: 24 },
    billingAddress: { $ref: '#/definitions/address' },
    custom: { type: 'custom' },
    dateOfBirth: {
      type: 'string',
      format: 'date-time',
    },
    dateOfBirthTuple: {
      type: 'array',
      items: [{ type: 'integer' }, { type: 'string' }, { type: 'integer' }],
    },
    email: {
      type: 'object',
      properties: {
        work: { type: 'string' },
        other: { type: 'string' },
      },
      required: ['work'],
    },
    friends: {
      type: 'array',
      items: {
        $ref: '#/definitions/personalData',
      },
    },
    hasAJob: { type: 'boolean', title: 'Currently Employed' },
    invalid: { type: 'null' },
    personalData: { $ref: '#/definitions/personalData' },
    salary: {
      type: 'number',
      options: {
        low: 6000,
        medium: 12000,
        height: 18000,
      },
    },
    shippingAddress: {
      allOf: [
        { $ref: '#/definitions/address' },
        {
          properties: {
            type: { enum: ['residential', 'business'] },
          },
          required: ['type'],
        },
      ],
    },
    complexNames: {
      type: 'object',
      properties: {
        a: {
          type: 'array',
          items: {
            type: 'object',
            properties: {
              b: {
                type: 'object',
                properties: {
                  'c-d': {
                    type: 'array',
                    items: {
                      type: 'object',
                      properties: {
                        "f/'g": { type: 'string', pattern: '[0-9]{5}' },
                        'h/"i': { type: 'string', pattern: '[0-9]{5}' },
                        'j\'/"k': { type: 'string', pattern: '[0-9]{5}' },
                      },
                    },
                  },
                },
              },
            },
          },
        },
      },
    },
    password: { type: 'string', uniforms: { type: 'password' } },
    passwordNumeric: {
      type: 'number',
      uniforms: { type: 'password' },
      maximum: 9999,
      minimum: 1000,
      multipleOf: 3,
    },
    recursive: { $ref: '#/definitions/recursive' },
    arrayWithAllOf: {
      type: 'array',
      items: {
        type: 'object',
        allOf: [{ required: ['child'] }],
        properties: { child: { type: 'string' } },
      },
      maxItems: 3,
      minItems: 1,
    },
    nonObjectAnyOf: {
      anyOf: [
        {
          const: 'alphabetic',
          type: 'string',
        },
        {
          enum: ['top', 'middle', 'bottom'],
          type: 'string',
        },
        {
          type: 'number',
          minimum: 0,
        },
      ],
    },
    nonObjectAnyOfRequired: {
      anyOf: [
        {
          const: 'alphabetic',
          type: 'string',
        },
        {
          enum: ['top', 'middle', 'bottom'],
          type: 'string',
        },
        {
          type: 'number',
          minimum: 0,
        },
      ],
    },
    objectWithoutProperties: { type: 'object' },
  },
  required: ['dateOfBirth', 'nonObjectAnyOfRequired'],
};

const validator = jest.fn();
const bridge = new JSONSchemaBridge(schema, validator);

describe('benchmark', () => {
  it.each(Array.from({ length: 25 }, (_, x) => x + 1))('is fast %i', () => {
    expect(true).toBe(true);
    for (let index = 0; index < 1000; ++index) {
      bridge.getProps('shippingAddress.type');
      bridge.getProps('shippingAddress.type', { allowedValues: [1] });
      bridge.getProps('age');
      bridge.getProps('dateOfBirth', { label: 'Death' });
      bridge.getProps('dateOfBirth', { label: true });
      bridge.getProps('hasAJob', { label: true });
      bridge.getProps('billingAddress.city');
      bridge.getProps('dateOfBirth', { label: null });
      bridge.getProps('email.work', { placeholder: 'Email' });
      bridge.getProps('email.work', { placeholder: true });
      bridge.getProps('email.work', { placeholder: null });
      bridge.getProps('email.work', { label: null, placeholder: true });
      bridge.getProps('email.work', { label: false, placeholder: true });
      bridge.getProps('salary');
      bridge.getProps('billingAddress.state');
      bridge.getProps('billingAddress.state');
      bridge.getProps('billingAddress.state');
      bridge.getProps('billingAddress.state');
      bridge.getProps('salary');
      bridge.getProps('salary');
      bridge.getProps('salary');
      bridge.getProps('salary');
      bridge.getProps('salary', { options: { minimal: 4000, avarage: 8000 } });
      bridge.getProps('salary', { options: { minimal: 4000, avarage: 8000 } });
      bridge.getProps('salary', { options: { minimal: 4000, avarage: 8000 } });
      bridge.getProps('salary', { options: { minimal: 4000, avarage: 8000 } });
      bridge.getProps('password');
      bridge.getProps('passwordNumeric');
      bridge.getProps('personalData.firstName', { x: 1, y: 1 });
      bridge.getProps('arrayWithAllOf.0.child');
      bridge.getProps('nonObjectAnyOf');
      bridge.getProps('nonObjectAnyOfRequired');
      bridge.getProps('nonObjectAnyOf');
      bridge.getProps('arrayWithAllOf');
      bridge.getProps('arrayWithAllOf');
      bridge.getProps('passwordNumeric');
      bridge.getProps('passwordNumeric');
      bridge.getProps('passwordNumeric');
    }
  });
});
```

</details>

Of course, the sheer amount of changes also impacts the behavior a little:
* `getError` now does `Array.isArray` check, instead of duck typing `.find`.
* `getProps` now no longer duplicates the logic of resolving `label` of `useField`. However, this was never working correctly (it was different between the bridges and deviated a little from the `useField` logic).
* `JSONSchemaBridge` will **never** yield `$ref` prop (previously it did _sometimes_).
* `JSONSchemaBridge` will no longer store resolved `allOf`/`anyOf`/`oneOf` references on the `_compiledSchema` property (it's "private" anyway).