### PR TITLE
Improved field type inference (fixes #951).

### DIFF
--- a/packages/uniforms-antd/__tests__/SelectField.tsx
+++ b/packages/uniforms-antd/__tests__/SelectField.tsx
@@ -388,7 +388,7 @@ test('<SelectField checkboxes> - renders a set of checkboxes with correct option
     <SelectField
       checkboxes
       name="x"
-      transform={(x: string) => x.toUpperCase()}
+      transform={(x: unknown) => String(x).toUpperCase()}
     />
   );
   const wrapper = mount(

--- a/packages/uniforms-material/__tests__/SelectField.tsx
+++ b/packages/uniforms-material/__tests__/SelectField.tsx
@@ -308,7 +308,6 @@ test('<SelectField> - disabled items (options) based on predicate', () => {
 
 test('<SelectField> - renders with correct classnames', () => {
   const wrapper = mount(
-    // @ts-expect-error Fix SelectFieldProps.
     <SelectField name="x" textFieldProps={{ className: 'select-class' }} />,
     createContext({ x: { type: String, allowedValues: ['a', 'b'] } }),
   );

--- a/packages/uniforms-material/src/SelectField.tsx
+++ b/packages/uniforms-material/src/SelectField.tsx
@@ -18,10 +18,8 @@ import wrapField from './wrapField';
 type SelectFieldCommonProps = {
   allowedValues?: string[];
   appearance?: 'checkbox' | 'switch';
-  checkboxes?: boolean;
   disableItem?: (value: string) => boolean;
   inputRef?: Ref<HTMLButtonElement>;
-  native?: boolean;
   required?: boolean;
   transform?: (value: string) => string;
 };
@@ -29,25 +27,25 @@ type SelectFieldCommonProps = {
 type CheckboxesProps = FieldProps<
   string | string[],
   CheckboxProps | SwitchProps,
-  {
+  SelectFieldCommonProps & {
     checkboxes: true;
     legend?: string;
-    native: false;
+    variant?: undefined;
   }
 >;
 
 type SelectProps = FieldProps<
   string | string[],
-  TextFieldProps & MaterialSelectProps,
-  {
+  MaterialSelectProps & TextFieldProps,
+  SelectFieldCommonProps & {
     checkboxes?: false;
     labelProps?: object;
-    textFieldProps: Omit<TextFieldProps, 'value'>;
+    native?: boolean;
+    textFieldProps?: Omit<TextFieldProps, 'value'>;
   }
 >;
 
-export type SelectFieldProps = (CheckboxesProps | SelectProps) &
-  SelectFieldCommonProps;
+export type SelectFieldProps = CheckboxesProps | SelectProps;
 
 const base64: typeof btoa =
   typeof btoa === 'undefined'
@@ -77,14 +75,10 @@ function Select(props: SelectFieldProps) {
     const appearance = props.appearance ?? 'checkbox';
     const SelectionControl = appearance === 'checkbox' ? Checkbox : Switch;
     const filteredProps = omit(filterDOMProps(props), [
-      'checkboxes',
-      'disableItem',
-      'fullWidth',
-      'helperText',
+      'checkboxes' as never,
+      'disableItem' as never,
       'id',
-      'margin',
-      'textFieldProps',
-      'variant',
+      'inputRef',
     ]);
 
     const children =

--- a/packages/uniforms/src/types.ts
+++ b/packages/uniforms/src/types.ts
@@ -73,7 +73,7 @@ export type HTMLFieldProps<Value, Element, Extension = object> = FieldProps<
 export type ModelTransformMode = 'form' | 'submit' | 'validate';
 
 /** @internal */
-export type Override<T, U> = U & Omit<T, keyof U>;
+export type Override<T, U> = T extends any ? U & Omit<T, keyof U> : never;
 
 export type ValidateMode = 'onChange' | 'onChangeAfterSubmit' | 'onSubmit';
 


### PR DESCRIPTION
This PR aims to improve the `Override` type as suggested in https://github.com/vazco/uniforms/issues/951#issuecomment-836944631. It revealed a few unnecessary props in the `omit` call as well as some other quirks of `SelectField` in `uniforms-material`.

If possible, @aburtsev, please do check this code.