### PR TITLE
Improved DateField label in Material-UI theme.

### DIFF
--- a/packages/uniforms-material/src/DateField.tsx
+++ b/packages/uniforms-material/src/DateField.tsx
@@ -44,7 +44,7 @@ function Date({
       fullWidth
       helperText={(error && showInlineError && errorMessage) || helperText}
       label={label}
-      InputLabelProps={{ ...labelProps, ...InputLabelProps }}
+      InputLabelProps={{ ...labelProps, ...InputLabelProps, shrink: true }}
       inputProps={{ readOnly }}
       margin="dense"
       name={name}

--- a/packages/uniforms-material/src/DateField.tsx
+++ b/packages/uniforms-material/src/DateField.tsx
@@ -44,7 +44,7 @@ function Date({
       fullWidth
       helperText={(error && showInlineError && errorMessage) || helperText}
       label={label}
-      InputLabelProps={{ ...labelProps, ...InputLabelProps, shrink: true }}
+      InputLabelProps={{ shrink: true, ...labelProps, ...InputLabelProps }}
       inputProps={{ readOnly }}
       margin="dense"
       name={name}


### PR DESCRIPTION
Improved DateField label in Material-UI theme.

Before:
![image](https://user-images.githubusercontent.com/47716936/118481081-631c6900-b713-11eb-9361-6c3c4138c82f.png)

After:
![image](https://user-images.githubusercontent.com/47716936/118481108-6a437700-b713-11eb-958f-edf9c0ad84c8.png)
