### PR TITLE
Improve typings of getNativeProps

### DIFF
--- a/packages/uniforms/src/AutoForm.tsx
+++ b/packages/uniforms/src/AutoForm.tsx
@@ -50,8 +50,9 @@ export function Auto<Base extends typeof ValidatedQuickForm>(Base: Base) {
       super.componentDidUpdate(prevProps, prevState, snapshot);
     }
 
-    getNativeFormProps(): Record<string, any> {
-      return omit(super.getNativeFormProps(), ['onChangeModel']);
+    getNativeFormProps() {
+      const superProps = super.getNativeFormProps();
+      return omit(superProps, ['onChangeModel']) as typeof superProps;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -166,7 +166,11 @@ export class BaseForm<
     return model;
   }
 
-  getNativeFormProps(): Record<string, any> {
+  getNativeFormProps(): {
+    [key: string]: unknown;
+    onSubmit: BaseForm<Model, Props, State>['onSubmit'];
+    key: string;
+  } {
     const props = omit(this.props, [
       'autosave',
       'autosaveDelay',

--- a/packages/uniforms/src/QuickForm.tsx
+++ b/packages/uniforms/src/QuickForm.tsx
@@ -20,13 +20,19 @@ export function Quick<Base extends typeof BaseForm>(Base: Base) {
     static Quick = Quick;
     static displayName = `Quick${Base.displayName}`;
 
-    getNativeFormProps(): Record<string, any> {
+    getNativeFormProps() {
+      const superProps = super.getNativeFormProps();
+      type ChildFields = {
+        autoField?: React.ComponentType<{ name: string }>;
+        errorsField?: React.ComponentType<{}>;
+        submitField?: React.ComponentType<{}>;
+      };
       const {
         autoField: AutoField = this.getAutoField(),
         errorsField: ErrorsField = this.getErrorsField(),
         submitField: SubmitField = this.getSubmitField(),
         ...props
-      } = super.getNativeFormProps();
+      }: typeof superProps & ChildFields = superProps;
 
       if (!props.children) {
         props.children = this.getContextSchema()

--- a/packages/uniforms/src/ValidatedForm.tsx
+++ b/packages/uniforms/src/ValidatedForm.tsx
@@ -69,12 +69,13 @@ export function Validated<Base extends typeof BaseForm>(Base: Base) {
       };
     }
 
-    getNativeFormProps(): Record<string, any> {
-      return omit(super.getNativeFormProps(), [
+    getNativeFormProps() {
+      const superProps = super.getNativeFormProps();
+      return omit(superProps, [
         'onValidate',
         'validate',
         'validator',
-      ]);
+      ]) as typeof superProps;
     }
 
     componentDidUpdate(prevProps: Props, prevState: State, snapshot: never) {


### PR DESCRIPTION
This PR closes #1037 by improving `.getNativeProps` by guaranteeing `key` and `onChange` props and replacing `any` with `unknown`. 