### PR TITLE
Move schema component to defaultComponentDetector

### DIFF
--- a/docs/migrating-3-to-4.md
+++ b/docs/migrating-3-to-4.md
@@ -7,4 +7,4 @@ This guide is designed to help you through the migration. If you went through it
 
 ## Breaking API changes
 
-- `componentDetector` in `AutoField`s now always takes precedence over `component` property on a schema. This may make your `AutoField` render a different component when you were using both previously. If that's the case, Move your schema's `component` definition to a [`AutoField.componentDetectorContext.Provider`](/docs/uth-autofield-algorithm/#overriding-autofield) instead.
+- `componentDetector` in `AutoField`s now always takes precedence over `component` property on a schema. This may make your `AutoField` render a different component when you were using both previously. If that's the case, move your schema's `component` definition to a [`AutoField.componentDetectorContext.Provider`](/docs/uth-autofield-algorithm/#overriding-autofield) instead.

--- a/docs/migrating-3-to-4.md
+++ b/docs/migrating-3-to-4.md
@@ -6,3 +6,5 @@ title: Migrating v3 to v4
 This guide is designed to help you through the migration. If you went through it and encountered any problems - do let us know. For more information on _why_ certain changes were made, see the [`CHANGELOG.md`](https://github.com/vazco/uniforms/blob/master/CHANGELOG.md). When migrating to v4, use the newest version. Gradual updates will take more time and won't ease this process.
 
 ## Breaking API changes
+
+- `componentDetector` in `AutoField`s now always takes precedence over `component` property on a schema. This may make your `AutoField` render a different component when you were using both previously. If that's the case, Move your schema's `component` definition to a [`AutoField.componentDetectorContext.Provider`](/docs/uth-autofield-algorithm/#overriding-autofield) instead.

--- a/packages/uniforms-antd/src/AutoField.tsx
+++ b/packages/uniforms-antd/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms-bootstrap3/src/AutoField.tsx
+++ b/packages/uniforms-bootstrap3/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms-bootstrap4/src/AutoField.tsx
+++ b/packages/uniforms-bootstrap4/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms-bootstrap5/src/AutoField.tsx
+++ b/packages/uniforms-bootstrap5/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms-material/src/AutoField.tsx
+++ b/packages/uniforms-material/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms-mui/src/AutoField.tsx
+++ b/packages/uniforms-mui/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms-semantic/src/AutoField.tsx
+++ b/packages/uniforms-semantic/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms-unstyled/src/AutoField.tsx
+++ b/packages/uniforms-unstyled/src/AutoField.tsx
@@ -12,6 +12,10 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const AutoField = createAutoField(props => {
+  if (props.component) {
+    return props.component;
+  }
+
   if (props.allowedValues) {
     return props.checkboxes && props.fieldType !== Array
       ? RadioField

--- a/packages/uniforms/src/createAutoField.tsx
+++ b/packages/uniforms/src/createAutoField.tsx
@@ -32,7 +32,7 @@ export function createAutoField(defaultComponentDetector: ComponentDetector) {
   function AutoField(rawProps: AutoFieldProps): ReactElement {
     const [props, uniforms] = useField(rawProps.name, rawProps);
     const componentDetector = useContext(context);
-    const component = props.component ?? componentDetector(props, uniforms);
+    const component = componentDetector(props, uniforms);
 
     invariant(component, 'AutoField received no component for: %s', props.name);
 


### PR DESCRIPTION
In this PR the component supplied by a schema is now moved to the `defaultComponentDetector` for each theme for the `AutoField`.

Closes #1114
