### PR TITLE
Implemented recursive `$ref` resolution (fixes #1006).

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -24,11 +24,13 @@ describe('JSONSchemaBridge', () => {
         type: 'object',
         properties: {
           firstName: { $ref: '#/definitions/firstName' },
+          middleName: { $ref: '#/definitions/middleName' },
           lastName: { $ref: '#/definitions/firstName' },
         },
         required: ['lastName'],
       },
       firstName: { type: 'string', default: 'John' },
+      middleName: { $ref: '#/definitions/lastName' },
       lastName: { type: 'string' },
       recursive: {
         type: 'object',
@@ -470,6 +472,12 @@ describe('JSONSchemaBridge', () => {
     it('returns correct definition (nested with $ref)', () => {
       expect(bridge.getField('personalData.firstName')).toEqual({
         default: 'John',
+        type: 'string',
+      });
+    });
+
+    it('returns correct definition ($ref pointing to $ref)', () => {
+      expect(bridge.getField('personalData.middleName')).toEqual({
         type: 'string',
       });
     });

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -36,16 +36,15 @@ function resolveRefIfNeeded(
   partial: Record<string, any>,
   schema: Record<string, any>,
 ): Record<string, any> {
-  const ref = partial.$ref;
-  if (!ref) {
+  if (!('$ref' in partial)) {
     return partial;
   }
-  delete partial.$ref;
-  partial = resolveRefIfNeeded(
-    Object.assign({}, partial, resolveRef(ref, schema)),
+
+  const { $ref, ...partialWithoutRef } = partial;
+  return resolveRefIfNeeded(
+    Object.assign({}, partialWithoutRef, resolveRef($ref, schema)),
     schema,
   );
-  return partial;
 }
 
 const partialNames = ['allOf', 'anyOf', 'oneOf'];

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -35,12 +35,16 @@ function resolveRef(reference: string, schema: Record<string, any>) {
 function resolveRefIfNeeded(
   partial: Record<string, any>,
   schema: Record<string, any>,
-) {
-  if (partial.$ref) {
-    partial = Object.assign({}, partial, resolveRef(partial.$ref, schema));
-    delete partial.$ref;
+): Record<string, any> {
+  const ref = partial.$ref;
+  if (!ref) {
+    return partial;
   }
-
+  delete partial.$ref;
+  partial = resolveRefIfNeeded(
+    Object.assign({}, partial, resolveRef(ref, schema)),
+    schema,
+  );
   return partial;
 }
 


### PR DESCRIPTION
This PR adds recursive `$ref` resolution in JSON Schema Bridge. Previously, only the first `$ref` was resolved so `$ref` pointing to another `$ref` caused errors. Also added tests for this case.