### PR TITLE
Register minCount and maxCount in `filterDOMProps` of JSONSchema

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -915,11 +915,9 @@ describe('JSONSchemaBridge', () => {
   describe('#filterDOMProps', () => {
     const props = bridge.getProps('arrayWithAllOf');
     const filteredProps = filterDOMProps(props);
-    it('filters minCount', () => {
-      expect(filteredProps).not.toHaveProperty('minCount');
-    });
-    it('filters maxCount', () => {
-      expect(filteredProps).not.toHaveProperty('maxCount');
+    it.each(['minCount', 'maxCount'])('filters %s', keyword => {
+      expect(props).toHaveProperty(keyword);
+      expect(filteredProps).not.toHaveProperty(keyword);
     });
   });
 });

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -1,3 +1,4 @@
+import { filterDOMProps } from 'uniforms';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 
 describe('JSONSchemaBridge', () => {
@@ -908,6 +909,17 @@ describe('JSONSchemaBridge', () => {
   describe('#getValidator', () => {
     it('calls correct validator', () => {
       expect(bridge.getValidator()).toBe(validator);
+    });
+  });
+
+  describe('#filterDOMProps', () => {
+    const props = bridge.getProps('arrayWithAllOf');
+    const filteredProps = filterDOMProps(props);
+    it('filters minCount', () => {
+      expect(filteredProps).not.toHaveProperty('minCount');
+    });
+    it('filters maxCount', () => {
+      expect(filteredProps).not.toHaveProperty('maxCount');
     });
   });
 });

--- a/packages/uniforms-bridge-json-schema/package.json
+++ b/packages/uniforms-bridge-json-schema/package.json
@@ -4,7 +4,14 @@
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "cjs/index.js",
+    "cjs/register.js",
+    "esm/index.js",
+    "esm/register.js",
+    "src/index.ts",
+    "src/register.ts"
+  ],
   "description": "JSONSchema schema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-json-schema",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-json-schema/src/index.ts
+++ b/packages/uniforms-bridge-json-schema/src/index.ts
@@ -1,1 +1,2 @@
+import './register';
 export { default, default as JSONSchemaBridge } from './JSONSchemaBridge';

--- a/packages/uniforms-bridge-json-schema/src/register.ts
+++ b/packages/uniforms-bridge-json-schema/src/register.ts
@@ -1,0 +1,11 @@
+import { filterDOMProps } from 'uniforms';
+
+// There's no possibility to retrieve them at runtime.
+declare module 'uniforms' {
+  interface FilterDOMProps {
+    minCount: never;
+    maxCount: never;
+  }
+}
+
+filterDOMProps.register('minCount', 'maxCount');


### PR DESCRIPTION
This PR closes #981 by registering `minCount` and `maxCount` in `filterDOMProps` when `JSONSchemaBridge` is imported.
