### PR TITLE
Imported prettier settings from eslint-config-vazco package

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
-const settings = require('./node_modules/eslint-config-vazco/default.json');
+const settings = require('eslint-config-vazco/default.json');
 
 module.exports = settings.rules['prettier/prettier'][1];

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+const settings = require('./node_modules/eslint-config-vazco/default.json');
+
+module.exports = settings.rules['prettier/prettier'][1];

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "bracketSpacing": true,
-  "printWidth": 80,
-  "singleQuote": true,
-  "tabWidth": 2,
-  "trailingComma": "none"
-}

--- a/docs/api-bridges.md
+++ b/docs/api-bridges.md
@@ -58,17 +58,17 @@ const schema = `
 const schemaType = buildASTSchema(parse(schema)).getType('Post');
 const schemaExtras = {
   id: {
-    allowedValues: [1, 2, 3]
+    allowedValues: [1, 2, 3],
   },
   title: {
     options: [
       { label: 1, value: 'a' },
-      { label: 2, value: 'b' }
-    ]
+      { label: 2, value: 'b' },
+    ],
   },
   'author.firstName': {
-    placeholder: 'John'
-  }
+    placeholder: 'John',
+  },
 };
 
 const schemaValidator = (model: object) => {
@@ -85,7 +85,7 @@ const schemaValidator = (model: object) => {
   if (model.votes < 0) {
     details.push({
       name: 'votes',
-      message: 'Votes must be a non-negative number!'
+      message: 'Votes must be a non-negative number!',
     });
   }
 
@@ -114,10 +114,10 @@ const schema = {
     age: {
       description: 'Age in years',
       type: 'integer',
-      minimum: 0
-    }
+      minimum: 0,
+    },
   },
-  required: ['firstName', 'lastName']
+  required: ['firstName', 'lastName'],
 };
 
 function createValidator(schema: object) {
@@ -202,9 +202,9 @@ const PersonSchema = new SimpleSchema({
     uniforms: {
       // ...or object...
       component: MyText, // ...with component...
-      propA: 1 // ...and/or extra props.
-    }
-  }
+      propA: 1, // ...and/or extra props.
+    },
+  },
 });
 
 const bridge = new SimpleSchema2Bridge(PersonSchema);
@@ -225,9 +225,9 @@ const PersonSchema = new SimpleSchema({
     uniforms: {
       // ...or object...
       component: MyText, // ...with component...
-      propA: 1 // ...and/or extra props.
-    }
-  }
+      propA: 1, // ...and/or extra props.
+    },
+  },
 });
 
 const bridge = new SimpleSchemaBridge(PersonSchema);

--- a/docs/examples-custom-bridge.md
+++ b/docs/examples-custom-bridge.md
@@ -22,20 +22,20 @@ const UserLoginSchema = {
     __type__: String,
     required: true,
     initialValue: '',
-    label: 'Login'
+    label: 'Login',
   },
   password1: {
     __type__: String,
     required: true,
     initialValue: '',
-    label: 'Password'
+    label: 'Password',
   },
   password2: {
     __type__: String,
     required: true,
     initialValue: '',
-    label: 'Password (again)'
-  }
+    label: 'Password (again)',
+  },
 };
 
 export default UserLoginSchema;
@@ -146,7 +146,7 @@ import UserLoginSchemaValidator from './UserLoginSchemaValidator';
 
 const bridge = new UserLoginSchemaBridge(
   UserLoginSchema,
-  UserLoginSchemaValidator
+  UserLoginSchemaValidator,
 );
 
 <AutoForm schema={bridge} />;

--- a/docs/examples-custom-fields.mdx
+++ b/docs/examples-custom-fields.mdx
@@ -38,7 +38,7 @@ const CustomAuto = props => {
 };
 
 const CustomAutoField = connectField(CustomAuto, {
-  initialValue: false
+  initialValue: false,
 });
 
 // Deprecated: You can also tell your `AutoForm`/`QuickForm`/`ValidatedQuickForm` to use it.

--- a/docs/examples-custom-form.md
+++ b/docs/examples-custom-form.md
@@ -34,7 +34,7 @@ const Modifier = parent =>
         // It's a good idea to omit empty modifiers.
         const $set = update.reduce(
           (acc, key) => ({ ...acc, [key]: doc[key] }),
-          {}
+          {},
         );
         const $unset = remove.reduce((acc, key) => ({ ...acc, [key]: '' }), {});
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,8 +26,8 @@ const schema = {
   /*...*/
   firstName: {
     type: 'string',
-    uniforms: MyCustomFirstNameField
-  }
+    uniforms: MyCustomFirstNameField,
+  },
   /*...*/
 };
 ```
