### PR TITLE
Optimized `connectField` for leaf fields.

### DIFF
--- a/packages/uniforms/src/connectField.tsx
+++ b/packages/uniforms/src/connectField.tsx
@@ -2,7 +2,7 @@ import mapValues from 'lodash/mapValues';
 import React, { ComponentType, FunctionComponent } from 'react';
 
 import { context as contextReference } from './context';
-import { GuaranteedProps, Override } from './types';
+import { Context, GuaranteedProps, Override } from './types';
 import { useField } from './useField';
 
 /** @internal */
@@ -36,6 +36,44 @@ export type ConnectedField<
   options?: ConnectFieldOptions;
 };
 
+function getNextContext<Model, Props extends Record<string, unknown>, Value>(
+  context: Context<Model>,
+  props: ConnectedFieldProps<Props, Value>,
+  options?: ConnectFieldOptions,
+) {
+  // Leaf components by definition do not affect the context. `AutoField` will
+  // skip most of them anyway, but if rendered directly we have to do it here.
+  // An example in the core theme are the `List*Field`s.
+  if (options?.kind === 'leaf') {
+    return context;
+  }
+
+  const changesName = props.name !== '';
+  const changesState = Object.keys(context.state).some(key => {
+    const next = props[key];
+    return next !== null && next !== undefined;
+  });
+
+  // There are no other ways of affecting the context.
+  if (!changesName && !changesState) {
+    return context;
+  }
+
+  const nextContext = { ...context };
+  if (changesName) {
+    nextContext.name = nextContext.name.concat(props.name);
+  }
+
+  if (changesState) {
+    nextContext.state = mapValues(nextContext.state, (prev, key) => {
+      const next = props[key];
+      return next !== null && next !== undefined ? !!next : prev;
+    });
+  }
+
+  return nextContext;
+}
+
 export function connectField<
   Props extends Record<string, unknown>,
   Value = Props['value'],
@@ -45,34 +83,17 @@ export function connectField<
 ): ConnectedField<Props, Value> {
   function Field(props: ConnectedFieldProps<Props, Value>) {
     const [fieldProps, context] = useField(props.name, props, options);
+    const nextContext = getNextContext(context, props, options);
+    const body = <Component {...(props as unknown as Props)} {...fieldProps} />;
 
-    const hasChainName = props.name !== '';
-    const anyFlowingPropertySet = Object.keys(context.state).some(key => {
-      const next = props[key];
-      return next !== null && next !== undefined;
-    });
-
-    if (!anyFlowingPropertySet && !hasChainName) {
-      return <Component {...(props as unknown as Props)} {...fieldProps} />;
+    // If the context has not changed, then don't render the `Provider`. It's
+    // possible that it will change at some point, but it's extremely rare, as
+    // either `name` or one of the "state props" has to change.
+    if (context === nextContext) {
+      return body;
     }
 
-    const nextContext = { ...context };
-    if (anyFlowingPropertySet) {
-      nextContext.state = mapValues(nextContext.state, (prev, key) => {
-        const next = props[key];
-        return next !== null && next !== undefined ? !!next : prev;
-      });
-    }
-
-    if (hasChainName) {
-      nextContext.name = nextContext.name.concat(props.name);
-    }
-
-    return (
-      <contextReference.Provider value={nextContext}>
-        <Component {...(props as unknown as Props)} {...fieldProps} />
-      </contextReference.Provider>
-    );
+    return <contextReference.Provider children={body} value={nextContext} />;
   }
 
   Field.displayName = `${Component.displayName || Component.name}Field`;


### PR DESCRIPTION
While testing #1091, I've noticed that some `kind='leaf'` fields, like `ListAddField`, are unnecessarily rendering the `Provider` component. It doesn't make sense, as there's nothing in the subtree that will use the adjusted context.

In the most common situation, i.e., `AutoField` rendering the field, it'd be skipped due to [this check](https://github.com/vazco/uniforms/blob/8cbb12516490c88d0ab0a71e2a7d467f92f4ae2f/packages/uniforms/src/createAutoField.tsx#L39-L41). However, when being rendered directly, they actually did render the `Provider` component. With this PR it's no longer the case.