### PR TITLE
Updated documentation about custom AutoField (#1009).

### DIFF
--- a/docs/examples-custom-fields.mdx
+++ b/docs/examples-custom-fields.mdx
@@ -21,6 +21,8 @@ field props here, like value or onChange for some extra logic.
 
 ### `CustomAutoField`
 
+**Note:** Since v3.1, the preferred way is to create an `AutoField` component is to use the `createAutoField` helper. Also, it's often the case that using the [`AutoField.componentDetectorContext`](uth-autofield-algorithm#overriding-autofield) is enough.
+
 These are two _standard_ options to define a custom `AutoField`: either using `connectField` or simply taking the code from the [original one](https://github.com/vazco/uniforms/blob/master/packages/uniforms-unstyled/src/AutoField.js#L14-L47) _(theme doesn't matter)_ and simply apply own components and/or rules to render components. Below an example with `connectField`.
 
 ```tsx

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@ You can style your form fields simply by passing a `className` property.
 
 ### How can I create custom fields?
 
-You can create a custom field by wrapping your component inside the [`connectField`](/docs/api-helpers#connectfieldcomponent-options).
+You can create a custom field by wrapping your component inside the [`connectField`](api-helpers#connectfieldcomponent-options).
 
 The `connectField` will pass various props related to the form management, such as `onChange()` function, current field's value, errors and so on, to your component.
 


### PR DESCRIPTION
As said in #1009, the `autoField` prop is not as useful and easy to use as the `AutoField.componentDetectorContext`. In this PR, I've added a note about that in the docs.