### PR TITLE
Implemented recursive `getInitialValue` for objects (fixes #1112).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- **Changed:** All bridges calculate initial values (`getInitialValue`) for objects just like for arrays, i.e., recursively for all subfields. [\#1112](https://github.com/vazco/uniforms/issues/1112)
+
 ## [v3.10.0-rc.0](https://github.com/vazco/uniforms/tree/v3.10.0-rc.0) (2022-05-30)
 
 - **Added:** New theme: `uniforms-mui`. [\#1054](https://github.com/vazco/uniforms/issues/1054)

--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -204,7 +204,11 @@ describe('GraphQLBridge', () => {
     });
 
     it('works with objects', () => {
-      expect(bridgeI.getInitialValue('author')).toEqual({});
+      expect(bridgeI.getInitialValue('author')).toEqual({
+        firstName: 'John',
+        lastName: 'Doe',
+        tags: [],
+      });
     });
 
     it('works with undefined primitives', () => {

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -89,7 +89,14 @@ export default class GraphQLBridge extends Bridge {
     }
 
     if (type === Object) {
-      return {};
+      const value: Record<string, unknown> = {};
+      this.getSubfields(name).forEach(key => {
+        const initialValue = this.getInitialValue(joinName(name, key));
+        if (initialValue !== undefined) {
+          value[key] = initialValue;
+        }
+      });
+      return value;
     }
 
     const { defaultValue } = this.getField(name);

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -617,7 +617,7 @@ describe('JSONSchemaBridge', () => {
     it('works with arrays', () => {
       expect(bridge.getInitialValue('friends')).toEqual([]);
       expect(bridge.getInitialValue('friends', { initialCount: 1 })).toEqual([
-        {},
+        { firstName: 'John', lastName: 'John' },
       ]);
       expect(
         bridge.getInitialValue('friends.0.firstName', { initialCount: 1 }),

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -223,7 +223,14 @@ export default class JSONSchemaBridge extends Bridge {
     }
 
     if (type === 'object') {
-      return {};
+      const value: Record<string, unknown> = {};
+      this.getSubfields(name).forEach(key => {
+        const initialValue = this.getInitialValue(joinName(name, key));
+        if (initialValue !== undefined) {
+          value[key] = initialValue;
+        }
+      });
+      return value;
     }
 
     return undefined;

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -176,7 +176,7 @@ describe('SimpleSchema2Bridge', () => {
     });
 
     it('works with objects', () => {
-      expect(bridge.getInitialValue('a')).toEqual({});
+      expect(bridge.getInitialValue('a')).toEqual({ b: {} });
     });
 
     it('works with objects (defaultValue)', () => {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -83,7 +83,14 @@ export default class SimpleSchema2Bridge extends Bridge {
     }
 
     if (field.type === Object || field.type instanceof SimpleSchema) {
-      return {};
+      const value: Record<string, unknown> = {};
+      this.getSubfields(name).forEach(key => {
+        const initialValue = this.getInitialValue(joinName(name, key));
+        if (initialValue !== undefined) {
+          value[key] = initialValue;
+        }
+      });
+      return value;
     }
 
     return undefined;
@@ -148,7 +155,7 @@ export default class SimpleSchema2Bridge extends Bridge {
     return props;
   }
 
-  getSubfields(name?: string) {
+  getSubfields(name?: string): string[] {
     // @ts-expect-error: Typing for `_makeGeneric` is missing.
     return this.schema.objectKeys(SimpleSchema._makeGeneric(name));
   }

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -195,7 +195,7 @@ describe('SimpleSchemaBridge', () => {
     });
 
     it('works with objects', () => {
-      expect(bridge.getInitialValue('a')).toEqual({});
+      expect(bridge.getInitialValue('a')).toEqual({ b: {} });
     });
 
     it('works with objects (defaultValue)', () => {

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -78,7 +78,14 @@ export default class SimpleSchemaBridge extends Bridge {
     }
 
     if (field.type === Object) {
-      return {};
+      const value: Record<string, unknown> = {};
+      this.getSubfields(name).forEach(key => {
+        const initialValue = this.getInitialValue(joinName(name, key));
+        if (initialValue !== undefined) {
+          value[key] = initialValue;
+        }
+      });
+      return value;
     }
 
     return undefined;
@@ -139,7 +146,7 @@ export default class SimpleSchemaBridge extends Bridge {
     return props;
   }
 
-  getSubfields(name?: string) {
+  getSubfields(name?: string): string[] {
     return this.schema.objectKeys(SimpleSchema._makeGeneric(name));
   }
 


### PR DESCRIPTION
As reported in #1112, there are cases where using an empty object for the initial value (`getInitialValue` on a bridge) causes problems with the invariants we have. To fix that, I made it work in the same way as we work with arrays, i.e., resolve all subfields recursively. 