### PR TITLE
Fixed SimpleSchema bridges not returning default values for objects and arrays.

### DIFF
--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -38,6 +38,13 @@ describe('SimpleSchema2Bridge', () => {
     u: { type: SimpleSchema.Integer },
     w: { type: new SimpleSchema({ x: String }) },
     x: { type: String, autoValue: () => '$setOnInsert:hack!' },
+    y: { type: Array, defaultValue: ['y'] },
+    'y.$': String,
+    z: { type: Object, defaultValue: { a: 'a' } },
+    'z.a': String,
+    aa: { type: Array, defaultValue: [{ a: 'a' }] },
+    'aa.$': Object,
+    'aa.$.a': String,
     // FIXME: `SimpleSchemaDefinition` ignores `extendOptions`.
   } as any);
 
@@ -136,7 +143,7 @@ describe('SimpleSchema2Bridge', () => {
     });
 
     it('throws on not found field', () => {
-      expect(() => bridge.getField('y')).toThrow(/Field not found in schema/);
+      expect(() => bridge.getField('-y')).toThrow(/Field not found in schema/);
     });
   });
 
@@ -159,8 +166,20 @@ describe('SimpleSchema2Bridge', () => {
       ]);
     });
 
+    it('works with arrays (defaultValue)', () => {
+      expect(bridge.getInitialValue('y')).toEqual(['y']);
+    });
+
+    it('works with arrays of objects (defaultValue)', () => {
+      expect(bridge.getInitialValue('aa')).toEqual([{ a: 'a' }]);
+    });
+
     it('works with objects', () => {
       expect(bridge.getInitialValue('a')).toEqual({});
+    });
+
+    it('works with objects (defaultValue)', () => {
+      expect(bridge.getInitialValue('z')).toEqual({ a: 'a' });
     });
   });
 
@@ -284,6 +303,9 @@ describe('SimpleSchema2Bridge', () => {
         'u',
         'w',
         'x',
+        'y',
+        'z',
+        'aa',
       ]);
     });
 

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -42,9 +42,9 @@ describe('SimpleSchema2Bridge', () => {
     'y.$': String,
     z: { type: Object, defaultValue: { a: 'a' } },
     'z.a': String,
-    aa: { type: Array, defaultValue: [{ a: 'a' }] },
-    'aa.$': Object,
-    'aa.$.a': String,
+    zs: { type: Array, defaultValue: [{ a: 'a' }] },
+    'zs.$': Object,
+    'zs.$.a': String,
     // FIXME: `SimpleSchemaDefinition` ignores `extendOptions`.
   } as any);
 
@@ -143,7 +143,7 @@ describe('SimpleSchema2Bridge', () => {
     });
 
     it('throws on not found field', () => {
-      expect(() => bridge.getField('-y')).toThrow(/Field not found in schema/);
+      expect(() => bridge.getField('xxx')).toThrow(/Field not found in schema/);
     });
   });
 
@@ -171,7 +171,7 @@ describe('SimpleSchema2Bridge', () => {
     });
 
     it('works with arrays of objects (defaultValue)', () => {
-      expect(bridge.getInitialValue('aa')).toEqual([{ a: 'a' }]);
+      expect(bridge.getInitialValue('zs')).toEqual([{ a: 'a' }]);
     });
 
     it('works with objects', () => {
@@ -305,7 +305,7 @@ describe('SimpleSchema2Bridge', () => {
         'x',
         'y',
         'z',
-        'aa',
+        'zs',
       ]);
     });
 

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -1,6 +1,5 @@
 import invariant from 'invariant';
 import cloneDeep from 'lodash/cloneDeep';
-import get from 'lodash/get';
 import memoize from 'lodash/memoize';
 import SimpleSchema from 'simpl-schema';
 import { Bridge, joinName } from 'uniforms';

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -1,5 +1,6 @@
 import invariant from 'invariant';
 import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
 import memoize from 'lodash/memoize';
 import SimpleSchema from 'simpl-schema';
 import { Bridge, joinName } from 'uniforms';
@@ -72,6 +73,11 @@ export default class SimpleSchema2Bridge extends Bridge {
   getInitialValue(name: string, props?: Record<string, any>): any {
     const field = this.getField(name);
 
+    const defaultValue = field.defaultValue;
+    if (defaultValue !== undefined) {
+      return cloneDeep(defaultValue);
+    }
+
     if (field.type === Array) {
       const item = this.getInitialValue(joinName(name, '0'));
       const items = Math.max(props?.initialCount || 0, field.minCount || 0);
@@ -82,7 +88,7 @@ export default class SimpleSchema2Bridge extends Bridge {
       return {};
     }
 
-    return field.defaultValue;
+    return undefined;
   }
 
   // eslint-disable-next-line complexity

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -71,7 +71,6 @@ export default class SimpleSchema2Bridge extends Bridge {
 
   getInitialValue(name: string, props?: Record<string, any>): any {
     const field = this.getField(name);
-
     const defaultValue = field.defaultValue;
     if (defaultValue !== undefined) {
       return cloneDeep(defaultValue);

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -42,6 +42,13 @@ describe('SimpleSchemaBridge', () => {
           },
         },
         t: { type: String, uniforms: { options: () => ({ a: 1, b: 2 }) } },
+        u: { type: Array, defaultValue: ['u'] },
+        'u.$': { type: String },
+        v: { type: Object, defaultValue: { a: 'a' } },
+        'v.a': { type: String },
+        w: { type: Array, defaultValue: [{ a: 'a' }] },
+        'w.$': { type: Object },
+        'w.$.a': { type: String },
       }[name];
 
       if (field) {
@@ -178,8 +185,20 @@ describe('SimpleSchemaBridge', () => {
       ]);
     });
 
+    it('works with arrays (defaultValue)', () => {
+      expect(bridge.getInitialValue('u')).toEqual(['u']);
+    });
+
+    it('works with arrays of objects (defaultValue)', () => {
+      expect(bridge.getInitialValue('w')).toEqual([{ a: 'a' }]);
+    });
+
     it('works with objects', () => {
       expect(bridge.getInitialValue('a')).toEqual({});
+    });
+
+    it('works with objects (defaultValue)', () => {
+      expect(bridge.getInitialValue('v')).toEqual({ a: 'a' });
     });
   });
 

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -66,7 +66,6 @@ export default class SimpleSchemaBridge extends Bridge {
 
   getInitialValue(name: string, props?: Record<string, any>): any {
     const field = this.getField(name);
-
     const defaultValue = field.defaultValue;
     if (defaultValue !== undefined) {
       return cloneDeep(defaultValue);

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -67,6 +67,11 @@ export default class SimpleSchemaBridge extends Bridge {
   getInitialValue(name: string, props?: Record<string, any>): any {
     const field = this.getField(name);
 
+    const defaultValue = field.defaultValue;
+    if (defaultValue !== undefined) {
+      return cloneDeep(defaultValue);
+    }
+
     if (field.type === Array) {
       const item = this.getInitialValue(joinName(name, '0'));
       const items = Math.max(props?.initialCount || 0, field.minCount || 0);
@@ -77,7 +82,7 @@ export default class SimpleSchemaBridge extends Bridge {
       return {};
     }
 
-    return field.defaultValue;
+    return undefined;
   }
 
   // eslint-disable-next-line complexity


### PR DESCRIPTION
Adjusted `getInitialValue` in both `SimpleSchemaBridge` and `SimpleSchema2Bridge`. The logic now follows more closely `JSONSchemaBridge`'s implementation. Also added a few tests to both bridges.