### PR TITLE
JSON Schema with Dot-Fieldnames

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -173,6 +173,32 @@ describe('JSONSchemaBridge', () => {
       objectWithoutProperties: { type: 'object' },
       withLabel: { type: 'string', uniforms: { label: 'Example' } },
       forcedRequired: { type: 'string', uniforms: { required: true } },
+      'path.with.a.dot': {
+        type: 'object',
+        properties: {
+          'another.with.a.dot': {
+            type: 'string',
+          },
+          another: {
+            type: 'object',
+            properties: {
+              with: {
+                type: 'object',
+                properties: {
+                  a: {
+                    type: 'object',
+                    properties: {
+                      dot: {
+                        type: 'number',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
     required: ['dateOfBirth', 'nonObjectAnyOfRequired'],
   };
@@ -474,6 +500,22 @@ describe('JSONSchemaBridge', () => {
       expect(bridge.getField('personalData.firstName')).toEqual({
         default: 'John',
         type: 'string',
+      });
+    });
+
+    it('returns correct definition (dots in name)', () => {
+      expect(bridge.getField('["path.with.a.dot"]')).toMatchObject({
+        type: 'object',
+      });
+      expect(
+        bridge.getField('["path.with.a.dot"].["another.with.a.dot"]'),
+      ).toMatchObject({
+        type: 'string',
+      });
+      expect(
+        bridge.getField('["path.with.a.dot"].another.with.a.dot'),
+      ).toMatchObject({
+        type: 'number',
       });
     });
 
@@ -830,6 +872,7 @@ describe('JSONSchemaBridge', () => {
         'objectWithoutProperties',
         'withLabel',
         'forcedRequired',
+        '["path.with.a.dot"]',
       ]);
     });
 

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -199,6 +199,14 @@ describe('JSONSchemaBridge', () => {
           },
         },
       },
+      path: {
+        type: 'object',
+        properties: {
+          'with.a.dot': {
+            type: 'boolean',
+          },
+        },
+      },
     },
     required: ['dateOfBirth', 'nonObjectAnyOfRequired'],
   };
@@ -516,6 +524,9 @@ describe('JSONSchemaBridge', () => {
         bridge.getField('["path.with.a.dot"].another.with.a.dot'),
       ).toMatchObject({
         type: 'number',
+      });
+      expect(bridge.getField('path["with.a.dot"]')).toMatchObject({
+        type: 'boolean',
       });
     });
 
@@ -873,6 +884,7 @@ describe('JSONSchemaBridge', () => {
         'withLabel',
         'forcedRequired',
         '["path.with.a.dot"]',
+        'path',
       ]);
     });
 

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -150,7 +150,9 @@ export default class JSONSchemaBridge extends Bridge {
         fieldInvariant(name, !!definition);
       } else if (definition.type === 'object') {
         fieldInvariant(name, !!definition.properties);
-        definition = definition.properties[next];
+        definition =
+          definition.properties[next] ||
+          definition.properties[next.slice(2, -2)];
         fieldInvariant(name, !!definition);
       } else {
         let nextFound = false;
@@ -296,7 +298,9 @@ export default class JSONSchemaBridge extends Bridge {
       this._compiledSchema[name];
 
     if (type === 'object' && properties) {
-      return Object.keys(properties);
+      return Object.keys(properties).map(key =>
+        key.includes('.') ? `["${key}"]` : key,
+      );
     }
 
     return [];

--- a/packages/uniforms/__tests__/joinName.ts
+++ b/packages/uniforms/__tests__/joinName.ts
@@ -49,4 +49,12 @@ describe('joinName', () => {
     expect(joinName(null, 'a.b', 'c.d')).toEqual(['a', 'b', 'c', 'd']);
     expect(joinName(null, 'a.b.c', 'd')).toEqual(['a', 'b', 'c', 'd']);
   });
+
+  it('works with dot-names', () => {
+    expect(joinName('a', 'b.c')).toBe('a.b.c');
+    expect(joinName('a', '["b.c"]')).toBe('a.["b.c"]');
+
+    expect(joinName(null, 'a', 'b.c')).toMatchObject(['a', 'b', 'c']);
+    expect(joinName(null, 'a', '["b.c"]')).toMatchObject(['a', '["b.c"]']);
+  });
 });

--- a/packages/uniforms/src/joinName.ts
+++ b/packages/uniforms/src/joinName.ts
@@ -1,3 +1,5 @@
+import flatten from 'lodash/flatten';
+
 export function joinName(flag: null, ...parts: unknown[]): string[];
 export function joinName(...parts: unknown[]): string;
 export function joinName(...parts: unknown[]) {
@@ -7,7 +9,15 @@ export function joinName(...parts: unknown[]) {
     if (part || part === 0) {
       if (typeof part === 'string') {
         if (part.indexOf('.') !== -1) {
-          name.push(...part.split('.'));
+          name.push(
+            ...flatten(
+              part
+                .split(/\[|\]/)
+                .map(subkey =>
+                  /^['"]/.exec(subkey) ? `[${subkey}]` : subkey.split('.'),
+                ),
+            ).filter(Boolean),
+          );
         } else {
           name.push(part);
         }


### PR DESCRIPTION
This PR closes #963.

**NOTE**: This is yet another approach that works, but will probably be changed.

When I was working on the implementation of [2 and 2.5](https://github.com/vazco/uniforms/issues/963#issuecomment-990859246) I encountered some problems which would make the API inconvenient. Instead, I implemented the _escape paths_. This is more convenient when used with React because you can pass a string to the `name` prop instead of an array.

Given schema
```json
{
    "$schema": "http://json-schema.org/draft-06/schema#",
    "type": "object",
    "properties": {
      "x": {
        "type": "object",
        "properties": {
          "y.z": {
            "type": "string"
          }
        }
      }
    }
}
```

we can access it like the following
```jsx
<AutoField name='x.["y.z"]' />
```

You can escape the path with _brackets_ like `normal.["path.with.dots.in.name"].second.["another.path.with.dots"].0`.
