### PR TITLE
Remove autoField prop from QuickForm and AutoForm

### DIFF
--- a/docs/api-fields.md
+++ b/docs/api-fields.md
@@ -57,19 +57,17 @@ import { AutoField } from 'uniforms-unstyled';
 `AutoFields` is basically a set of rendered `AutoField`s.
 By default, the rendered fields will be `AutoField` in a chosen theme.
 However, you can replace the standard `AutoField` with [`AutoField.componentDetectorContext`](/docs/uth-autofield-algorithm#overriding-autofield).
-There is also an `autoField` prop, but [it's deprecated](https://github.com/vazco/uniforms/issues/980) and will be removed in a future release.
 
 The `element` property defines a wrapping component.
 E.g. you want to group your fields inside a section, just do `element="section"`. The default one is `div`.
 
 ##### Props:
 
-|     Name     |       Default        |                                        Description                                         |
-| :----------: | :------------------: | :----------------------------------------------------------------------------------------: |
-| `autoField`  | Standard `AutoField` | `AutoField` component to render (see [#980](https://github.com/vazco/uniforms/issues/980)) |
-|  `element`   |        `div`         |                                       Fields wrapper                                       |
-|   `fields`   |  All schema fields   |                                  List of fields to render                                  |
-| `omitFields` |         `[]`         |                                   List of fields to omit                                   |
+|     Name     |      Default      |       Description        |
+| :----------: | :---------------: | :----------------------: |
+|  `element`   |       `div`       |      Fields wrapper      |
+|   `fields`   | All schema fields | List of fields to render |
+| `omitFields` |       `[]`        |  List of fields to omit  |
 
 ##### Props usage:
 
@@ -77,7 +75,6 @@ E.g. you want to group your fields inside a section, just do `element="section"`
 import { AutoFields } from 'uniforms-unstyled';
 
 <AutoFields
-  autoField={MyAutoField}
   element="section"
   fields={['fieldA', 'fieldB']}
   omitFields={['fieldA', 'fieldB']}

--- a/docs/api-forms.md
+++ b/docs/api-forms.md
@@ -121,11 +121,10 @@ You can customize which `AutoField` should be used with [`AutoField.componentDet
 
 ##### Props:
 
-|     Name      |                                        Description                                         |
-| :-----------: | :----------------------------------------------------------------------------------------: |
-|  `autoField`  | Custom `AutoField` (deprecated, see [#980](https://github.com/vazco/uniforms/issues/980)). |
-| `errorsField` | Custom `ErrorsField`. It should be anything that will pass through `React.createElement`.  |
-| `submitField` | Custom `SubmitField`. It should be anything that will pass through `React.createElement`.  |
+|     Name      |                                        Description                                        |
+| :-----------: | :---------------------------------------------------------------------------------------: |
+| `errorsField` | Custom `ErrorsField`. It should be anything that will pass through `React.createElement`. |
+| `submitField` | Custom `SubmitField`. It should be anything that will pass through `React.createElement`. |
 
 **Note:** All `BaseForm` props are also accepted and all methods are available.
 
@@ -134,11 +133,7 @@ You can customize which `AutoField` should be used with [`AutoField.componentDet
 ```tsx
 import { QuickForm } from 'uniforms'; // Or from the theme package.
 
-<QuickForm
-  autoField={CustomAutoField}
-  errorsField={CustomErrorsField}
-  submitField={CustomSubmitField}
-/>;
+<QuickForm errorsField={CustomErrorsField} submitField={CustomSubmitField} />;
 ```
 
 ### `BaseForm`

--- a/docs/examples-custom-fields.mdx
+++ b/docs/examples-custom-fields.mdx
@@ -41,8 +41,13 @@ const CustomAutoField = connectField(CustomAuto, {
   initialValue: false,
 });
 
-// Deprecated: You can also tell your `AutoForm`/`QuickForm`/`ValidatedQuickForm` to use it.
-<AutoForm {...props} autoField={CustomAutoField} />;
+const CustomAutoFieldDetector = () => {
+  return CustomAutoField;
+};
+
+<AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+  <Application />
+</AutoField.componentDetectorContext.Provider>;
 ```
 
 ### `CycleField`

--- a/docs/migrating-3-to-4.md
+++ b/docs/migrating-3-to-4.md
@@ -7,4 +7,4 @@ This guide is designed to help you through the migration. If you went through it
 
 ## Breaking API changes
 
-- Removed `autoField` prop from `QuickForm` and `AutoForm`. Use [`AutoField.componentDetectorContext.Provider`](/docs/uth-autofield-algorithm/#overriding-autofield) instead.
+- Removed the `autoField` prop from `QuickForm`, `AutoForm`, and `AutoFields` components in all themes. Use [`AutoField.componentDetectorContext.Provider`](/docs/uth-autofield-algorithm/#overriding-autofield) instead.

--- a/docs/migrating-3-to-4.md
+++ b/docs/migrating-3-to-4.md
@@ -6,3 +6,5 @@ title: Migrating v3 to v4
 This guide is designed to help you through the migration. If you went through it and encountered any problems - do let us know. For more information on _why_ certain changes were made, see the [`CHANGELOG.md`](https://github.com/vazco/uniforms/blob/master/CHANGELOG.md). When migrating to v4, use the newest version. Gradual updates will take more time and won't ease this process.
 
 ## Breaking API changes
+
+- Removed `autoField` prop from `QuickForm` and `AutoForm`. Use [`AutoField.componentDetectorContext.Provider`](/docs/uth-autofield-algorithm/#overriding-autofield) instead.

--- a/docs/uth-autofield-algorithm.md
+++ b/docs/uth-autofield-algorithm.md
@@ -42,8 +42,6 @@ const AutoField = createAutoField(props => {
 
 ## Overriding `AutoField`
 
-While specifying the `autoField` prop on your `QuickForm` or `AutoForm` components may cover a lot of cases, some fields - `ListField` and `NestField` - use `AutoField` directly. That means there's no easy way to let them know that you have a custom component defined.
-
 To make it possible, all `AutoFields` created with the `createAutoField` are configurable. To adjust the components, use the React context available in `AutoField.componentDetectorContext`. You can use it as often as needed - in most apps once will be enough. Example:
 
 ```tsx

--- a/packages/uniforms-antd/__tests__/AutoFields.tsx
+++ b/packages/uniforms-antd/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-antd/src/AutoFields.tsx
+++ b/packages/uniforms-antd/src/AutoFields.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
@@ -12,7 +11,6 @@ export type AutoFieldsProps = {
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -28,7 +26,7 @@ export default function AutoFields({
       .filter(field => !omitFields.includes(field))
       .map(field =>
         createElement(
-          autoField,
+          AutoField,
           Object.assign(
             { key: field, name: field },
             showInlineError === undefined ? null : { showInlineError },

--- a/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-bootstrap3/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap3/src/AutoFields.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
@@ -12,7 +11,6 @@ export type AutoFieldsProps = {
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -28,7 +26,7 @@ export default function AutoFields({
       .filter(field => !omitFields.includes(field))
       .map(field =>
         createElement(
-          autoField,
+          AutoField,
           Object.assign(
             { key: field, name: field },
             showInlineError === undefined ? null : { showInlineError },

--- a/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-bootstrap4/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap4/src/AutoFields.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
@@ -12,7 +11,6 @@ export type AutoFieldsProps = {
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -28,7 +26,7 @@ export default function AutoFields({
       .filter(field => !omitFields.includes(field))
       .map(field =>
         createElement(
-          autoField,
+          AutoField,
           Object.assign(
             { key: field, name: field },
             showInlineError === undefined ? null : { showInlineError },

--- a/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-bootstrap5/src/AutoFields.tsx
+++ b/packages/uniforms-bootstrap5/src/AutoFields.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
@@ -12,7 +11,6 @@ export type AutoFieldsProps = {
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -28,7 +26,7 @@ export default function AutoFields({
       .filter(field => !omitFields.includes(field))
       .map(field =>
         createElement(
-          autoField,
+          AutoField,
           Object.assign(
             { key: field, name: field },
             showInlineError === undefined ? null : { showInlineError },

--- a/packages/uniforms-material/__tests__/AutoFields.tsx
+++ b/packages/uniforms-material/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-material/src/AutoFields.tsx
+++ b/packages/uniforms-material/src/AutoFields.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
@@ -12,7 +11,6 @@ export type AutoFieldsProps = {
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -28,7 +26,7 @@ export default function AutoFields({
       .filter(field => !omitFields.includes(field))
       .map(field =>
         createElement(
-          autoField,
+          AutoField,
           Object.assign(
             { key: field, name: field },
             showInlineError === undefined ? null : { showInlineError },

--- a/packages/uniforms-mui/__tests__/AutoFields.tsx
+++ b/packages/uniforms-mui/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-mui/src/AutoFields.tsx
+++ b/packages/uniforms-mui/src/AutoFields.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
@@ -12,7 +11,6 @@ export type AutoFieldsProps = {
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -28,7 +26,7 @@ export default function AutoFields({
       .filter(field => !omitFields.includes(field))
       .map(field =>
         createElement(
-          autoField,
+          AutoField,
           Object.assign(
             { key: field, name: field },
             showInlineError === undefined ? null : { showInlineError },

--- a/packages/uniforms-semantic/__tests__/AutoFields.tsx
+++ b/packages/uniforms-semantic/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-semantic/src/AutoFields.tsx
+++ b/packages/uniforms-semantic/src/AutoFields.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
@@ -12,7 +11,6 @@ export type AutoFieldsProps = {
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -28,7 +26,7 @@ export default function AutoFields({
       .filter(field => !omitFields.includes(field))
       .map(field =>
         createElement(
-          autoField,
+          AutoField,
           Object.assign(
             { key: field, name: field },
             showInlineError === undefined ? null : { showInlineError },

--- a/packages/uniforms-unstyled/__tests__/AutoFields.tsx
+++ b/packages/uniforms-unstyled/__tests__/AutoFields.tsx
@@ -57,22 +57,6 @@ test('<AutoFields> - does not render ommited fields', () => {
   );
 });
 
-test('<AutoFields> - works with custom component', () => {
-  const Component = jest.fn(() => null);
-
-  const element = <AutoFields autoField={Component} />;
-  mount(
-    element,
-    createContext({
-      x: { type: String },
-      y: { type: String },
-      z: { type: String },
-    }),
-  );
-
-  expect(Component).toHaveBeenCalledTimes(3);
-});
-
 test('<AutoFields> - wraps fields in specified element', () => {
   const element = <AutoFields element="section" />;
   const wrapper = mount(

--- a/packages/uniforms-unstyled/src/AutoFields.tsx
+++ b/packages/uniforms-unstyled/src/AutoFields.tsx
@@ -4,14 +4,12 @@ import { useForm } from 'uniforms';
 import AutoField from './AutoField';
 
 export type AutoFieldsProps = {
-  autoField?: ComponentType<{ name: string }>;
   element?: ComponentType | string;
   fields?: string[];
   omitFields?: string[];
 };
 
 export default function AutoFields({
-  autoField = AutoField,
   element = 'div',
   fields,
   omitFields = [],
@@ -24,6 +22,6 @@ export default function AutoFields({
     props,
     (fields ?? schema.getSubfields())
       .filter(field => !omitFields.includes(field))
-      .map(field => createElement(autoField, { key: field, name: field })),
+      .map(field => createElement(AutoField, { key: field, name: field })),
   );
 }

--- a/packages/uniforms/__tests__/AutoForm.tsx
+++ b/packages/uniforms/__tests__/AutoForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SimpleSchema from 'simpl-schema';
-import { AutoForm, connectField } from 'uniforms';
+import { AutoForm } from 'uniforms';
 import { SimpleSchema2Bridge } from 'uniforms-bridge-simple-schema-2';
 
 import mount from './_mount';
@@ -87,25 +87,6 @@ describe('AutoForm', () => {
   });
 
   describe('when rendered', () => {
-    it('calls `onChange` before render', () => {
-      const field = () => null;
-      const Field = connectField(field);
-
-      // FIXME: AutoForm is not a valid Component.
-      mount<AutoForm | any>(
-        <AutoForm
-          autoField={Field}
-          model={model}
-          onChange={onChange}
-          schema={schema}
-        />,
-      );
-
-      expect(onChange).toHaveBeenCalledTimes(2);
-      expect(onChange.mock.calls[0]).toEqual(expect.arrayContaining(['b', '']));
-      expect(onChange.mock.calls[1]).toEqual(expect.arrayContaining(['c', '']));
-    });
-
     it('skips `onSubmit` until rendered (`autosave` = true)', async () => {
       // FIXME: AutoForm is not a valid Component.
       const wrapper = mount<AutoForm | any>(

--- a/packages/uniforms/__tests__/QuickForm.tsx
+++ b/packages/uniforms/__tests__/QuickForm.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import SimpleSchema from 'simpl-schema';
 import { QuickForm } from 'uniforms';
 import { SimpleSchema2Bridge } from 'uniforms-bridge-simple-schema-2';
@@ -45,17 +45,6 @@ describe('QuickForm', () => {
   });
 
   describe('when rendered with custom fields in `props`', () => {
-    it('renders `AutoField` for each field', () => {
-      const wrapper = mount<TestForm>(
-        <TestForm
-          schema={schema}
-          autoField={() => <i className="autoOverride" />}
-        />,
-      );
-
-      expect(wrapper.find('.autoOverride').length).toBeGreaterThan(0);
-    });
-
     it('renders `ErrorsField`', () => {
       const wrapper = mount<TestForm>(
         <TestForm
@@ -76,26 +65,6 @@ describe('QuickForm', () => {
       );
 
       expect(wrapper.find('.submitOverride').length).toBeGreaterThan(0);
-    });
-
-    it('works with elements', () => {
-      class Code extends Component<{ name: string }> {
-        render = () => <code />;
-      }
-
-      const wrapper = mount<TestForm>(
-        <TestForm schema={schema} autoField={Code} />,
-      );
-
-      expect(wrapper.find('code').length).toBeGreaterThan(0);
-    });
-
-    it('works with functions', () => {
-      const wrapper = mount<TestForm>(
-        <TestForm schema={schema} autoField={() => <code />} />,
-      );
-
-      expect(wrapper.find('code').length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/uniforms/src/QuickForm.tsx
+++ b/packages/uniforms/src/QuickForm.tsx
@@ -3,10 +3,6 @@ import React, { ComponentType } from 'react';
 import { BaseForm, BaseFormProps, BaseFormState } from './BaseForm';
 
 export type QuickFormProps<Model> = BaseFormProps<Model> & {
-  /**
-   * @deprecated
-   */
-  autoField?: ComponentType<{ name: string }>;
   errorsField?: ComponentType;
   submitField?: ComponentType;
 };
@@ -26,12 +22,12 @@ export function Quick<Base extends typeof BaseForm>(Base: Base) {
     getNativeFormProps() {
       const _props = super.getNativeFormProps();
       const {
-        autoField: AutoField = this.getAutoField(),
         errorsField: ErrorsField = this.getErrorsField(),
         submitField: SubmitField = this.getSubmitField(),
         ...props
-      }: typeof _props &
-        Pick<Props, 'autoField' | 'errorsField' | 'submitField'> = _props;
+      }: typeof _props & Pick<Props, 'errorsField' | 'submitField'> = _props;
+
+      const AutoField = this.getAutoField();
 
       if (!props.children) {
         props.children = this.getContextSchema()


### PR DESCRIPTION
In this PR the `autoField` prop is removed from `QuickForm` and `AutoForm`.

Closes #980.