### PR TITLE
Fixed `BoolField` label in uniforms-semantic.

### DIFF
--- a/packages/uniforms-semantic/src/BoolField.tsx
+++ b/packages/uniforms-semantic/src/BoolField.tsx
@@ -53,7 +53,7 @@ function Bool({
           type="checkbox"
         />
 
-        {!!label && <label htmlFor={id}>{label}</label>}
+        <label htmlFor={id}>{label || null}</label>
       </div>
 
       {!!(error && showInlineError) && (


### PR DESCRIPTION
In this PR I fixed the presence of the checkbox in `BoolField` of uniforms-semantic as it wasn't there if the field had no label.