### PR TITLE
Improved documentation for useForm error.

### DIFF
--- a/docs/api-bridges.md
+++ b/docs/api-bridges.md
@@ -168,6 +168,8 @@ If you're using the [`bluebird`](https://www.npmjs.com/package/bluebird) package
 
 > Warning: a promise was rejected with a non-error [object Object]
 
+There could be multiple causes of this error. One of it is not returning a proper error object.
+
 In order to fix it, your `validator` function should return a `Error`-like object instead of an object with a single `details` property. The cleanest would be to create a custom `ValidationError` class:
 
 ```ts
@@ -184,6 +186,10 @@ class ValidationError extends Error {
 // Usage.
 return validator.errors?.length ? new ValidationError(validator.errors) : null;
 ```
+
+Another cause of this error may be two different implementations of the `Promise` object when using an asynchronous validate function.
+Ensure that you are returning the same `Promise` object implementation that Bluebird is expecting.
+The simplest way to do that should be to avoid using the `async` keyword and instead make the function return a `Promise` instead.
 
 See [#1047](https://github.com/vazco/uniforms/discussions/1047) for more details.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -294,3 +294,14 @@ const anyProps: any = {
 }
 <AutoForm {...anyProps} />
 ```
+
+### Why am I getting "useForm must be used within a form" error?
+
+`uniforms` uses a `React.Context` in order to keep the state of the whole form.
+The provider for this context is created by `BaseForm`, and in turn all the other Form components inheriting it.
+
+There are two most common issues causing this problem:
+
+1. The component calling this function does not have a Form component above it anywhere in the component tree. To fix
+   this, wrap this component within a parent Form component (does not have to be direct).
+2. There are multiple versions of `uniforms` installed in your `node_modules`. This usually happens when you have more than one version of the core `uniforms` package installed which can happen when you have a mismatch of versions between any of your `uniforms` related dependencies. Ensure all your versions are matching, clean any `node_modules` directories and reinstall dependencies to resolve this error.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -295,13 +295,21 @@ const anyProps: any = {
 <AutoForm {...anyProps} />
 ```
 
-### Why am I getting "useForm must be used within a form" error?
+### "`useForm` must be used within a form"
 
-`uniforms` uses a `React.Context` in order to keep the state of the whole form.
-The provider for this context is created by `BaseForm`, and in turn all the other Form components inheriting it.
+uniforms uses a `React.Context` in order to keep the state of the whole form.
+The provider for this context is rendered by `BaseForm`, and in turn all the other form components inheriting it.
 
 There are two most common issues causing this problem:
 
 1. The component calling this function does not have a Form component above it anywhere in the component tree. To fix
+
    this, wrap this component within a parent Form component (does not have to be direct).
-2. There are multiple versions of `uniforms` installed in your `node_modules`. This usually happens when you have more than one version of the core `uniforms` package installed which can happen when you have a mismatch of versions between any of your `uniforms` related dependencies. Ensure all your versions are matching, clean any `node_modules` directories and reinstall dependencies to resolve this error.
+
+2. There are multiple versions of `uniforms` installed in your `node_modules`. This usually happens when you have
+
+   more than one version of the core `uniforms` package installed which can happen when you have a mismatch of
+
+   versions between any of your `uniforms` related dependencies. Ensure all your versions are matching,
+
+   clean any `node_modules` directories and reinstall dependencies to resolve this error.

--- a/packages/uniforms/src/useForm.ts
+++ b/packages/uniforms/src/useForm.ts
@@ -14,7 +14,7 @@ Two most common reasons for this error are:
 1. Component calling this function doesn't have a parent Form component in the tree.
 2. A duplicate uniforms dependency is installed in node_modules.
 
-For more info check FAQ: https://uniforms.tools/docs/faq/#why-am-i-getting-useForm-must-be-used-within-a-form-error
+For more info check FAQ: https://uniforms.tools/docs/faq/#useform-must-be-used-within-a-form
   `,
   );
   return context;

--- a/packages/uniforms/src/useForm.ts
+++ b/packages/uniforms/src/useForm.ts
@@ -6,6 +6,16 @@ import { Context } from './types';
 
 export function useForm<Model>(): Context<Model> {
   const context = useContext(contextReference);
-  invariant(context !== null, 'useForm must be used within a form.');
+  invariant(
+    context !== null,
+    `useForm must be used within a form.
+
+Two most common reasons for this error are:
+1. Component calling this function doesn't have a parent Form component in the tree.
+2. A duplicate uniforms dependency is installed in node_modules.
+
+For more info check FAQ: https://uniforms.tools/docs/faq/#why-am-i-getting-useForm-must-be-used-within-a-form-error
+  `,
+  );
   return context;
 }


### PR DESCRIPTION
Extended the current invariant message and added an entry to the FAQ.

* [x] `useForm` hook error documentation
* [x] [bluebird promise error documentation](https://github.com/vazco/uniforms/discussions/1047#discussioncomment-2891337)