### PR TITLE
Updated Codecov GitHub action.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,10 @@ jobs:
       - name: Test
         run: npm run coverage -- --no-cache --runInBand
       - name: Report coverage
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          fail_ci_if_error: true
+          verbose: true
       - name: Build docs
         run: npm --prefix website run build
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.node-version == '16.x'


### PR DESCRIPTION
Codecov recently [introduced a new, NodeJS-based uploader](https://about.codecov.io/blog/introducing-codecovs-new-uploader/). It was in beta for a while, but now the Bash-based one we're using [became deprecated](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/). This PR updates the `codecov/codecov-action` to v2, as described in [docs](https://github.com/marketplace/actions/codecov#%EF%B8%8F--deprecration-of-v1).