### PR TITLE
Added support for React 18 (closes #1109).

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,6 +3,14 @@ id: faq
 title: FAQ
 ---
 
+### Can I use React v18?
+
+_Yes_, but be cautious about it.
+
+Our test suite is incompatible with it (we're using Enzyme; see [enzymejs/enzyme#2429](https://github.com/enzymejs/enzyme/issues/2429) and [enzymejs/enzyme#2524](https://github.com/enzymejs/enzyme/issues/2524)), therefore we are not certain that everything works as it should. Based on the [official upgrade guide](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html), there's nothing you should worry about. A few people (including some of our projects) are already doing that (see [#1109](https://github.com/vazco/uniforms/issues/1109)).
+
+If you'll encounter any issues, do file an issue.
+
 ### How can I customize/style my form fields?
 
 You can style your form fields simply by passing a `className` property.

--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ant-design/icons": "^4.0.0",
     "antd": "^4.0.0",
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "invariant": "^2.0.0",

--- a/packages/uniforms-bootstrap3/package.json
+++ b/packages/uniforms-bootstrap3/package.json
@@ -28,7 +28,7 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-bootstrap4/package.json
+++ b/packages/uniforms-bootstrap4/package.json
@@ -28,7 +28,7 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-bootstrap5/package.json
+++ b/packages/uniforms-bootstrap5/package.json
@@ -28,7 +28,7 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-material/package.json
+++ b/packages/uniforms-material/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@material-ui/core": "^4.0.0",
     "csstype": "^2.0.0",
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "invariant": "^2.0.0",

--- a/packages/uniforms-mui/package.json
+++ b/packages/uniforms-mui/package.json
@@ -31,7 +31,7 @@
   ],
   "peerDependencies": {
     "@mui/material": "^5.0.0",
-    "react": "^17.0.0"
+    "react": "^18.0.0 || ^17.0.0"
   },
   "dependencies": {
     "invariant": "^2.0.0",

--- a/packages/uniforms-semantic/package.json
+++ b/packages/uniforms-semantic/package.json
@@ -28,7 +28,7 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-unstyled/package.json
+++ b/packages/uniforms-unstyled/package.json
@@ -27,7 +27,7 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "invariant": "^2.0.0",

--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -34,7 +34,7 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
   },
   "dependencies": {
     "invariant": "^2.0.0",


### PR DESCRIPTION
As described in [#1109](https://github.com/vazco/uniforms/issues/1109#issuecomment-1152271810), we've decided to make v18 a valid peer dependency with a note in the FAQ.