### PR TITLE
Use reusable workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 jobs:
+  npm_dedupe_check:
+    uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@v1
   CI:
     runs-on: ubuntu-latest
     strategy:
@@ -23,8 +25,6 @@ jobs:
           npm audit fix || true # skip non-0 exit
           git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Found vulnerabilities in the project dependencies. Run npm audit to show the audit details. More info: https://docs.npmjs.com/cli/v7/commands/npm-audit
           git reset --hard HEAD
-      - name: Check dependency duplications
-        uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@v1
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,10 +24,7 @@ jobs:
           git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Found vulnerabilities in the project dependencies. Run npm audit to show the audit details. More info: https://docs.npmjs.com/cli/v7/commands/npm-audit
           git reset --hard HEAD
       - name: Check dependency duplications
-        run: |
-          npm dedupe
-          git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Duplicate dependencies found. Run npm dedupe to remove them, or add --dry-run parameter to get more info.
-          git reset --hard HEAD
+        uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
           git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Found vulnerabilities in the project dependencies. Run npm audit to show the audit details. More info: https://docs.npmjs.com/cli/v7/commands/npm-audit
           git reset --hard HEAD
       - name: Check dependency duplications
-        uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml
+        uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@v1
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ jobs:
   npm_dedupe_check:
     name: NPM dependency duplication check
     uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@master
+  npm_vuln_check:
+    name: NPM dependency vulnerabilities check
+    uses: vazco/open-standards/.github/workflows/check_dependency_vulnerabilities.yml@master
   CI:
     runs-on: ubuntu-latest
     strategy:
@@ -21,11 +24,6 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
-      - name: Check dependency vulnerabilities
-        run: |
-          npm audit fix || true # skip non-0 exit
-          git status -s | grep " M package-lock.json" && echo "::"warning file=package-lock.json"::"Found vulnerabilities in the project dependencies. Run npm audit to show the audit details. More info: https://docs.npmjs.com/cli/v7/commands/npm-audit
-          git reset --hard HEAD
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 jobs:
-  npm_vuln_check:
-    name: NPM dependency vulnerabilities check
-    uses: vazco/open-standards/.github/workflows/check_dependency_vulnerabilities.yml@master
   CI:
     runs-on: ubuntu-latest
     strategy:
@@ -21,8 +18,10 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
-      - name: Npm dependency duplication check
-        uses: vazco/open-standards/actions/npm-dependency-duplications/@action-test
+      - name: Check dependency duplications
+        uses: vazco/open-standards/actions/npm-dependency-duplications/@master
+      - name: Check dependency vulnerabilities
+        uses: vazco/open-standards/actions/npm-dependency-vulnerabilities/@master
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ jobs:
   npm_dedupe_check:
     name: NPM dependency duplication check
     uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@master
+    with:
+      node-version: 17.2.0
+      project-path: reproductions
   npm_vuln_check:
     name: NPM dependency vulnerabilities check
     uses: vazco/open-standards/.github/workflows/check_dependency_vulnerabilities.yml@master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,9 +8,6 @@ jobs:
   npm_dedupe_check:
     name: NPM dependency duplication check
     uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@master
-    with:
-      node-version: 17.2.0
-      project-path: reproductions
   npm_vuln_check:
     name: NPM dependency vulnerabilities check
     uses: vazco/open-standards/.github/workflows/check_dependency_vulnerabilities.yml@master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,13 +16,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
-      - name: npm_dedupe_check
-        uses: vazco/open-standards/actions/npm-dependency-duplications/@action-test
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.2.0
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}
+      - name: Npm dependency duplication check
+        uses: vazco/open-standards/actions/npm-dependency-duplications/@action-test
       - name: Install
         run: npm i -g npm@7 && npm ci
       - name: Lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,12 +5,6 @@ on:
     branches:
       - master
 jobs:
-  npm_dedupe_check:
-    runs-on: ubuntu-latest
-    name: NPM dependency duplication check
-    steps:
-      - name: Check dedupe
-        uses: vazco/open-standards/actions/npm-dependency-duplications/@action-test
   npm_vuln_check:
     name: NPM dependency vulnerabilities check
     uses: vazco/open-standards/.github/workflows/check_dependency_vulnerabilities.yml@master
@@ -22,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+      - name: npm_dedupe_check
+        uses: vazco/open-standards/actions/npm-dependency-duplications/@action-test
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.2.0
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,8 +6,11 @@ on:
       - master
 jobs:
   npm_dedupe_check:
+    runs-on: ubuntu-latest
     name: NPM dependency duplication check
-    uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@master
+    steps:
+      - name: Check dedupe
+        uses: vazco/open-standards/actions/npm-dependency-duplications/@action-test
   npm_vuln_check:
     name: NPM dependency vulnerabilities check
     uses: vazco/open-standards/.github/workflows/check_dependency_vulnerabilities.yml@master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   npm_dedupe_check:
-    uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@v1
+    uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@master
   CI:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,7 @@ on:
       - master
 jobs:
   npm_dedupe_check:
+    name: NPM dependency duplication check
     uses: vazco/open-standards/.github/workflows/check_dependency_duplications.yml@master
   CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As we discussed at the internal planning meeting ([card](https://github.com/orgs/vazco/projects/1#card-72596364)) we want to simplify and unify the ci workflow steps, so I created the [open-standards](https://github.com/vazco/open-standards) repo under the [Vazco](https://github.com/vazco) organization for workflows like npm dedupe and vulnerability checks.
This PR introduces a change to use workflows from [open-standards](https://github.com/vazco/open-standards) repo.

The reusable workflows have to be run as standalone jobs (what distinguishes them from official actions), and we have to deal with its consequences: 
1. We have to run checkout and node setup steps 2 times additionally.
2. We can run both actions only once per workflow run, not like it was - once every node matrix run (6 checks less)  
3. It is a standalone job (obviously), and it brings UI changes - now it is more visible, what can be pros or a con, depending on context or approach. It's great if we want to put more emphasis on this element, but unfavorable if it's not that crucial action.

Explanation picture for point 3.:
![screenshot from GitHub actions](https://user-images.githubusercontent.com/17573948/146373623-a30e2255-29f5-4e6d-92e5-1604868f00b7.png)

References: 
[learn-github-actions/reusing-workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows)

Disclaimer:
This PR probably shouldn't be merged before [this PR](https://github.com/vazco/open-standards/pull/1).