### PR TITLE
JSONSchemaBridge: Get errors for fields with dots

### DIFF
--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -388,6 +388,22 @@ describe('JSONSchemaBridge', () => {
         expect(bridge.getError(name, error)).toEqual(error.details[0]);
       });
     });
+
+    it('works with correct error (complex instance paths - dots in names)', () => {
+      const pairs = [
+        ['["path.with.a.dot"]', '/path.with.a.dot'],
+        ['["path.with.a.dot"].another', '/path.with.a.dot/another'],
+        [
+          '["path.with.a.dot"].["another.with.a.dot"]',
+          '/path.with.a.dot/another.with.a.dot',
+        ],
+      ];
+
+      pairs.forEach(([name, instancePath]) => {
+        const error = { details: [{ instancePath }] };
+        expect(bridge.getError(name, error)).toEqual(error.details[0]);
+      });
+    });
   });
 
   describe('#getErrorMessage', () => {

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -391,12 +391,13 @@ describe('JSONSchemaBridge', () => {
 
     it('works with correct error (complex instance paths - dots in names)', () => {
       const pairs = [
-        ['["path.with.a.dot"]', '/path.with.a.dot'],
-        ['["path.with.a.dot"].another', '/path.with.a.dot/another'],
-        [
-          '["path.with.a.dot"].["another.with.a.dot"]',
-          '/path.with.a.dot/another.with.a.dot',
-        ],
+        ['["a.b.c"].["d.e/f"].g', '/a.b.c/d.e~1f/g'],
+        ['a.["b"]', '/a/b'],
+        ['a.["b"].c', '/a/b/c'],
+        ['a.["b.c"]', '/a/b.c'],
+        ['a.["b.c"].d', '/a/b.c/d'],
+        ['["a"].b', '/a/b'],
+        ['["a.b"].c', '/a.b/c'],
       ];
 
       pairs.forEach(([name, instancePath]) => {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -103,7 +103,7 @@ export default class JSONSchemaBridge extends Bridge {
     }
 
     const nameParts = joinName(null, name).map(joinName.unescape);
-    const unescapedName = joinName(...nameParts);
+    const unescapedName = joinName(nameParts);
     const rootName = joinName(nameParts.slice(0, -1));
     const baseName = nameParts[nameParts.length - 1];
     const scopedError = details.find(error => {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -102,13 +102,14 @@ export default class JSONSchemaBridge extends Bridge {
       return null;
     }
 
-    const nameParts = joinName(null, name);
+    const nameParts = joinName(null, name).map(joinName.unescape);
+    const unescapedName = joinName(...nameParts);
     const rootName = joinName(nameParts.slice(0, -1));
     const baseName = nameParts[nameParts.length - 1];
     const scopedError = details.find(error => {
       const path = pathToName(error.instancePath ?? error.dataPath);
       return (
-        name === path ||
+        unescapedName === path ||
         (rootName === path && baseName === error.params.missingProperty)
       );
     });

--- a/reproductions/schema/json-schema.tsx
+++ b/reproductions/schema/json-schema.tsx
@@ -13,66 +13,15 @@ function createValidator(schema: object) {
 }
 
 const schema = {
+  title: 'Address',
   type: 'object',
   properties: {
-    regularRequired: {
-      type: 'string',
-    },
-    'nested.required': {
-      type: 'string',
-    },
-
-    regularMinLength: {
-      type: 'string',
-      minLength: 5,
-      default: 'Horse',
-    },
-    'nested.minLength': {
-      type: 'string',
-      minLength: 5,
-      default: 'Horse',
-    },
-    'nested.array': {
-      type: 'array',
-      minItems: 5,
-      items: {
-        type: 'object',
-        required: ['first.name', 'last.name'],
-        properties: {
-          'first.name': {
-            type: 'string',
-            minLength: 5,
-          },
-          'last.name': {
-            type: 'string',
-            minLength: 5,
-          },
-        },
-      },
-    },
-    'nested.object': {
-      type: 'object',
-      required: ['first.name', 'last.name'],
-      properties: {
-        'first.name': {
-          type: 'string',
-          minLength: 5,
-        },
-        'last.name': {
-          type: 'string',
-          minLength: 5,
-        },
-        'another.nested': {
-          type: 'object',
-          properties: {
-            a: { type: 'string', minLength: 5 },
-            b: { type: 'string', minLength: 5 },
-          },
-        },
-      },
-    },
+    city: { type: 'string' },
+    state: { type: 'string' },
+    street: { type: 'string' },
+    zip: { type: 'string', pattern: '[0-9]{5}' },
   },
-  required: ['nested.required', 'regularRequired'],
+  required: ['street', 'zip', 'state'],
 };
 
 const schemaValidator = createValidator(schema);

--- a/reproductions/schema/json-schema.tsx
+++ b/reproductions/schema/json-schema.tsx
@@ -15,34 +15,64 @@ function createValidator(schema: object) {
 const schema = {
   type: 'object',
   properties: {
-    a: {
-      type: 'number',
-      title: 'a',
-      uniforms: { title: 'Horse' },
-    },
-    b: {
+    regularRequired: {
       type: 'string',
-      uniforms: {
-        placeholder: 'Horse',
-        required: false,
+    },
+    'nested.required': {
+      type: 'string',
+    },
+
+    regularMinLength: {
+      type: 'string',
+      minLength: 5,
+      default: 'Horse',
+    },
+    'nested.minLength': {
+      type: 'string',
+      minLength: 5,
+      default: 'Horse',
+    },
+    'nested.array': {
+      type: 'array',
+      minItems: 5,
+      items: {
+        type: 'object',
+        required: ['first.name', 'last.name'],
+        properties: {
+          'first.name': {
+            type: 'string',
+            minLength: 5,
+          },
+          'last.name': {
+            type: 'string',
+            minLength: 5,
+          },
+        },
       },
     },
-    c: {
-      type: 'string',
-      title: 'Title',
-      uniforms: { label: 'Horse' },
-    },
-    d: { type: 'string' },
-    e: {
-      type: 'string',
-      title: 'Title',
-      uniforms: {
-        label: 'Horse A',
-        placeholder: 'Horse B',
+    'nested.object': {
+      type: 'object',
+      required: ['first.name', 'last.name'],
+      properties: {
+        'first.name': {
+          type: 'string',
+          minLength: 5,
+        },
+        'last.name': {
+          type: 'string',
+          minLength: 5,
+        },
+        'another.nested': {
+          type: 'object',
+          properties: {
+            a: { type: 'string', minLength: 5 },
+            b: { type: 'string', minLength: 5 },
+          },
+        },
       },
     },
   },
-  required: ['b', 'c', 'd', 'e'],
+  required: ['nested.required', 'regularRequired'],
 };
 
 const schemaValidator = createValidator(schema);


### PR DESCRIPTION
This PR closes #1131 by extending behavior of `JSONSchemaBridge.getError` which now correctly returns errors for the fields with dots in their names.

The problem was that `Ajv` provides the `error.instancePath` in a "non-escaped way" for field names with dots.
```js
// Example schema
{
  type: 'object',
  properties: {
    'nested.minLength': {
      type: 'string',
      minLength: 5,
      default: 'Horse',
    },
}
```
Uniforms would escape this field name into `["nested.minLength"]` but the `error.instancePath` would be `/nested.minLength`.

The fix uses `joinName.unescape` to unescape individual parts of the `name` and compare it to the `path` created from `error.instancePath`.