### PR TITLE
Add `formRef` to documentation

### DIFF
--- a/docs/api-context-data.md
+++ b/docs/api-context-data.md
@@ -64,6 +64,10 @@ A map of changed fields. Rather internal one, used for checking if _other_ field
 
 An object with a `details` field, which is an array of any validation errors.
 
+### `formRef`
+
+Contains reference to the form component that gives access to [the form methods](/docs/api-forms#methods).
+
 ### `model`
 
 An object with current form fields values structured `{field: value}`.

--- a/docs/api-forms.md
+++ b/docs/api-forms.md
@@ -292,6 +292,29 @@ const MyForm = ({ schema, onSubmit }) => {
 };
 ```
 
+You can do the same by using the [`useForm`](/docs/api-context-data#accessing-context-data) hook and the [`formRef`](/docs/api-context-data#formref) property.
+
+```tsx
+function FormControls() {
+  const { formRef } = useForm();
+
+  return (
+    <>
+      <button onClick={() => formRef.reset()}>Reset</button>
+      <button onClick={() => formRef.submit()}>Submit</button>
+    </>
+  );
+}
+
+function App() {
+  return (
+    <AutoForm>
+      <FormControls />
+    </AutoForm>
+  );
+}
+```
+
 All available methods:
 
 #### `change(key, value)`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -120,7 +120,7 @@ You change the way your form validates by setting `validate` prop:
 
 ### How can I reset my form state?
 
-You can use [React `ref` prop](https://facebook.github.io/react/docs/more-about-refs.html) to manually access form methods.
+You can use [React `ref` prop](https://facebook.github.io/react/docs/more-about-refs.html) or [`formRef`](/docs/api-context-data#formref) to manually access form methods.
 
 These methods are:
 
@@ -145,6 +145,29 @@ const MyForm = ({ schema, onSubmit }) => {
     </section>
   );
 };
+```
+
+or the hook way:
+
+```tsx
+function FormControls() {
+  const { formRef } = useForm();
+
+  return (
+    <>
+      <button onClick={() => formRef.reset()}>Reset</button>
+      <button onClick={() => formRef.submit()}>Submit</button>
+    </>
+  );
+}
+
+function App() {
+  return (
+    <AutoForm>
+      <FormControls />
+    </AutoForm>
+  );
+}
 ```
 
 You can find more about form methods [here](/docs/api-forms).


### PR DESCRIPTION
This PR adds small sections about new property `formRef` accessible in the context and how to use it.

Updated sections include:
- Context API reference
- Forms methods reference
- FAQ: How can I reset my form state?