### PR TITLE
Support GraphQL Enums and show them as dropdown (continuation)

### DIFF
--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, buildASTSchema, parse } from 'graphql';
+import { buildASTSchema, GraphQLString, parse } from 'graphql';
 import { GraphQLBridge } from 'uniforms-bridge-graphql';
 
 describe('GraphQLBridge', () => {
@@ -7,6 +7,7 @@ describe('GraphQLBridge', () => {
 
         enum AccessLevel {
             Admin
+            User
         }
 
         input Author {
@@ -461,6 +462,20 @@ describe('GraphQLBridge', () => {
       expect(bridgeI.getProps('category', { x: 1, y: 1 })).toEqual({
         label: 'Category',
         required: true,
+      });
+    });
+
+    describe('when enum', () => {
+      it('should return possibleValues', () => {
+        expect(bridgeI.getProps('author.level').allowedValues).toEqual([
+          'Admin',
+          'User',
+        ]);
+      });
+
+      it('should transform the value to the name', () => {
+        const transform = bridgeI.getProps('author.level').transform;
+        expect(transform('Admin')).toBe('Admin');
       });
     });
   });

--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -477,6 +477,26 @@ describe('GraphQLBridge', () => {
         const transform = bridgeI.getProps('author.level').transform;
         expect(transform('Admin')).toBe('Admin');
       });
+
+      it('should prefer options over enum', () => {
+        const bridge = new GraphQLBridge(
+          astI.getType('Post')!,
+          schemaValidator,
+          {
+            ...schemaData,
+            'author.level': {
+              options: [
+                { label: 'A', value: 'a' },
+                { label: 'B', value: 'b' },
+              ],
+            },
+          },
+        );
+        const { allowedValues, transform } = bridge.getProps('author.level');
+        expect(allowedValues).toEqual(['a', 'b']);
+        expect(transform('a')).toEqual('A');
+        expect(transform('b')).toEqual('B');
+      });
     });
   });
 

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -134,9 +134,7 @@ export default class GraphQLBridge extends Bridge {
         props.allowedValues = Object.keys(options);
         props.transform = (value: string) => options[value];
       }
-    }
-
-    if (isEnumType(fieldType)) {
+    } else if (isEnumType(fieldType)) {
       const values = fieldType.getValues();
       props.allowedValues = values.map(option => option.value);
       props.transform = (value: unknown) =>

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -1,7 +1,8 @@
 import {
+  getNullableType,
   GraphQLInputField,
   GraphQLType,
-  getNullableType,
+  isEnumType,
   isInputObjectType,
   isListType,
   isNonNullType,
@@ -133,6 +134,13 @@ export default class GraphQLBridge extends Bridge {
         props.allowedValues = Object.keys(options);
         props.transform = (value: string) => options[value];
       }
+    }
+
+    if (isEnumType(fieldType)) {
+      const values = fieldType.getValues();
+      props.allowedValues = values.map(option => option.value);
+      props.transform = (value: unknown) =>
+        values.find(searchValue => searchValue.value === value)!.name;
     }
 
     return props;


### PR DESCRIPTION
This PR continues the work of #1135 (thanks @simonhoss) by adding priority to the `options` and using enum values only as a last resort.