### PR TITLE
Unified implementation of DateField type handling.

### DIFF
--- a/packages/uniforms-bootstrap3/__tests__/DateField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/DateField.tsx
@@ -1,8 +1,33 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DateField, DateFieldProps } from 'uniforms-bootstrap3';
+import { render } from 'uniforms/__suites__';
 
 import createContext from './_createContext';
 import mount from './_mount';
+
+describe('@RTL - DateField tests', () => {
+  test('<DateField> - handles "date" type correctly', () => {
+    const onChange = jest.fn();
+    const initialDate = new Date(Date.UTC(2020, 0, 1));
+
+    render(
+      <DateField name="x" type="date" placeholder="X" value={initialDate} />,
+      { x: Date },
+      { onChange },
+    );
+
+    const wrapper = screen.getByPlaceholderText('X');
+    // @ts-expect-error Incorrect types, approach taken from docs: https://testing-library.com/docs/example-input-event/
+    expect(wrapper.value).toBe('2020-01-01');
+    userEvent.type(wrapper, '2021-03-03');
+    expect(onChange.mock.calls[1][0]).toBe('x');
+    expect(onChange.mock.calls[1][1].toISOString()).toBe(
+      '2021-03-03T00:00:00.000Z',
+    );
+  });
+});
 
 test('<DateField> - renders an input', () => {
   const element = <DateField name="x" />;

--- a/packages/uniforms-bootstrap3/src/DateField.tsx
+++ b/packages/uniforms-bootstrap3/src/DateField.tsx
@@ -38,11 +38,9 @@ function Date({
   placeholder,
   readOnly,
   value,
-  type,
+  type = 'datetime-local',
   ...props
 }: DateFieldProps) {
-  const dateType = type === 'date' ? type : 'datetime-local';
-
   return wrapField(
     { ...props, id },
     <input
@@ -65,7 +63,7 @@ function Date({
       placeholder={placeholder}
       readOnly={readOnly}
       ref={inputRef}
-      type={dateType}
+      type={type}
       value={dateFormat(value, type) ?? ''}
     />,
   );

--- a/packages/uniforms-bootstrap3/src/DateField.tsx
+++ b/packages/uniforms-bootstrap3/src/DateField.tsx
@@ -4,9 +4,12 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
+type DateFieldType = 'date' | 'datetime-local';
+
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
+const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
+  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 
 export type DateFieldProps = HTMLFieldProps<
   Date,
@@ -18,7 +21,7 @@ export type DateFieldProps = HTMLFieldProps<
     max?: Date;
     min?: Date;
     wrapClassName?: string;
-    type?: 'date' | 'datetime-local';
+    type?: DateFieldType;
   }
 >;
 
@@ -63,7 +66,7 @@ function Date({
       readOnly={readOnly}
       ref={inputRef}
       type={dateType}
-      value={dateFormat(value) ?? ''}
+      value={dateFormat(value, type) ?? ''}
     />,
   );
 }

--- a/packages/uniforms-bootstrap4/__tests__/DateField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/DateField.tsx
@@ -1,8 +1,33 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DateField, DateFieldProps } from 'uniforms-bootstrap4';
+import { render } from 'uniforms/__suites__';
 
 import createContext from './_createContext';
 import mount from './_mount';
+
+describe('@RTL - DateField tests', () => {
+  test('<DateField> - handles "date" type correctly', () => {
+    const onChange = jest.fn();
+    const initialDate = new Date(Date.UTC(2020, 0, 1));
+
+    render(
+      <DateField name="x" type="date" placeholder="X" value={initialDate} />,
+      { x: Date },
+      { onChange },
+    );
+
+    const wrapper = screen.getByPlaceholderText('X');
+    // @ts-expect-error Incorrect types, approach taken from docs: https://testing-library.com/docs/example-input-event/
+    expect(wrapper.value).toBe('2020-01-01');
+    userEvent.type(wrapper, '2021-03-03');
+    expect(onChange.mock.calls[1][0]).toBe('x');
+    expect(onChange.mock.calls[1][1].toISOString()).toBe(
+      '2021-03-03T00:00:00.000Z',
+    );
+  });
+});
 
 test('<DateField> - renders an input', () => {
   const element = <DateField name="x" />;

--- a/packages/uniforms-bootstrap4/src/DateField.tsx
+++ b/packages/uniforms-bootstrap4/src/DateField.tsx
@@ -37,11 +37,9 @@ function Date({
   placeholder,
   readOnly,
   value,
-  type,
+  type = 'datetime-local',
   ...props
 }: DateFieldProps) {
-  const dateType = type === 'date' ? type : 'datetime-local';
-
   return wrapField(
     { ...props, id },
     <input
@@ -65,7 +63,7 @@ function Date({
       placeholder={placeholder}
       readOnly={readOnly}
       ref={inputRef}
-      type={dateType}
+      type={type}
       value={dateFormat(value, type) ?? ''}
     />,
   );

--- a/packages/uniforms-bootstrap4/src/DateField.tsx
+++ b/packages/uniforms-bootstrap4/src/DateField.tsx
@@ -4,9 +4,12 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
+type DateFieldType = 'date' | 'datetime-local';
+
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
+const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
+  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 
 export type DateFieldProps = HTMLFieldProps<
   Date,
@@ -17,7 +20,7 @@ export type DateFieldProps = HTMLFieldProps<
     max?: Date;
     min?: Date;
     wrapClassName?: string;
-    type?: 'date' | 'datetime-local';
+    type?: DateFieldType;
   }
 >;
 
@@ -63,7 +66,7 @@ function Date({
       readOnly={readOnly}
       ref={inputRef}
       type={dateType}
-      value={dateFormat(value) ?? ''}
+      value={dateFormat(value, type) ?? ''}
     />,
   );
 }

--- a/packages/uniforms-bootstrap5/__tests__/DateField.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/DateField.tsx
@@ -1,8 +1,33 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DateField, DateFieldProps } from 'uniforms-bootstrap5';
+import { render } from 'uniforms/__suites__';
 
 import createContext from './_createContext';
 import mount from './_mount';
+
+describe('@RTL - DateField tests', () => {
+  test('<DateField> - handles "date" type correctly', () => {
+    const onChange = jest.fn();
+    const initialDate = new Date(Date.UTC(2020, 0, 1));
+
+    render(
+      <DateField name="x" type="date" placeholder="X" value={initialDate} />,
+      { x: Date },
+      { onChange },
+    );
+
+    const wrapper = screen.getByPlaceholderText('X');
+    // @ts-expect-error Incorrect types, approach taken from docs: https://testing-library.com/docs/example-input-event/
+    expect(wrapper.value).toBe('2020-01-01');
+    userEvent.type(wrapper, '2021-03-03');
+    expect(onChange.mock.calls[1][0]).toBe('x');
+    expect(onChange.mock.calls[1][1].toISOString()).toBe(
+      '2021-03-03T00:00:00.000Z',
+    );
+  });
+});
 
 test('<DateField> - renders an input', () => {
   const element = <DateField name="x" />;

--- a/packages/uniforms-bootstrap5/src/DateField.tsx
+++ b/packages/uniforms-bootstrap5/src/DateField.tsx
@@ -37,11 +37,9 @@ function Date({
   placeholder,
   readOnly,
   value,
-  type,
+  type = 'datetime-local',
   ...props
 }: DateFieldProps) {
-  const dateType = type === 'date' ? type : 'datetime-local';
-
   return wrapField(
     { ...props, id },
     <input
@@ -65,7 +63,7 @@ function Date({
       placeholder={placeholder}
       readOnly={readOnly}
       ref={inputRef}
-      type={dateType}
+      type={type}
       value={dateFormat(value, type) ?? ''}
     />,
   );

--- a/packages/uniforms-bootstrap5/src/DateField.tsx
+++ b/packages/uniforms-bootstrap5/src/DateField.tsx
@@ -4,9 +4,12 @@ import { connectField, HTMLFieldProps } from 'uniforms';
 
 import wrapField from './wrapField';
 
+type DateFieldType = 'date' | 'datetime-local';
+
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
+const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
+  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 
 export type DateFieldProps = HTMLFieldProps<
   Date,
@@ -17,7 +20,7 @@ export type DateFieldProps = HTMLFieldProps<
     max?: Date;
     min?: Date;
     wrapClassName?: string;
-    type?: 'date' | 'datetime-local';
+    type?: DateFieldType;
   }
 >;
 
@@ -63,7 +66,7 @@ function Date({
       readOnly={readOnly}
       ref={inputRef}
       type={dateType}
-      value={dateFormat(value) ?? ''}
+      value={dateFormat(value, type) ?? ''}
     />,
   );
 }

--- a/packages/uniforms-material/__tests__/DateField.tsx
+++ b/packages/uniforms-material/__tests__/DateField.tsx
@@ -4,12 +4,36 @@ import FormLabel from '@material-ui/core/FormLabel';
 import Input from '@material-ui/core/Input';
 import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
 import ThemeProvider from '@material-ui/styles/ThemeProvider/ThemeProvider';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DateField, DateFieldProps } from 'uniforms-material';
 import { render } from 'uniforms/__suites__';
 
 import createContext from './_createContext';
 import mount from './_mount';
+
+describe('@RTL - DateField tests', () => {
+  test('<DateField> - handles "date" type correctly', () => {
+    const onChange = jest.fn();
+    const initialDate = new Date(Date.UTC(2020, 0, 1));
+
+    render(
+      <DateField name="x" type="date" placeholder="X" value={initialDate} />,
+      { x: Date },
+      { onChange },
+    );
+
+    const wrapper = screen.getByPlaceholderText('X');
+    // @ts-expect-error Incorrect types, approach taken from docs: https://testing-library.com/docs/example-input-event/
+    expect(wrapper.value).toBe('2020-01-01');
+    userEvent.type(wrapper, '2021-03-03');
+    expect(onChange.mock.calls[1][0]).toBe('x');
+    expect(onChange.mock.calls[1][1].toISOString()).toBe(
+      '2021-03-03T00:00:00.000Z',
+    );
+  });
+});
 
 describe('@RTL - DateField tests', () => {
   test('<DateField> - default props are not passed when MUI theme props are specified', () => {

--- a/packages/uniforms-material/src/DateField.tsx
+++ b/packages/uniforms-material/src/DateField.tsx
@@ -3,12 +3,8 @@ import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
-type DateFieldType = 'date' | 'datetime-local';
-
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
-  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 
 const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
   const date = new DateConstructor(timestamp);
@@ -24,7 +20,7 @@ export type DateFieldProps = FieldProps<
   TextFieldProps,
   {
     labelProps?: object;
-    type?: DateFieldType;
+    type?: 'date' | 'datetime-local';
   }
 >;
 
@@ -67,7 +63,10 @@ function Date({
       placeholder={placeholder}
       ref={inputRef}
       type={type}
-      value={dateFormat(value, type) ?? ''}
+      value={
+        value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14) ??
+        ''
+      }
       {...filterDOMProps(props)}
     />
   );

--- a/packages/uniforms-material/src/DateField.tsx
+++ b/packages/uniforms-material/src/DateField.tsx
@@ -43,12 +43,11 @@ function Date({
   readOnly,
   showInlineError,
   value,
-  type,
+  type = 'datetime-local',
   ...props
 }: DateFieldProps) {
   const theme = useTheme();
   const themeProps = theme.props?.MuiTextField;
-  const dateType = type === 'date' ? type : 'datetime-local';
 
   return (
     <TextField
@@ -67,7 +66,7 @@ function Date({
       }
       placeholder={placeholder}
       ref={inputRef}
-      type={dateType}
+      type={type}
       value={dateFormat(value, type) ?? ''}
       {...filterDOMProps(props)}
     />

--- a/packages/uniforms-material/src/DateField.tsx
+++ b/packages/uniforms-material/src/DateField.tsx
@@ -3,10 +3,13 @@ import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
+type DateFieldType = 'date' | 'datetime-local';
+
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date, type = 'datetime-local') =>
+const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
   value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
+
 const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
   const date = new DateConstructor(timestamp);
   if (date.getFullYear() < 10000) {
@@ -21,7 +24,7 @@ export type DateFieldProps = FieldProps<
   TextFieldProps,
   {
     labelProps?: object;
-    type?: 'date' | 'datetime-local';
+    type?: DateFieldType;
   }
 >;
 

--- a/packages/uniforms-mui/__tests__/DateField.tsx
+++ b/packages/uniforms-mui/__tests__/DateField.tsx
@@ -2,11 +2,36 @@ import FormControl from '@mui/material/FormControl';
 import FormHelperText from '@mui/material/FormHelperText';
 import FormLabel from '@mui/material/FormLabel';
 import OutlinedInput from '@mui/material/OutlinedInput';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DateField } from 'uniforms-mui';
+import { render } from 'uniforms/__suites__';
 
 import createContext from './_createContext';
 import mount from './_mount';
+
+describe('@RTL - DateField tests', () => {
+  test('<DateField> - handles "date" type correctly', () => {
+    const onChange = jest.fn();
+    const initialDate = new Date(Date.UTC(2020, 0, 1));
+
+    render(
+      <DateField name="x" type="date" placeholder="X" value={initialDate} />,
+      { x: Date },
+      { onChange },
+    );
+
+    const wrapper = screen.getByPlaceholderText('X');
+    // @ts-expect-error Incorrect types, approach taken from docs: https://testing-library.com/docs/example-input-event/
+    expect(wrapper.value).toBe('2020-01-01');
+    userEvent.type(wrapper, '2021-03-03');
+    expect(onChange.mock.calls[1][0]).toBe('x');
+    expect(onChange.mock.calls[1][1].toISOString()).toBe(
+      '2021-03-03T00:00:00.000Z',
+    );
+  });
+});
 
 test('<DateField> - renders Input', () => {
   const element = <DateField name="x" />;

--- a/packages/uniforms-mui/src/DateField.tsx
+++ b/packages/uniforms-mui/src/DateField.tsx
@@ -2,8 +2,6 @@ import TextField, { TextFieldProps } from '@mui/material/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
-type DateFieldType = 'date' | 'datetime-local';
-
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 
@@ -19,7 +17,7 @@ const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
 export type DateFieldProps = FieldProps<
   Date,
   TextFieldProps,
-  { labelProps?: object; type?: DateFieldType }
+  { labelProps?: object; type?: 'date' | 'datetime-local' }
 >;
 
 function Date({

--- a/packages/uniforms-mui/src/DateField.tsx
+++ b/packages/uniforms-mui/src/DateField.tsx
@@ -39,11 +39,9 @@ function Date({
   readOnly,
   showInlineError,
   value,
-  type,
+  type = 'datetime-local',
   ...props
 }: DateFieldProps) {
-  const dateType = type === 'date' ? type : 'datetime-local';
-
   return (
     <TextField
       disabled={disabled}
@@ -61,7 +59,7 @@ function Date({
       }
       placeholder={placeholder}
       ref={inputRef}
-      type={dateType}
+      type={type}
       value={dateFormat(value, type) ?? ''}
       {...filterDOMProps(props)}
     />

--- a/packages/uniforms-mui/src/DateField.tsx
+++ b/packages/uniforms-mui/src/DateField.tsx
@@ -6,8 +6,6 @@ type DateFieldType = 'date' | 'datetime-local';
 
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
-  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 
 const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
   const date = new DateConstructor(timestamp);
@@ -60,7 +58,10 @@ function Date({
       placeholder={placeholder}
       ref={inputRef}
       type={type}
-      value={dateFormat(value, type) ?? ''}
+      value={
+        value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14) ??
+        ''
+      }
       {...filterDOMProps(props)}
     />
   );

--- a/packages/uniforms-mui/src/DateField.tsx
+++ b/packages/uniforms-mui/src/DateField.tsx
@@ -2,9 +2,13 @@ import TextField, { TextFieldProps } from '@mui/material/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
+type DateFieldType = 'date' | 'datetime-local';
+
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date) => value && value.toISOString().slice(0, -8);
+const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
+  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
+
 const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
   const date = new DateConstructor(timestamp);
   if (date.getFullYear() < 10000) {
@@ -17,7 +21,7 @@ const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
 export type DateFieldProps = FieldProps<
   Date,
   TextFieldProps,
-  { labelProps?: object }
+  { labelProps?: object; type?: DateFieldType }
 >;
 
 function Date({
@@ -35,8 +39,11 @@ function Date({
   readOnly,
   showInlineError,
   value,
+  type,
   ...props
 }: DateFieldProps) {
+  const dateType = type === 'date' ? type : 'datetime-local';
+
   return (
     <TextField
       disabled={disabled}
@@ -54,8 +61,8 @@ function Date({
       }
       placeholder={placeholder}
       ref={inputRef}
-      type="datetime-local"
-      value={dateFormat(value) ?? ''}
+      type={dateType}
+      value={dateFormat(value, type) ?? ''}
       {...filterDOMProps(props)}
     />
   );

--- a/packages/uniforms-semantic/__tests__/DateField.tsx
+++ b/packages/uniforms-semantic/__tests__/DateField.tsx
@@ -1,8 +1,33 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DateField, DateFieldProps } from 'uniforms-semantic';
+import { render } from 'uniforms/__suites__';
 
 import createContext from './_createContext';
 import mount from './_mount';
+
+describe('@RTL - DateField tests', () => {
+  test('<DateField> - handles "date" type correctly', () => {
+    const onChange = jest.fn();
+    const initialDate = new Date(Date.UTC(2020, 0, 1));
+
+    render(
+      <DateField name="x" type="date" placeholder="X" value={initialDate} />,
+      { x: Date },
+      { onChange },
+    );
+
+    const wrapper = screen.getByPlaceholderText('X');
+    // @ts-expect-error Incorrect types, approach taken from docs: https://testing-library.com/docs/example-input-event/
+    expect(wrapper.value).toBe('2020-01-01');
+    userEvent.type(wrapper, '2021-03-03');
+    expect(onChange.mock.calls[1][0]).toBe('x');
+    expect(onChange.mock.calls[1][1].toISOString()).toBe(
+      '2021-03-03T00:00:00.000Z',
+    );
+  });
+});
 
 test('<DateField> - renders an input', () => {
   const element = <DateField name="x" />;

--- a/packages/uniforms-semantic/src/DateField.tsx
+++ b/packages/uniforms-semantic/src/DateField.tsx
@@ -45,11 +45,9 @@ function Date({
   showInlineError,
   value,
   wrapClassName,
-  type,
+  type = 'datetime-local',
   ...props
 }: DateFieldProps) {
-  const dateType = type === 'date' ? type : 'datetime-local';
-
   return (
     <div
       className={classnames(className, { disabled, error, required }, 'field')}
@@ -82,8 +80,8 @@ function Date({
           placeholder={placeholder}
           readOnly={readOnly}
           ref={inputRef}
-          type={dateType}
-          value={dateFormat(value, dateType) ?? ''}
+          type={type}
+          value={dateFormat(value, type) ?? ''}
         />
 
         {(icon || iconLeft) && (

--- a/packages/uniforms-semantic/src/DateField.tsx
+++ b/packages/uniforms-semantic/src/DateField.tsx
@@ -83,7 +83,7 @@ function Date({
           readOnly={readOnly}
           ref={inputRef}
           type={dateType}
-          value={dateFormat(value) ?? ''}
+          value={dateFormat(value, dateType) ?? ''}
         />
 
         {(icon || iconLeft) && (

--- a/packages/uniforms-semantic/src/DateField.tsx
+++ b/packages/uniforms-semantic/src/DateField.tsx
@@ -2,9 +2,12 @@ import classnames from 'classnames';
 import React, { Ref } from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 
+type DateFieldType = 'date' | 'datetime-local';
+
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
+const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
+  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 
 export type DateFieldProps = HTMLFieldProps<
   Date,
@@ -17,7 +20,7 @@ export type DateFieldProps = HTMLFieldProps<
     max?: Date;
     min?: Date;
     wrapClassName?: string;
-    type?: 'date' | 'datetime-local';
+    type?: DateFieldType;
   }
 >;
 

--- a/packages/uniforms-unstyled/__tests__/DateField.tsx
+++ b/packages/uniforms-unstyled/__tests__/DateField.tsx
@@ -1,8 +1,33 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DateField, DateFieldProps } from 'uniforms-unstyled';
+import { render } from 'uniforms/__suites__';
 
 import createContext from './_createContext';
 import mount from './_mount';
+
+describe('@RTL - DateField tests', () => {
+  test('<DateField> - handles "date" type correctly', () => {
+    const onChange = jest.fn();
+    const initialDate = new Date(Date.UTC(2020, 0, 1));
+
+    render(
+      <DateField name="x" type="date" placeholder="X" value={initialDate} />,
+      { x: Date },
+      { onChange },
+    );
+
+    const wrapper = screen.getByPlaceholderText('X');
+    // @ts-expect-error Incorrect types, approach taken from docs: https://testing-library.com/docs/example-input-event/
+    expect(wrapper.value).toBe('2020-01-01');
+    userEvent.type(wrapper, '2021-03-03');
+    expect(onChange.mock.calls[1][0]).toBe('x');
+    expect(onChange.mock.calls[1][1].toISOString()).toBe(
+      '2021-03-03T00:00:00.000Z',
+    );
+  });
+});
 
 test('<DateField> - renders an input', () => {
   const element = <DateField name="x" />;

--- a/packages/uniforms-unstyled/src/DateField.tsx
+++ b/packages/uniforms-unstyled/src/DateField.tsx
@@ -1,9 +1,12 @@
 import React, { Ref } from 'react';
 import { HTMLFieldProps, connectField, filterDOMProps } from 'uniforms';
 
+type DateFieldType = 'date' | 'datetime-local';
+
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date) => value?.toISOString().slice(0, -8);
+const dateFormat = (value?: Date, type: DateFieldType = 'datetime-local') =>
+  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 
 export type DateFieldProps = HTMLFieldProps<
   Date,
@@ -12,7 +15,7 @@ export type DateFieldProps = HTMLFieldProps<
     inputRef?: Ref<HTMLInputElement>;
     max?: Date;
     min?: Date;
-    type?: 'date' | 'datetime-local';
+    type?: DateFieldType;
   }
 >;
 
@@ -55,7 +58,7 @@ function Date({
         readOnly={readOnly}
         ref={inputRef}
         type={dateType}
-        value={dateFormat(value) ?? ''}
+        value={dateFormat(value, type) ?? ''}
       />
     </div>
   );

--- a/packages/uniforms-unstyled/src/DateField.tsx
+++ b/packages/uniforms-unstyled/src/DateField.tsx
@@ -31,11 +31,9 @@ function Date({
   placeholder,
   readOnly,
   value,
-  type,
+  type = 'datetime-local',
   ...props
 }: DateFieldProps) {
-  const dateType = type === 'date' ? type : 'datetime-local';
-
   return (
     <div {...filterDOMProps(props)}>
       {label && <label htmlFor={id}>{label}</label>}
@@ -57,7 +55,7 @@ function Date({
         placeholder={placeholder}
         readOnly={readOnly}
         ref={inputRef}
-        type={dateType}
+        type={type}
         value={dateFormat(value, type) ?? ''}
       />
     </div>


### PR DESCRIPTION
Fixes #1138

Unified the implementation of date type logic across `DateField`s in themes. The only theme that was not adjusted was `antd` due to the fact that this is handled by a separate prop which is `showTime` that is already implemented. `antd` does not accept a `type` prop like the native date input does.

to do:
* [x] Copy the date test to all other themes
* [x] Test manually once more

<details>
<summary>Screenshots</summary>

tested for this playground schema

```
new SimpleSchema2Bridge(
  new SimpleSchema({
      date: {
    type: Date,
    defaultValue: new Date(),
    uniforms: {
      type: 'date',
    },
  },
  date2: {
    type: Date,
    defaultValue: new Date(),
  },
  })
)
```

unstyled

![image](https://user-images.githubusercontent.com/36732892/176910688-e1564f04-4e55-41a9-bfc8-0e9e7fd7b8f1.png)

semantic

![image](https://user-images.githubusercontent.com/36732892/176910727-62843a6b-9425-4b5e-b21b-d27183b4ff8e.png)

mui

![image](https://user-images.githubusercontent.com/36732892/176910764-ad62ce15-1261-4469-b365-d059ae7cd2af.png)

material

![image](https://user-images.githubusercontent.com/36732892/176910801-c0215c38-86b1-4a9d-a487-df52d66e2299.png)


bootstrap5

![image](https://user-images.githubusercontent.com/36732892/176910837-2fff42fc-a77e-464d-854c-4d107e369f07.png)


bootstrap4

![image](https://user-images.githubusercontent.com/36732892/176910879-30eb2abb-2956-41df-8a17-c1e475e6f044.png)


bootstrap3

![image](https://user-images.githubusercontent.com/36732892/176910926-5a6d24dd-5d05-4461-bd38-e75886f4bba8.png)


</details>