### PR TITLE
Adjusted uniforms-material's TextField type.

### DIFF
--- a/packages/uniforms-material/src/DateField.tsx
+++ b/packages/uniforms-material/src/DateField.tsx
@@ -1,4 +1,4 @@
-import TextField, { StandardTextFieldProps } from '@material-ui/core/TextField';
+import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
@@ -16,7 +16,7 @@ const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
 
 export type DateFieldProps = FieldProps<
   Date,
-  StandardTextFieldProps,
+  TextFieldProps,
   { labelProps?: object }
 >;
 

--- a/packages/uniforms-material/src/LongTextField.tsx
+++ b/packages/uniforms-material/src/LongTextField.tsx
@@ -1,8 +1,8 @@
-import TextField, { StandardTextFieldProps } from '@material-ui/core/TextField';
+import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
-export type LongTextFieldProps = FieldProps<string, StandardTextFieldProps>;
+export type LongTextFieldProps = FieldProps<string, TextFieldProps>;
 
 const LongText = ({
   disabled,

--- a/packages/uniforms-material/src/NumField.tsx
+++ b/packages/uniforms-material/src/NumField.tsx
@@ -1,10 +1,10 @@
-import TextField, { StandardTextFieldProps } from '@material-ui/core/TextField';
+import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
 export type NumFieldProps = FieldProps<
   number,
-  StandardTextFieldProps,
+  TextFieldProps,
   { decimal?: boolean; max?: number; min?: number; step?: number }
 >;
 

--- a/packages/uniforms-material/src/TextField.tsx
+++ b/packages/uniforms-material/src/TextField.tsx
@@ -1,8 +1,10 @@
-import TextField, { StandardTextFieldProps } from '@material-ui/core/TextField';
+import TextField, {
+  TextFieldProps as MUITextFieldProps,
+} from '@material-ui/core/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
-export type TextFieldProps = FieldProps<string, StandardTextFieldProps>;
+export type TextFieldProps = FieldProps<string, MUITextFieldProps>;
 
 function Text({
   disabled,


### PR DESCRIPTION
The previous type was only relevant for the "standard" variant of TextField. This PR changes the used type to the more general TextField one.

Fixes #987 
