### PR TITLE
Improved key in playground.

### DIFF
--- a/website/components/Playground.tsx
+++ b/website/components/Playground.tsx
@@ -11,7 +11,7 @@ import presets from '../lib/presets';
 import { bridge, schema } from '../lib/schema';
 import styles from '../lib/styles';
 import { themes } from '../lib/universal';
-import { parseQuery, updateQuery } from '../lib/utils';
+import { compress, parseQuery, updateQuery } from '../lib/utils';
 
 export class Playground extends Component<any, any> {
   static getDerivedStateFromError(error: Error) {
@@ -166,7 +166,7 @@ class PlaygroundPreview extends Component<any, any> {
         {this.props.errorMessage ? (
           <span children={this.props.errorMessage} />
         ) : (
-          <AutoForm key={schema} {...props}>
+          <AutoForm key={compress(schema)} {...props}>
             <AutoFields />
             <ErrorsField />
             <SubmitField />

--- a/website/lib/utils.ts
+++ b/website/lib/utils.ts
@@ -3,7 +3,7 @@ import LZString from 'lz-string';
 
 const URL_KEYS = ['preset', 'props', 'theme'];
 
-const compress = (string: string) =>
+export const compress = (string: string) =>
   LZString.compressToBase64(string)
     .replace(/\+/g, '-') // Convert '+' to '-'.
     .replace(/\//g, '_') // Convert '/' to '_'.


### PR DESCRIPTION
In this PR, I've added `key` compression in the playground, as React DevTools don't handle it well.

| Before | After |
| - | - |
| ![Screenshot from 2021-10-06 18-17-18](https://user-images.githubusercontent.com/1379064/136243983-0ea16f1a-92f6-48e5-8dd7-a5c6f06ed347.png) | ![Screenshot from 2021-10-06 18-18-08](https://user-images.githubusercontent.com/1379064/136243986-8ad43017-bda3-4c5d-a901-a4ae29b7170a.png) |