### PR TITLE
Implemented handling of complex field names.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,7 +68,8 @@
     "prefer-rest-params": "off",
     "react/jsx-pascal-case": "off",
     "react/no-children-prop": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "valid-jsdoc": "off"
   },
   "settings": {
     "import/core-modules": ["meteor/aldeed:simple-schema", "meteor/check"],

--- a/docs/api-helpers.md
+++ b/docs/api-helpers.md
@@ -104,14 +104,39 @@ filterDOMProps.register('propA', 'propB');
 
 ## `joinName`
 
-Safely joins partial field names. When the first param is null, returns an array of strings. Otherwise, returns a string. If you create a custom field with subfields, then it's better to use this helper than manually concatenating them.
+Safely joins partial field names.
+If you create a custom field with subfields, do use `joinName` instead of manually concatenating them.
+It ensures that the name will be correctly escaped if needed.
 
 ```tsx
 import { joinName } from 'uniforms';
 
-joinName(null, 'a', 'b.c', 'd'); // ['a', 'b', 'c', 'd']
-joinName('a', 'b.c', 'd'); // 'a.b.c.d'
+joinName('array', 1, 'field'); // 'array.1.field'
+joinName('object', 'nested.property'); // 'object.nested.property'
 ```
+
+If the first argument is `null`, then it returns an array of escaped parts.
+
+```tsx
+import { joinName } from 'uniforms';
+
+joinName(null, 'array', 1, 'field'); // ['array', '1', 'field']
+joinName(null, 'object', 'nested.property'); // ['object', 'nested', 'property']
+```
+
+If the field name contains a dot (`.`) or a bracket (`[` or `]`), it has to be escaped with `["..."]`.
+If any of these characters is not escaped, `joinName` will **not** throw an error but its behavior is not specified.
+The escape of any other name part will be stripped.
+
+```tsx
+joinName(null, 'object["with.dot"].field'); // ['object', '["with.dot"]', 'field']
+joinName('object["with.dot"].field'); // 'object["with.dot"].field'
+
+joinName(null, 'this["is"].safe'); // ['this', 'is', 'safe']
+joinName('this["is"].safe'); // 'this.is.safe'
+```
+
+For more examples check [`joinName` tests](https://github.com/vazco/uniforms/blob/master/packages/uniforms/__tests__/joinName.ts).
 
 ## `randomIds`
 

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -885,7 +885,7 @@ describe('JSONSchemaBridge', () => {
         'objectWithoutProperties',
         'withLabel',
         'forcedRequired',
-        'path.with.a.dot',
+        '["path.with.a.dot"]',
         'path',
       ]);
     });

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -173,6 +173,39 @@ describe('JSONSchemaBridge', () => {
       objectWithoutProperties: { type: 'object' },
       withLabel: { type: 'string', uniforms: { label: 'Example' } },
       forcedRequired: { type: 'string', uniforms: { required: true } },
+      'path.with.a.dot': {
+        type: 'object',
+        properties: {
+          'another.with.a.dot': {
+            type: 'string',
+          },
+          another: {
+            type: 'object',
+            properties: {
+              with: {
+                type: 'object',
+                properties: {
+                  a: {
+                    type: 'object',
+                    properties: {
+                      dot: {
+                        type: 'number',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      path: {
+        type: 'object',
+        properties: {
+          'with.a.dot': { type: 'number' },
+          '["with.a.dot"]': { type: 'string' },
+        },
+      },
     },
     required: ['dateOfBirth', 'nonObjectAnyOfRequired'],
   };
@@ -473,6 +506,28 @@ describe('JSONSchemaBridge', () => {
     it('returns correct definition (nested with $ref)', () => {
       expect(bridge.getField('personalData.firstName')).toEqual({
         default: 'John',
+        type: 'string',
+      });
+    });
+
+    it('returns correct definition (dots in name)', () => {
+      expect(bridge.getField('["path.with.a.dot"]')).toMatchObject({
+        type: 'object',
+      });
+      expect(
+        bridge.getField('["path.with.a.dot"]["another.with.a.dot"]'),
+      ).toMatchObject({
+        type: 'string',
+      });
+      expect(
+        bridge.getField('["path.with.a.dot"].another.with.a.dot'),
+      ).toMatchObject({
+        type: 'number',
+      });
+      expect(bridge.getField('path["with.a.dot"]')).toMatchObject({
+        type: 'number',
+      });
+      expect(bridge.getField('path["[\\"with.a.dot\\"]"]')).toMatchObject({
         type: 'string',
       });
     });
@@ -830,6 +885,8 @@ describe('JSONSchemaBridge', () => {
         'objectWithoutProperties',
         'withLabel',
         'forcedRequired',
+        'path.with.a.dot',
+        'path',
       ]);
     });
 

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -296,7 +296,7 @@ export default class JSONSchemaBridge extends Bridge {
       this._compiledSchema[name];
 
     if (type === 'object' && properties) {
-      return Object.keys(properties);
+      return Object.keys(properties).map(joinName.escape);
     }
 
     return [];

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -150,7 +150,7 @@ export default class JSONSchemaBridge extends Bridge {
         fieldInvariant(name, !!definition);
       } else if (definition.type === 'object') {
         fieldInvariant(name, !!definition.properties);
-        definition = definition.properties[next];
+        definition = definition.properties[joinName.unescape(next)];
         fieldInvariant(name, !!definition);
       } else {
         let nextFound = false;

--- a/packages/uniforms/__tests__/joinName.ts
+++ b/packages/uniforms/__tests__/joinName.ts
@@ -24,8 +24,20 @@ describe('joinName', () => {
   });
 
   it('works with arrays', () => {
+    test([['a']], ['a'], 'a');
+    test([[['a']]], ['a'], 'a');
+    test([[[['a']]]], ['a'], 'a');
+
+    test([[], 'a'], ['a'], 'a');
+    test(['a', []], ['a'], 'a');
+
     test([['a'], 'b'], ['a', 'b'], 'a.b');
     test(['a', ['b']], ['a', 'b'], 'a.b');
+
+    test([['a', 'b'], 'c'], ['a', 'b', 'c'], 'a.b.c');
+    test(['a', ['b', 'c']], ['a', 'b', 'c'], 'a.b.c');
+
+    test(['a', ['b', 'c'], 'd'], ['a', 'b', 'c', 'd'], 'a.b.c.d');
   });
 
   it('works with empty strings', () => {
@@ -84,6 +96,11 @@ describe('joinName', () => {
   });
 
   it('handles incorrect cases _somehow_', () => {
+    // Boolean `true`.
+    test([true], ['true'], 'true');
+    test([true, 'a'], ['true', 'a'], 'true.a');
+    test(['a', true], ['a', 'true'], 'a.true');
+
     // Dots before subscripts.
     test(['a["b"].c.["d"]'], ['a', 'b', 'c', 'd'], 'a.b.c.d');
     test(['a.["b"].c["d"]'], ['a', 'b', 'c', 'd'], 'a.b.c.d');

--- a/packages/uniforms/src/joinName.ts
+++ b/packages/uniforms/src/joinName.ts
@@ -1,13 +1,51 @@
-export function joinName(flag: null, ...parts: unknown[]): string[];
-export function joinName(...parts: unknown[]): string;
-export function joinName(...parts: unknown[]) {
+const escapeMatch = /^([^.[\]]+?(?:\.[^.[\]]+?)+?|\[".*?"]|.*[.[\]].*|)$/;
+const escapeRegex = /"/g;
+/** @internal */
+function escape(string: string) {
+  return escapeMatch.test(string)
+    ? `["${string.replace(escapeRegex, '\\"')}"]`
+    : string;
+}
+
+const unescapeMatch = /^\[".*?"]$/;
+const unescapeRegex = /\\"/g;
+/** @internal */
+function unescape(string: string) {
+  return unescapeMatch.test(string)
+    ? string.slice(2, -2).replace(unescapeRegex, '"')
+    : string;
+}
+
+const nameRegex =
+  /^([^.[\]]*(?:\.[^.[\]]+)*)(?:\.?(\["(?:[^"]|\\")*?(?<!\\)"])\.?(.*))?$/;
+function joinName_(flag: null, ...parts: unknown[]): string[];
+function joinName_(...parts: unknown[]): string;
+function joinName_(...parts: unknown[]) {
   const name: string[] = [];
   for (let index = 0; index !== parts.length; ++index) {
     const part = parts[index];
     if (part || part === 0) {
       if (typeof part === 'string') {
-        if (part.indexOf('.') !== -1) {
-          name.push(...part.split('.'));
+        const match = nameRegex.exec(part);
+        if (match) {
+          const [, prefix, subscript, rest] = match;
+
+          // `prefix` is a dotted name, e.g., `object.nested.2.field`.
+          if (prefix) {
+            name.push(...prefix.split('.'));
+          }
+
+          // `subscript` is a `["..."]` subscript. The content within should be
+          // escaped by the user, e.g., `["\\""]`.
+          if (subscript !== undefined) {
+            name.push(unescape(subscript));
+
+            // `rest` is anything _after_ the subscript. If the first character
+            // is a dot (`.`), then it's stripped (`.a` -> `a`).
+            if (rest) {
+              parts[index--] = rest;
+            }
+          }
         } else {
           name.push(part);
         }
@@ -19,5 +57,14 @@ export function joinName(...parts: unknown[]) {
     }
   }
 
-  return parts[0] === null ? name : name.join('.');
+  return parts[0] === null
+    ? name.map(escape)
+    : name
+        .map((part, index) => {
+          const escaped = escape(part);
+          return escaped === part ? (index ? `.${part}` : part) : escaped;
+        })
+        .join('');
 }
+
+export const joinName = Object.assign(joinName_, { escape, unescape });

--- a/packages/uniforms/src/joinName.ts
+++ b/packages/uniforms/src/joinName.ts
@@ -1,5 +1,6 @@
 const escapeMatch = /[.[\]]/;
 const escapeRegex = /"/g;
+
 /** @internal */
 function escape(string: string) {
   return string === '' || escapeMatch.test(string)
@@ -7,35 +8,73 @@ function escape(string: string) {
     : string;
 }
 
-function escapeIfNeeded(string: string, index: number) {
+/** @internal */
+function escapeToJoin(string: string, index: number) {
   const escaped = escape(string);
   return escaped === string ? (index ? `.${string}` : string) : escaped;
 }
 
+const unescapeMatch = /^\["(.*)"]$/;
 const unescapeRegex = /\\"/g;
+
 /** @internal */
 function unescape(string: string) {
-  return string.startsWith('["') && string.endsWith('"]')
-    ? string.slice(2, -2).replace(unescapeRegex, '"')
-    : string;
+  const match = unescapeMatch.exec(string);
+  return match ? match[1].replace(unescapeRegex, '"') : string;
 }
 
+// This regular expression splits the string into three parts:
+//   `prefix` is a dotted name, e.g., `object.nested.2.field` at the
+//            front (hence prefix). It covers most standard usecases.
+//   `subscript` is a `["..."]` subscript after the prefix. The content
+//               within should be escaped by the user, e.g., `["\\""]`.
+//   `rest` is anything following the subscript. The leading dot (`.`)
+//          is stripped (`.a` -> `a`) if there is one. It is empty if
+//          `subscript` is empty.
+//
+// All three parts can be empty!
 const nameRegex =
   /^([^.[\]]*(?:\.[^.[\]]+)*)(?:\.?(\["(?:[^"]|\\")*?(?<!\\)"])\.?(.*))?$/;
-function joinName_(flag: null, ...parts: unknown[]): string[];
-function joinName_(...parts: unknown[]): string;
-function joinName_(...parts: unknown[]) {
+
+// We cannot use `joinName` as we export a function with assigned internal
+// helpers and the symbol has to stay free until then.
+function joinNameImpl(flag: null, ...parts: unknown[]): string[];
+function joinNameImpl(...parts: unknown[]): string;
+
+// eslint-disable-next-line complexity -- The complexity of it _is_ high.
+function joinNameImpl(...parts: unknown[]) {
+  // If the first argument is `null`, then we return an escaped array of parts.
+  // Otherwise, an escaped string is returned. As we may modify `parts` later,
+  // this has to be checked now.
+  const returnAsParts = parts[0] === null;
+
+  // Result parts (not escaped).
   const name: string[] = [];
+
+  // This cannot be transformed into a `.forEach` loop and the length of it
+  // can not be memoized, as we modify `parts` as we go for performance reasons.
   for (let index = 0; index !== parts.length; ++index) {
     const part = parts[index];
+
+    // All falsy values except `0` are ignored.
     if (part || part === 0) {
       if (typeof part === 'string') {
+        // Strings are matched against the regular expression that split it into
+        // three parts (all can be empty):
+        //   `prefix` is a dotted name, e.g., `object.nested.2.field` at the
+        //            front (hence prefix). It covers most standard usecases.
+        //   `subscript` is a `["..."]` subscript after the prefix. The content
+        //               within should be escaped by the user, e.g., `["\\""]`.
+        //   `rest` is anything following the subscript. The leading dot (`.`)
+        //          is stripped (`.a` -> `a`) if there is one. It is empty if
+        //          `subscript` is empty.
         const match = nameRegex.exec(part);
         if (match) {
           const [, prefix, subscript, rest] = match;
 
-          // `prefix` is a dotted name, e.g., `object.nested.2.field`.
           if (prefix) {
+            // We could always `.split` the `prefix`, but it results in a severe
+            // performance hit.
             if (prefix.includes('.')) {
               name.push(...prefix.split('.'));
             } else {
@@ -43,31 +82,47 @@ function joinName_(...parts: unknown[]) {
             }
           }
 
-          // `subscript` is a `["..."]` subscript. The content within should be
-          // escaped by the user, e.g., `["\\""]`.
-          if (subscript !== undefined) {
+          if (subscript) {
+            // We could adjust the `nameRegex` to skip brackets and `unescape`
+            // to skip this check, but then every other call (e.g., a one in the
+            // bridge) would have to know that. The performance is not affected
+            // much by it anyway.
             name.push(unescape(subscript));
 
-            // `rest` is anything _after_ the subscript. If the first character
-            // is a dot (`.`), then it's stripped (`.a` -> `a`).
+            // The `rest` is inlined in place as it is a single string.
             if (rest) {
               parts[index--] = rest;
             }
           }
         } else {
+          // If a string is not matching the pattern, we leave it as it is. We
+          // may want to raise a warning here as it should not happen. Most
+          // likely it is something that should have been escaped (e.g., `[`).
           name.push(part);
         }
       } else if (Array.isArray(part)) {
-        parts.splice(index--, 1, ...part);
+        // Arrays are flattened in place but only if needed, i.e., they are not
+        // empty. We calculate the length of the overlapping parts to reuse the
+        // `parts` array as much as possible:
+        // [[], ...]              -> [[], ...]       // No change.
+        // [['a'], ...]           -> ['a', ...]      // Inline in place.
+        // [['a', 'b'], ...]      -> ['a', 'b', ...] // Inline with extension.
+        // ['a', ['b'], ...]      -> ['a', 'b', ...] // Inline in place.
+        // ['a', ['b', 'c'], ...] -> ['b', 'c', ...] // Inline with overlap.
+        if (part.length) {
+          const length = Math.min(index + 1, part.length);
+          index -= length;
+          parts.splice(index + 1, length, ...part);
+        }
       } else {
+        // Other values -- most likely numbers and `true` -- are stringified.
         name.push('' + part);
       }
     }
   }
 
-  return parts[0] === null
-    ? name.map(escape)
-    : name.map(escapeIfNeeded).join('');
+  // We cannot escape the parts earlier as `escapeToJoin` depends on the index.
+  return returnAsParts ? name.map(escape) : name.map(escapeToJoin).join('');
 }
 
-export const joinName = Object.assign(joinName_, { escape, unescape });
+export const joinName = Object.assign(joinNameImpl, { escape, unescape });


### PR DESCRIPTION
In this pull request, I've extended the `joinName` helper to make it work with "complex" field names. There are a lot of possible names that are impossible for uniforms at the moment - most importantly the ones with dots in names (see #963).

Most importantly, this change is backward compatible for all schemas with alphanumeric fields only (I believe it covers more than 99% of projects). When it comes to the rest, like the ones with fields called `/` or `[`, it may not be the case (it probably will with most of them; I still have to test it).

The point of this change is that `joinName` correctly understands JSON Path-like names. The rules are simple and very similar to the ones in JavaScript:
* `a` works as before, accessing top-level fields.
* `a.b` works as before, accessing objects' properties.
* `a.0` works as before, accessing array elements.
* `["a"]` is a new way of accessing top-level fields.
* `["a"]["b"]` is a new way of accessing objects' properties.
  * You can mix them freely: `a["b"].c` is the same as `a.b.c` or `["a"].b["c"]`.
  * You can use all of the characters within the subscript (`[""]`) with only one limitation: `"` has to be escaped into `\"`.
    * If you'd like to render field called `[""]`, then `["[\"\"]"]` it is.

There are however three things that I'm not entirely happy with:
1. **The fact that `joinName` _always_ returns _something_.** This doesn't sound like a problem, but it is - there are some potentially incorrect names, that we handle in a given way (based on the current implementation). For example `[` is normalized to `["["]` and `['']` is normalized to `["['']"]`. See the [tests](https://github.com/vazco/uniforms/blob/69f2e958d4f96123be8b4a8773d1f8f9ab98f5b8/packages/uniforms/__tests__/joinName.ts#L86-L110) for more examples. (Maybe we should add a development-only warning?)
2. **More semi-public API.** As the escaping is needed for the forms to work, the bridge that would like to support "complex" names should use `joinName.escape` and `joinName.unescape` functions. I've marked them as `@internal`, but they are still visible and typed.

---

Performance changes.

Example data taken from the `joinName` test cases: less than 1% slower on average.

|        |   min  |   avg  |   max  |
|:------:|:------:|:------:|:------:|
| Before |  912ms |  936ms |  982ms |
| After  |  925ms |  936ms |  991ms |

Example data taken from an actual project: 7% slower on average.

|        |   min  |   avg  |   max  |
|:------:|:------:|:------:|:------:|
| Before |  220ms |  228ms |  239ms |
| After  |  239ms |  244ms |  259ms |

---

<details>
<summary>Here's an example schema so you can test it yourself.</summary>

```js
(() => {
  const ajv = new Ajv({ allErrors: true, useDefaults: true, keywords: ["uniforms"] });
  const schema = {
    type: 'object',
    properties: {
      complexNames: {
        type: 'object',
        properties: {
          a: {
            type: 'array',
            items: {
              type: 'object',
              properties: {
                b: {
                  type: 'object',
                  properties: {
                    'c-d': {
                      type: 'array',
                      items: {
                        type: 'object',
                        properties: {
                          "f/'g": { type: 'string', pattern: '[0-9]{5}' },
                          'h/"i': { type: 'string', pattern: '[0-9]{5}' },
                          'j\'/"k': { type: 'string', pattern: '[0-9]{5}' },
                        },
                      },
                    },
                  },
                },
              },
            },
          },
        },
      },
      'path.with.a.dot': {
        type: 'object',
        properties: {
          'another.with.a.dot': {
            type: 'string',
          },
          another: {
            type: 'object',
            properties: {
              with: {
                type: 'object',
                properties: {
                  a: {
                    type: 'object',
                    properties: {
                      dot: {
                        type: 'number',
                      },
                    },
                  },
                },
              },
            },
          },
        },
      },
      path: {
        type: 'object',
        properties: {
          'with.a.dot': { type: 'number' },
          '["with.a.dot"]': { type: 'string' },
        },
      },
    },
  };

  function createValidator(schema) {
    const validator = ajv.compile(schema);

    return (model) => {
      validator(model);

      if (validator.errors && validator.errors.length) {
        return { details: validator.errors };
      }
    };
  }

  const schemaValidator = createValidator(schema);

  return new JSONSchemaBridge(schema, schemaValidator);
})()
```

</details>

I took the tests from #1078 but went with a completely different approach.