### PR TITLE
Fix playground schema validation.

### DIFF
--- a/website/lib/schema.ts
+++ b/website/lib/schema.ts
@@ -63,7 +63,7 @@ const propsSchema = new SimpleSchema({
     type: String,
     custom() {
       try {
-        eval(`(${this.value})`);
+        eval(`(${this.value ?? ''})`);
         return undefined;
       } catch (error) {
         MessageBox.defaults({


### PR DESCRIPTION
If the schema field in Playground has a value equal `undefined`  the playground UI crashes. To fix that I added a check in the form validator.   
The UI after error occurred:
![image](https://user-images.githubusercontent.com/17573948/136259712-a1da85ad-39ea-4f4b-a3cc-231fad10d689.png)
The default UI (for the context):
![image](https://user-images.githubusercontent.com/17573948/136259592-9c15d4c1-5d91-4a7c-aa7f-7b76b9d214d2.png)
