### PR TITLE
Add dependencies duplication and npm vulnerabilities reports to the CI workflow.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
+      - name: Check dependency vulnerabilities
+        run: |
+          npm audit fix
+          git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Found vulnerabilities in the project dependencies. Run npm audit to show the audit details. More info: https://docs.npmjs.com/cli/v7/commands/npm-audit
+          git reset --hard HEAD
       - name: Check dependency duplications
         run: |
           npm dedupe

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check differences
         run: git status -s
           | grep " M package-lock.json"
-          && echo "::""warning file=package-lock.json""::"Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info."
+          && echo "::"warning file=package-lock.json"::"Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info.
       - name: Reset changes
         run: git reset --hard HEAD
       - name: Install

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
-      - name: Fix dependency duplications
+      - name: Find dependency duplications
         run: npm dedupe
       - name: Check differences
         run: git status -s

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check differences
         run: git status -s
           | grep " M package-lock.json"
-          && echo "warning file=package-lock.json Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info."
+          && echo "::""warning file=package-lock.json""::"Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info."
       - name: Reset changes
         run: git reset --hard HEAD
       - name: Install

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,14 +18,11 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
-      - name: Find dependency duplications
-        run: npm dedupe
-      - name: Check differences
-        run: git status -s
-          | grep " M package-lock.json"
-          && echo "::"warning file=package-lock.json"::"Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info.
-      - name: Reset changes
-        run: git reset --hard HEAD
+      - name: Check dependency duplications
+        run: |
+          npm dedupe
+          git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info.
+          git reset --hard HEAD
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Check dependency vulnerabilities
         run: |
-          npm audit fix
+          npm audit fix | : # skip non-0 exit 
           git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Found vulnerabilities in the project dependencies. Run npm audit to show the audit details. More info: https://docs.npmjs.com/cli/v7/commands/npm-audit
           git reset --hard HEAD
       - name: Check dependency duplications

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Check dependency vulnerabilities
         run: |
-          npm audit fix | : # skip non-0 exit 
+          npm audit fix || true # skip non-0 exit
           git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Found vulnerabilities in the project dependencies. Run npm audit to show the audit details. More info: https://docs.npmjs.com/cli/v7/commands/npm-audit
           git reset --hard HEAD
       - name: Check dependency duplications

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
+      - name: Fix dependency duplications
+        run: npm dedupe
+      - name: Check differences
+        run: git status -s
+          | grep " M package-lock.json"
+          && echo "warning file=package-lock.json Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info."
+      - name: Reset changes
+        run: git reset --hard HEAD
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint


### PR DESCRIPTION
Add [dependencies duplication](https://docs.npmjs.com/cli/v7/commands/npm-dedupe) and [npm vulnerabilities](https://docs.npmjs.com/cli/v7/commands/npm-audit) reports to the CI workflow.
The CI run on PR to master branch will produce a warning if there are some possible fixes spotted.

The dependencies duplication report is checked by the `npm dedupe` command, while the vulnerabilities report by the `npm audit fix`.

Example warning in the GH action:
![image](https://user-images.githubusercontent.com/17573948/126511516-2817df34-20eb-4a17-8163-699725970ee9.png)
And in the workflow logs:
![image](https://user-images.githubusercontent.com/17573948/126493457-e310a36b-1eb6-4f62-8070-78523aad45ba.png)