### PR TITLE
[WIP] uniforms-bridge-simple-schema does not pass uniforms.type prop correctly

### DIFF
--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -7,6 +7,7 @@ describe('SimpleSchema2Bridge', () => {
     a: { type: Object },
     'a.b': { type: Object },
     'a.b.c': { type: String },
+    aa: { type: String, uniforms: { type: 'password' } },
     d: { type: String, defaultValue: 'D' },
     e: { type: String, allowedValues: ['E'] },
     f: { type: Number, min: 42 },
@@ -278,12 +279,21 @@ describe('SimpleSchema2Bridge', () => {
         required: true,
       });
     });
+
+    it('works with type', () => {
+      expect(bridge.getProps('aa')).toEqual({
+        label: 'Aa',
+        type: 'password',
+        required: true,
+      });
+    });
   });
 
   describe('#getSubfields', () => {
     it('works on top level', () => {
       expect(bridge.getSubfields()).toEqual([
         'a',
+        'aa',
         'd',
         'e',
         'f',


### PR DESCRIPTION
Before you open a pull request, please check if a similar one already exists or has been closed before. Detailed information about the process of contributing can be found in [CONTRIBUTING.md](https://github.com/vazco/uniforms/blob/master/.github/CONTRIBUTING.md).

Do link all relevant issues and pull requests. If there is none, please do file an issue first to discuss it upfront.