@@ -58,9 +58,9 @@ const schema = {
     uniforms: {
       component: MyCustomFirstNameField,
       propA: 1,
-      propB: 2
-    }
-  }
+      propB: 2,
+    },
+  },
   /*...*/
 };
 ```

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -20,7 +20,7 @@ Now the schema package.
     { name: 'GraphQL' },
     { name: 'JSON-Schema' },
     { name: 'Simple-Schema' },
-    { name: 'Simple-Schema-2' }
+    { name: 'Simple-Schema-2' },
   ]}
 >
   {({ name: bridgeName }) => (
@@ -39,7 +39,7 @@ Now the schema package.
           { name: 'Bootstrap4' },
           { name: 'Bootstrap5' },
           { name: 'AntD' },
-          { name: 'Unstyled' }
+          { name: 'Unstyled' },
         ]}
       >
         {({ name: themeName }) => (

--- a/docs/tutorials-creating-custom-field.mdx
+++ b/docs/tutorials-creating-custom-field.mdx
@@ -51,7 +51,7 @@ Take a look at the form code:
   language="tsx"
   replace={{
     "'[^']*?/universal'": "'uniforms-semantic'",
-    './GuestSchema\\d': './GuestSchema'
+    './GuestSchema\\d': './GuestSchema',
   }}
   source={require('!!raw-loader!../website/pages-parts/Tutorial/GuestFormFinal')}
 />

--- a/docs/tutorials-using-predefined-fields.mdx
+++ b/docs/tutorials-using-predefined-fields.mdx
@@ -30,7 +30,7 @@ We will add the `profession` field above the `workExperience` field and the `add
   language="tsx"
   replace={{
     "'[^']*?/universal'": "'uniforms-semantic'",
-    './GuestSchema\\d': './GuestSchema'
+    './GuestSchema\\d': './GuestSchema',
   }}
   source={require('!!raw-loader!../website/pages-parts/Tutorial/GuestFormProfessionAdditionalInfo')}
 />
@@ -61,7 +61,7 @@ Let's see our changes in action:
   language="tsx"
   replace={{
     "'[^']*?/universal'": "'uniforms-semantic'",
-    './GuestSchema\\d': './GuestSchema'
+    './GuestSchema\\d': './GuestSchema',
   }}
   source={require('!!raw-loader!../website/pages-parts/Tutorial/GuestFormPredefinedFields')}
 />
@@ -83,7 +83,7 @@ Before touching the schema, let's have a look at the React form first:
   language="tsx"
   replace={{
     "'[^']*?/universal'": "'uniforms-semantic'",
-    './GuestSchema\\d': './GuestSchema'
+    './GuestSchema\\d': './GuestSchema',
   }}
   source={require('!!raw-loader!../website/pages-parts/Tutorial/GuestFormWithFieldsInSchema')}
 />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "node",
     "paths": { "uniforms": ["uniforms/src"], "uniforms-*": ["uniforms-*/src"] },
     "strict": true,
-    "target": "ES6",
-    "resolveJsonModule": true
+    "target": "ES6"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "paths": { "uniforms": ["uniforms/src"], "uniforms-*": ["uniforms-*/src"] },
     "strict": true,
-    "target": "ES6"
+    "target": "ES6",
+    "resolveJsonModule": true
   }
 }

--- a/website/components/Playground.tsx
+++ b/website/components/Playground.tsx
@@ -129,6 +129,7 @@ class PlaygroundPreview extends Component<any, any> {
     this._schema = eval(`(${this.props.value.schema})`);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(props: any) {
     if (this.props.value.schema !== props.value.schema) {
       this._schema = eval(`(${props.value.schema})`);


### PR DESCRIPTION
Instead of duplicating a prettier config, it's imported from the `eslint-config-package` settings.