### PR TITLE
Added Zod integration (closes #1159)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,7 @@
   - 'packages/uniforms-bridge-json-schema/**/*'
   - 'packages/uniforms-bridge-simple-schema-2/**/*'
   - 'packages/uniforms-bridge-simple-schema/**/*'
+  - 'packages/uniforms-bridge-zod/**/*'
 'Area: Core':
   - 'packages/uniforms/**/*'
 'Area: Docs':
@@ -48,6 +49,8 @@
   - 'packages/uniforms-bridge-simple-schema/**/*'
 'Bridge: SimpleSchema (v2)':
   - 'packages/uniforms-bridge-simple-schema-2/**/*'
+'Bridge: Zod':
+  - 'packages/uniforms-bridge-zod/**/*'
 'Theme: AntD':
   - 'packages/uniforms-antd/**/*'
 'Theme: Bootstrap 3':

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,8 @@
         "tslib": "^2.2.0",
         "typescript": "4.2.4",
         "universal-fetch": "1.0.0",
-        "warning": "^4.0.0"
+        "warning": "^4.0.0",
+        "zod": "^3.0.0"
       },
       "engines": {
         "npm": ">=7.0.0"
@@ -26494,6 +26495,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
@@ -46035,6 +46044,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zod": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "tslib": "^2.2.0",
     "typescript": "4.2.4",
     "universal-fetch": "1.0.0",
-    "warning": "^4.0.0"
+    "warning": "^4.0.0",
+    "zod": "^3.0.0"
   },
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/uniforms-bridge-zod/README.md
+++ b/packages/uniforms-bridge-zod/README.md
@@ -1,0 +1,11 @@
+# uniforms-bridge-zod
+
+> Zod bridge for `uniforms`.
+
+## Install
+
+```sh
+$ npm install uniforms-bridge-zod
+```
+
+For more in depth documentation see [uniforms.tools](https://uniforms.tools).

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -154,6 +154,50 @@ describe('ZodBridge', () => {
     });
   });
 
+  describe('#getInitialValue', () => {
+    it('works with array', () => {
+      const schema = object({ a: array(array(string())) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual([]);
+    });
+
+    it('works with array (min length)', () => {
+      const schema = object({ a: array(array(string()).min(1)).min(2) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual([[], []]);
+    });
+
+    it('works with boolean', () => {
+      const schema = object({ a: boolean() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual(undefined);
+    });
+
+    it('works with date', () => {
+      const schema = object({ a: date() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual(undefined);
+    });
+
+    it('works with number', () => {
+      const schema = object({ a: number() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual(undefined);
+    });
+
+    it('works with object', () => {
+      const schema = object({ a: object({ b: object({ c: string() }) }) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual({ b: {} });
+    });
+
+    it('works with string', () => {
+      const schema = object({ a: string() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual(undefined);
+    });
+  });
+
   describe('#getSubfields', () => {
     it('works with empty objects', () => {
       const schema = object({});

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -1,14 +1,33 @@
 import { ZodBridge } from 'uniforms-bridge-zod';
 import {
+  any,
   array,
+  bigint,
   boolean,
   date,
+  discriminatedUnion,
   enum as enum_,
+  function as function_,
+  instanceof as instanceof_,
+  intersection,
+  lazy,
+  literal,
+  map,
+  nan,
   nativeEnum,
+  never,
+  null as null_,
   number,
   object,
   optional,
+  promise,
+  record,
+  set,
   string,
+  tuple,
+  undefined as undefined_,
+  union,
+  unknown,
 } from 'zod';
 
 describe('ZodBridge', () => {
@@ -599,10 +618,43 @@ describe('ZodBridge', () => {
       const bridge = new ZodBridge(schema);
       expect(bridge.getType('a')).toBe(String);
     });
+
+    it.each([
+      ['any', any()],
+      ['bigint', bigint()],
+      [
+        'discriminatedUnion',
+        discriminatedUnion('type', [
+          object({ type: literal('a') }),
+          object({ type: literal('b') }),
+        ]),
+      ],
+      ['function', function_()],
+      ['intersection', intersection(number(), string())],
+      ['instanceof', instanceof_(Date)],
+      ['lazy', lazy(() => string())],
+      ['literal', literal('a')],
+      ['map', map(string(), string())],
+      ['nan', nan()],
+      ['never', never()],
+      ['null', null_()],
+      ['promise', promise(string())],
+      ['record', record(string())],
+      ['set', set(string())],
+      ['tuple', tuple([])],
+      ['undefined', undefined_()],
+      ['union', union([number(), string()])],
+      ['unknown', unknown()],
+    ])('throws on %s', (type, fieldSchema) => {
+      const schema = object({ a: fieldSchema });
+      const bridge = new ZodBridge(schema);
+      const error = 'Field "a" has an unknown type';
+      expect(() => bridge.getType('a')).toThrowError(error);
+    });
   });
 
   describe('#getValidator', () => {
-    it('is a function', () => {
+    it('return a function', () => {
       const schema = object({});
       const bridge = new ZodBridge(schema);
       const validator = bridge.getValidator();

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -198,6 +198,48 @@ describe('ZodBridge', () => {
     });
   });
 
+  describe('#getProps', () => {
+    it('works with array', () => {
+      const schema = object({ a: array(array(string())) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+      expect(bridge.getProps('a.0')).toEqual({ label: '0', required: true });
+      expect(bridge.getProps('a.0.0')).toEqual({ label: '0', required: true });
+    });
+
+    it('works with boolean', () => {
+      const schema = object({ a: boolean() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+    });
+
+    it('works with date', () => {
+      const schema = object({ a: date() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+    });
+
+    it('works with number', () => {
+      const schema = object({ a: number() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+    });
+
+    it('works with object', () => {
+      const schema = object({ a: object({ b: object({ c: string() }) }) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+      expect(bridge.getProps('a.b')).toEqual({ label: 'B', required: true });
+      expect(bridge.getProps('a.b.c')).toEqual({ label: 'C', required: true });
+    });
+
+    it('works with string', () => {
+      const schema = object({ a: string() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+    });
+  });
+
   describe('#getSubfields', () => {
     it('works with empty objects', () => {
       const schema = object({});

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -7,6 +7,7 @@ import {
   nativeEnum,
   number,
   object,
+  optional,
   string,
 } from 'zod';
 
@@ -161,6 +162,13 @@ describe('ZodBridge', () => {
       expect(bridge.getField('a.b')).toBe(schema.shape.a.shape.b);
       expect(bridge.getField('a.b.c')).toBe(schema.shape.a.shape.b.shape.c);
     });
+
+    it('works with optional', () => {
+      const schema = object({ a: optional(object({ b: string() })) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getField('a')).toBe(schema.shape.a);
+      expect(bridge.getField('a.b')).toBe(schema.shape.a.unwrap().shape.b);
+    });
   });
 
   describe('#getInitialValue', () => {
@@ -240,6 +248,12 @@ describe('ZodBridge', () => {
       const schema = object({ a: object({ b: object({ c: string() }) }) });
       const bridge = new ZodBridge(schema);
       expect(bridge.getInitialValue('a')).toEqual({ b: {} });
+    });
+
+    it('works with optional', () => {
+      const schema = object({ a: optional(string()) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual(undefined);
     });
 
     it('works with string', () => {
@@ -342,6 +356,12 @@ describe('ZodBridge', () => {
       expect(bridge.getProps('a.b.c')).toEqual({ label: 'C', required: true });
     });
 
+    it('works with optional', () => {
+      const schema = object({ a: optional(string()) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: false });
+    });
+
     it('works with string', () => {
       const schema = object({ a: string() });
       const bridge = new ZodBridge(schema);
@@ -383,6 +403,13 @@ describe('ZodBridge', () => {
       expect(bridge.getSubfields('a')).toEqual(['b']);
       expect(bridge.getSubfields('a.b')).toEqual(['c']);
       expect(bridge.getSubfields('a.b.c')).toEqual([]);
+    });
+
+    it('works with optional', () => {
+      const schema = object({ a: optional(object({ b: string() })) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getSubfields('a')).toEqual(['b']);
+      expect(bridge.getSubfields('a.b')).toEqual([]);
     });
   });
 
@@ -457,6 +484,12 @@ describe('ZodBridge', () => {
       const schema = object({ a: object({ b: object({ c: string() }) }) });
       const bridge = new ZodBridge(schema);
       expect(bridge.getType('a')).toBe(Object);
+    });
+
+    it('works with optional', () => {
+      const schema = object({ a: optional(string()) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(String);
     });
 
     it('works with string', () => {

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -1,7 +1,38 @@
 import { ZodBridge } from 'uniforms-bridge-zod';
-import { number, object, string } from 'zod';
+import { array, number, object, string } from 'zod';
 
 describe('ZodBridge', () => {
+  describe('#getField', () => {
+    it('works with root schema', () => {
+      const schema = object({});
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getField('')).toBe(schema);
+    });
+
+    it('works with simple types', () => {
+      const schema = object({ a: string(), b: number() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getField('a')).toBe(schema.shape.a);
+      expect(bridge.getField('b')).toBe(schema.shape.b);
+    });
+
+    it('works with arrays', () => {
+      const schema = object({ a: array(array(string())) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getField('a')).toEqual(schema.shape.a);
+      expect(bridge.getField('a.$')).toEqual(schema.shape.a.element);
+      expect(bridge.getField('a.$.$')).toEqual(schema.shape.a.element.element);
+    });
+
+    it('works with nested objects', () => {
+      const schema = object({ a: object({ b: object({ c: string() }) }) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getField('a')).toBe(schema.shape.a);
+      expect(bridge.getField('a.b')).toBe(schema.shape.a.shape.b);
+      expect(bridge.getField('a.b.c')).toBe(schema.shape.a.shape.b.shape.c);
+    });
+  });
+
   describe('#getSubfields', () => {
     it('works with empty objects', () => {
       const schema = object({});
@@ -13,6 +44,29 @@ describe('ZodBridge', () => {
       const schema = object({ a: string(), b: number() });
       const bridge = new ZodBridge(schema);
       expect(bridge.getSubfields()).toEqual(['a', 'b']);
+    });
+
+    it('works with simple types', () => {
+      const schema = object({ a: string(), b: number() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getSubfields('a')).toEqual([]);
+      expect(bridge.getSubfields('b')).toEqual([]);
+    });
+
+    it('works with arrays', () => {
+      const schema = object({ a: array(array(string())) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getSubfields('a')).toEqual(['$']);
+      expect(bridge.getSubfields('a.$')).toEqual(['$']);
+      expect(bridge.getSubfields('a.$.$')).toEqual([]);
+    });
+
+    it('works with nested objects', () => {
+      const schema = object({ a: object({ b: object({ c: string() }) }) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getSubfields('a')).toEqual(['b']);
+      expect(bridge.getSubfields('a.b')).toEqual(['c']);
+      expect(bridge.getSubfields('a.b.c')).toEqual([]);
     });
   });
 });

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -1,5 +1,14 @@
 import { ZodBridge } from 'uniforms-bridge-zod';
-import { array, boolean, date, number, object, string } from 'zod';
+import {
+  array,
+  boolean,
+  date,
+  enum as enum_,
+  nativeEnum,
+  number,
+  object,
+  string,
+} from 'zod';
 
 describe('ZodBridge', () => {
   describe('#getError', () => {
@@ -179,6 +188,48 @@ describe('ZodBridge', () => {
       expect(bridge.getInitialValue('a')).toEqual(undefined);
     });
 
+    it('works with enum (array)', () => {
+      const schema = object({ a: enum_(['x', 'y', 'z']) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual('x');
+    });
+
+    it('works with enum (native, numbers)', () => {
+      enum Test {
+        x,
+        y,
+        z = 'a',
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual('x');
+    });
+
+    it('works with enum (native, numbers)', () => {
+      enum Test {
+        x,
+        y,
+        z,
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual('x');
+    });
+
+    it('works with enum (native, string)', () => {
+      enum Test {
+        x = 'x',
+        y = 'y',
+        z = 'z',
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual('x');
+    });
+
     it('works with number', () => {
       const schema = object({ a: number() });
       const bridge = new ZodBridge(schema);
@@ -217,6 +268,64 @@ describe('ZodBridge', () => {
       const schema = object({ a: date() });
       const bridge = new ZodBridge(schema);
       expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+    });
+
+    it('works with enum (array)', () => {
+      const schema = object({ a: enum_(['x', 'y', 'z']) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        allowedValues: ['x', 'y', 'z'],
+        label: 'A',
+        required: true,
+      });
+    });
+
+    it('works with enum (native, mixed)', () => {
+      enum Test {
+        x,
+        y,
+        z = 'a',
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        allowedValues: ['x', 'y', 'a'],
+        label: 'A',
+        required: true,
+      });
+    });
+
+    it('works with enum (native, number)', () => {
+      enum Test {
+        x,
+        y,
+        z,
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        allowedValues: ['x', 'y', 'z'],
+        label: 'A',
+        required: true,
+      });
+    });
+
+    it('works with enum (native, string)', () => {
+      enum Test {
+        x = 'x',
+        y = 'y',
+        z = 'z',
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        allowedValues: ['x', 'y', 'z'],
+        label: 'A',
+        required: true,
+      });
     });
 
     it('works with number', () => {
@@ -294,6 +403,48 @@ describe('ZodBridge', () => {
       const schema = object({ a: date() });
       const bridge = new ZodBridge(schema);
       expect(bridge.getType('a')).toBe(Date);
+    });
+
+    it('works with enum (array)', () => {
+      const schema = object({ a: enum_(['x', 'y', 'z']) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(String);
+    });
+
+    it('works with enum (native, mixed)', () => {
+      enum Test {
+        x,
+        y,
+        z = 'a',
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(String);
+    });
+
+    it('works with enum (native, number)', () => {
+      enum Test {
+        x,
+        y,
+        z,
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(String);
+    });
+
+    it('works with enum (native, string)', () => {
+      enum Test {
+        x = 'x',
+        y = 'y',
+        z = 'z',
+      }
+
+      const schema = object({ a: nativeEnum(Test) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(String);
     });
 
     it('works with number', () => {

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -163,6 +163,15 @@ describe('ZodBridge', () => {
       expect(bridge.getField('a.b.c')).toBe(schema.shape.a.shape.b.shape.c);
     });
 
+    it('works with default', () => {
+      const schema = object({ a: object({ b: string() }).default({ b: 'x' }) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getField('a')).toBe(schema.shape.a);
+      expect(bridge.getField('a.b')).toBe(
+        schema.shape.a.removeDefault().shape.b,
+      );
+    });
+
     it('works with optional', () => {
       const schema = object({ a: optional(object({ b: string() })) });
       const bridge = new ZodBridge(schema);
@@ -182,6 +191,8 @@ describe('ZodBridge', () => {
       const schema = object({ a: array(array(string()).min(1)).min(2) });
       const bridge = new ZodBridge(schema);
       expect(bridge.getInitialValue('a')).toEqual([[], []]);
+      expect(bridge.getInitialValue('a.0')).toEqual([]);
+      expect(bridge.getInitialValue('a.0.0')).toEqual(undefined);
     });
 
     it('works with boolean', () => {
@@ -248,6 +259,14 @@ describe('ZodBridge', () => {
       const schema = object({ a: object({ b: object({ c: string() }) }) });
       const bridge = new ZodBridge(schema);
       expect(bridge.getInitialValue('a')).toEqual({ b: {} });
+      expect(bridge.getInitialValue('a.b')).toEqual({});
+      expect(bridge.getInitialValue('a.b.c')).toEqual(undefined);
+    });
+
+    it('works with default', () => {
+      const schema = object({ a: string().default('x') });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getInitialValue('a')).toEqual('x');
     });
 
     it('works with optional', () => {
@@ -356,6 +375,12 @@ describe('ZodBridge', () => {
       expect(bridge.getProps('a.b.c')).toEqual({ label: 'C', required: true });
     });
 
+    it('works with default', () => {
+      const schema = object({ a: string().default('x') });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({ label: 'A', required: false });
+    });
+
     it('works with optional', () => {
       const schema = object({ a: optional(string()) });
       const bridge = new ZodBridge(schema);
@@ -403,6 +428,13 @@ describe('ZodBridge', () => {
       expect(bridge.getSubfields('a')).toEqual(['b']);
       expect(bridge.getSubfields('a.b')).toEqual(['c']);
       expect(bridge.getSubfields('a.b.c')).toEqual([]);
+    });
+
+    it('works with optional', () => {
+      const schema = object({ a: object({ b: string() }).default({ b: 'x' }) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getSubfields('a')).toEqual(['b']);
+      expect(bridge.getSubfields('a.b')).toEqual([]);
     });
 
     it('works with optional', () => {

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -107,4 +107,12 @@ describe('ZodBridge', () => {
       expect(bridge.getType('a')).toBe(String);
     });
   });
+
+  describe('#getValidator', () => {
+    it('is a function', () => {
+      const schema = object({});
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getValidator()).toEqual(expect.any(Function));
+    });
+  });
 });

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -1,5 +1,5 @@
 import { ZodBridge } from 'uniforms-bridge-zod';
-import { array, number, object, string } from 'zod';
+import { array, boolean, date, number, object, string } from 'zod';
 
 describe('ZodBridge', () => {
   describe('#getField', () => {
@@ -67,6 +67,44 @@ describe('ZodBridge', () => {
       expect(bridge.getSubfields('a')).toEqual(['b']);
       expect(bridge.getSubfields('a.b')).toEqual(['c']);
       expect(bridge.getSubfields('a.b.c')).toEqual([]);
+    });
+  });
+
+  describe('#getType', () => {
+    it('works with array', () => {
+      const schema = object({ a: array(array(string())) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(Array);
+    });
+
+    it('works with boolean', () => {
+      const schema = object({ a: boolean() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(Boolean);
+    });
+
+    it('works with date', () => {
+      const schema = object({ a: date() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(Date);
+    });
+
+    it('works with number', () => {
+      const schema = object({ a: number() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(Number);
+    });
+
+    it('works with object', () => {
+      const schema = object({ a: object({ b: object({ c: string() }) }) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(Object);
+    });
+
+    it('works with string', () => {
+      const schema = object({ a: string() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(String);
     });
   });
 });

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -238,24 +238,12 @@ describe('ZodBridge', () => {
       enum Test {
         x,
         y,
-        z = 'a',
-      }
-
-      const schema = object({ a: nativeEnum(Test) });
-      const bridge = new ZodBridge(schema);
-      expect(bridge.getInitialValue('a')).toEqual('x');
-    });
-
-    it('works with enum (native, numbers)', () => {
-      enum Test {
-        x,
-        y,
         z,
       }
 
       const schema = object({ a: nativeEnum(Test) });
       const bridge = new ZodBridge(schema);
-      expect(bridge.getInitialValue('a')).toEqual('x');
+      expect(bridge.getInitialValue('a')).toEqual(0);
     });
 
     it('works with enum (native, string)', () => {
@@ -354,22 +342,6 @@ describe('ZodBridge', () => {
       });
     });
 
-    it('works with enum (native, mixed)', () => {
-      enum Test {
-        x,
-        y,
-        z = 'a',
-      }
-
-      const schema = object({ a: nativeEnum(Test) });
-      const bridge = new ZodBridge(schema);
-      expect(bridge.getProps('a')).toEqual({
-        allowedValues: ['x', 'y', 'a'],
-        label: 'A',
-        required: true,
-      });
-    });
-
     it('works with enum (native, number)', () => {
       enum Test {
         x,
@@ -380,7 +352,7 @@ describe('ZodBridge', () => {
       const schema = object({ a: nativeEnum(Test) });
       const bridge = new ZodBridge(schema);
       expect(bridge.getProps('a')).toEqual({
-        allowedValues: ['x', 'y', 'z'],
+        allowedValues: [0, 1, 2],
         label: 'A',
         required: true,
       });
@@ -553,18 +525,6 @@ describe('ZodBridge', () => {
       expect(bridge.getType('a')).toBe(String);
     });
 
-    it('works with enum (native, mixed)', () => {
-      enum Test {
-        x,
-        y,
-        z = 'a',
-      }
-
-      const schema = object({ a: nativeEnum(Test) });
-      const bridge = new ZodBridge(schema);
-      expect(bridge.getType('a')).toBe(String);
-    });
-
     it('works with enum (native, number)', () => {
       enum Test {
         x,
@@ -574,7 +534,7 @@ describe('ZodBridge', () => {
 
       const schema = object({ a: nativeEnum(Test) });
       const bridge = new ZodBridge(schema);
-      expect(bridge.getType('a')).toBe(String);
+      expect(bridge.getType('a')).toBe(Number);
     });
 
     it('works with enum (native, string)', () => {

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -1,0 +1,18 @@
+import { ZodBridge } from 'uniforms-bridge-zod';
+import { number, object, string } from 'zod';
+
+describe('ZodBridge', () => {
+  describe('#getSubfields', () => {
+    it('works with empty objects', () => {
+      const schema = object({});
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getSubfields()).toEqual([]);
+    });
+
+    it('works with non-empty objects', () => {
+      const schema = object({ a: string(), b: number() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getSubfields()).toEqual(['a', 'b']);
+    });
+  });
+});

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -84,6 +84,45 @@ describe('ZodBridge', () => {
     });
   });
 
+  describe('#getErrorMessages', () => {
+    it('works without error', () => {
+      const schema = object({ a: string() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getErrorMessages(null)).toEqual([]);
+      expect(bridge.getErrorMessages(undefined)).toEqual([]);
+    });
+
+    it('works with generic error', () => {
+      const schema = object({ a: string() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getErrorMessages(new Error('Error'))).toEqual(['Error']);
+    });
+
+    it('works with simple types', () => {
+      const schema = object({ a: string(), b: number() });
+      const bridge = new ZodBridge(schema);
+      const error = bridge.getValidator()({});
+      const messages = error?.issues?.map(issue => issue.message);
+      expect(bridge.getErrorMessages(error)).toEqual(messages);
+    });
+
+    it('works with arrays', () => {
+      const schema = object({ a: array(array(string())) });
+      const bridge = new ZodBridge(schema);
+      const error = bridge.getValidator()({ a: [['x', 'y', 0], [1]] });
+      const messages = error?.issues?.map(issue => issue.message);
+      expect(bridge.getErrorMessages(error)).toEqual(messages);
+    });
+
+    it('works with nested objects', () => {
+      const schema = object({ a: object({ b: object({ c: string() }) }) });
+      const bridge = new ZodBridge(schema);
+      const error = bridge.getValidator()({ a: { b: { c: 1 } } });
+      const messages = error?.issues?.map(issue => issue.message);
+      expect(bridge.getErrorMessages(error)).toEqual(messages);
+    });
+  });
+
   describe('#getField', () => {
     it('works with root schema', () => {
       const schema = object({});

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -14,29 +14,73 @@ describe('ZodBridge', () => {
       const schema = object({ a: string(), b: number() });
       const bridge = new ZodBridge(schema);
       const error = bridge.getValidator()({});
-      expect(bridge.getError('a', error)).toBe(error?.issues[0]);
-      expect(bridge.getError('b', error)).toBe(error?.issues[1]);
+      const issues = error?.issues;
+      expect(bridge.getError('a', error)).toBe(issues?.[0]);
+      expect(bridge.getError('b', error)).toBe(issues?.[1]);
     });
 
     it('works with arrays', () => {
       const schema = object({ a: array(array(string())) });
       const bridge = new ZodBridge(schema);
       const error = bridge.getValidator()({ a: [['x', 'y', 0], [1]] });
+      const issues = error?.issues;
       expect(bridge.getError('a', error)).toBe(null);
       expect(bridge.getError('a.0', error)).toBe(null);
       expect(bridge.getError('a.0.0', error)).toBe(null);
       expect(bridge.getError('a.0.1', error)).toBe(null);
-      expect(bridge.getError('a.0.2', error)).toBe(error?.issues[0]);
-      expect(bridge.getError('a.1.0', error)).toBe(error?.issues[1]);
+      expect(bridge.getError('a.0.2', error)).toBe(issues?.[0]);
+      expect(bridge.getError('a.1.0', error)).toBe(issues?.[1]);
     });
 
     it('works with nested objects', () => {
       const schema = object({ a: object({ b: object({ c: string() }) }) });
       const bridge = new ZodBridge(schema);
       const error = bridge.getValidator()({ a: { b: { c: 1 } } });
+      const issues = error?.issues;
       expect(bridge.getError('a', error)).toBe(null);
       expect(bridge.getError('a.b', error)).toBe(null);
-      expect(bridge.getError('a.b.c', error)).toBe(error?.issues[0]);
+      expect(bridge.getError('a.b.c', error)).toBe(issues?.[0]);
+    });
+  });
+
+  describe('#getErrorMessage', () => {
+    it('works without error', () => {
+      const schema = object({ a: string() });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getErrorMessage('a', null)).toBe('');
+      expect(bridge.getErrorMessage('a', undefined)).toBe('');
+    });
+
+    it('works with simple types', () => {
+      const schema = object({ a: string(), b: number() });
+      const bridge = new ZodBridge(schema);
+      const error = bridge.getValidator()({});
+      const issues = error?.issues;
+      expect(bridge.getErrorMessage('a', error)).toBe(issues?.[0].message);
+      expect(bridge.getErrorMessage('b', error)).toBe(issues?.[1].message);
+    });
+
+    it('works with arrays', () => {
+      const schema = object({ a: array(array(string())) });
+      const bridge = new ZodBridge(schema);
+      const error = bridge.getValidator()({ a: [['x', 'y', 0], [1]] });
+      const issues = error?.issues;
+      expect(bridge.getErrorMessage('a', error)).toBe('');
+      expect(bridge.getErrorMessage('a.0', error)).toBe('');
+      expect(bridge.getErrorMessage('a.0.0', error)).toBe('');
+      expect(bridge.getErrorMessage('a.0.1', error)).toBe('');
+      expect(bridge.getErrorMessage('a.0.2', error)).toBe(issues?.[0].message);
+      expect(bridge.getErrorMessage('a.1.0', error)).toBe(issues?.[1].message);
+    });
+
+    it('works with nested objects', () => {
+      const schema = object({ a: object({ b: object({ c: string() }) }) });
+      const bridge = new ZodBridge(schema);
+      const error = bridge.getValidator()({ a: { b: { c: 1 } } });
+      const issues = error?.issues;
+      expect(bridge.getErrorMessage('a', error)).toBe('');
+      expect(bridge.getErrorMessage('a.b', error)).toBe('');
+      expect(bridge.getErrorMessage('a.b.c', error)).toBe(issues?.[0].message);
     });
   });
 

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -185,6 +185,8 @@ describe('ZodBridge', () => {
       const schema = object({ a: array(array(string())) });
       const bridge = new ZodBridge(schema);
       expect(bridge.getInitialValue('a')).toEqual([]);
+      expect(bridge.getInitialValue('a.0')).toEqual([]);
+      expect(bridge.getInitialValue('a.0.0')).toEqual(undefined);
     });
 
     it('works with array (min length)', () => {
@@ -580,6 +582,12 @@ describe('ZodBridge', () => {
       expect(bridge.getType('a')).toBe(Object);
     });
 
+    it('works with default', () => {
+      const schema = object({ a: string().default('x') });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getType('a')).toBe(String);
+    });
+
     it('works with optional', () => {
       const schema = object({ a: optional(string()) });
       const bridge = new ZodBridge(schema);
@@ -597,7 +605,9 @@ describe('ZodBridge', () => {
     it('is a function', () => {
       const schema = object({});
       const bridge = new ZodBridge(schema);
-      expect(bridge.getValidator()).toEqual(expect.any(Function));
+      const validator = bridge.getValidator();
+      expect(validator).toEqual(expect.any(Function));
+      expect(validator({})).toEqual(null);
     });
   });
 });

--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -291,6 +291,26 @@ describe('ZodBridge', () => {
       expect(bridge.getProps('a.0.0')).toEqual({ label: '0', required: true });
     });
 
+    it('works with array (maxCount)', () => {
+      const schema = object({ a: array(array(string())).max(1) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        label: 'A',
+        required: true,
+        maxCount: 1,
+      });
+    });
+
+    it('works with array (minCount)', () => {
+      const schema = object({ a: array(array(string())).min(1) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        label: 'A',
+        required: true,
+        minCount: 1,
+      });
+    });
+
     it('works with boolean', () => {
       const schema = object({ a: boolean() });
       const bridge = new ZodBridge(schema);
@@ -364,7 +384,49 @@ describe('ZodBridge', () => {
     it('works with number', () => {
       const schema = object({ a: number() });
       const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        label: 'A',
+        required: true,
+        decimal: true,
+      });
+    });
+
+    it('works with number (int)', () => {
+      const schema = object({ a: number().int() });
+      const bridge = new ZodBridge(schema);
       expect(bridge.getProps('a')).toEqual({ label: 'A', required: true });
+    });
+
+    it('works with number (max)', () => {
+      const schema = object({ a: number().max(1) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        label: 'A',
+        required: true,
+        decimal: true,
+        max: 1,
+      });
+    });
+
+    it('works with number (min)', () => {
+      const schema = object({ a: number().min(1) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        label: 'A',
+        required: true,
+        decimal: true,
+        min: 1,
+      });
+    });
+
+    it('works with number (multipleOf)', () => {
+      const schema = object({ a: number().int().multipleOf(7) });
+      const bridge = new ZodBridge(schema);
+      expect(bridge.getProps('a')).toEqual({
+        label: 'A',
+        required: true,
+        step: 7,
+      });
     });
 
     it('works with object', () => {

--- a/packages/uniforms-bridge-zod/__tests__/index.ts
+++ b/packages/uniforms-bridge-zod/__tests__/index.ts
@@ -1,0 +1,8 @@
+import * as uniformsZod from 'uniforms-bridge-zod';
+
+it('exports everything', () => {
+  expect(uniformsZod).toEqual({
+    default: expect.any(Function),
+    ZodBridge: expect.any(Function),
+  });
+});

--- a/packages/uniforms-bridge-zod/package.json
+++ b/packages/uniforms-bridge-zod/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "uniforms-bridge-zod",
+  "version": "3.10.0",
+  "license": "MIT",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
+  "sideEffects": false,
+  "description": "Zod schema bridge for uniforms.",
+  "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-zod",
+  "bugs": "https://github.com/vazco/uniforms/issues",
+  "funding": "https://github.com/vazco/uniforms?sponsor=1",
+  "keywords": [
+    "form",
+    "forms",
+    "react",
+    "schema",
+    "validation",
+    "zod"
+  ],
+  "files": [
+    "cjs/*.d.ts",
+    "cjs/*.js",
+    "esm/*.d.ts",
+    "esm/*.js",
+    "src/*.ts",
+    "src/*.tsx"
+  ],
+  "dependencies": {
+    "invariant": "^2.0.0",
+    "lodash": "^4.0.0",
+    "tslib": "^2.2.0",
+    "uniforms": "^3.10.0",
+    "zod": "^3.0.0"
+  }
+}

--- a/packages/uniforms-bridge-zod/package.json
+++ b/packages/uniforms-bridge-zod/package.json
@@ -4,7 +4,14 @@
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "cjs/index.js",
+    "cjs/register.js",
+    "esm/index.js",
+    "esm/register.js",
+    "src/index.ts",
+    "src/register.ts"
+  ],
   "description": "Zod schema bridge for uniforms.",
   "repository": "https://github.com/vazco/uniforms/tree/master/packages/uniforms-bridge-zod",
   "bugs": "https://github.com/vazco/uniforms/issues",

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -1,5 +1,7 @@
 import invariant from 'invariant';
+import lowerCase from 'lodash/lowerCase';
 import memoize from 'lodash/memoize';
+import upperFirst from 'lodash/upperFirst';
 import { Bridge, joinName } from 'uniforms';
 import {
   ZodArray,
@@ -93,6 +95,17 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
     }
 
     return undefined;
+  }
+
+  // TODO: The `props` argument could be removed in v4, just like in the
+  // `getInitialValue` function.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getProps(name: string, props?: Record<string, unknown>) {
+    return {
+      label: upperFirst(lowerCase(joinName(null, name).slice(-1)[0])),
+      // TODO: Handle optional values.
+      required: true,
+    };
   }
 
   getSubfields(name = '') {

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -5,6 +5,7 @@ import {
   ZodArray,
   ZodBoolean,
   ZodDate,
+  ZodError,
   ZodNumber,
   ZodObject,
   ZodRawShape,
@@ -22,6 +23,14 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
 
     this.getField = memoize(this.getField.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
+  }
+
+  getError(name: string, error: unknown) {
+    if (!(error instanceof ZodError)) {
+      return null;
+    }
+
+    return error.issues.find(issue => name === joinName(issue.path)) || null;
   }
 
   getField(name: string) {

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -1,0 +1,3 @@
+import { Bridge } from 'uniforms';
+
+export default class ZodBridge extends Bridge {}

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -1,3 +1,20 @@
+import memoize from 'lodash/memoize';
 import { Bridge } from 'uniforms';
+import { ZodObject, ZodRawShape } from 'zod';
 
-export default class ZodBridge extends Bridge {}
+export default class ZodBridge<T extends ZodRawShape> extends Bridge {
+  constructor(public schema: ZodObject<T>) {
+    super();
+
+    this.getSubfields = memoize(this.getSubfields.bind(this));
+  }
+
+  getSubfields(name?: string): string[] {
+    if (name === undefined) {
+      return Object.keys(this.schema.shape);
+    }
+
+    // TODO.
+    return [];
+  }
+}

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -37,6 +37,20 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
     return this.getError(name, error)?.message || '';
   }
 
+  getErrorMessages(error: unknown) {
+    if (error instanceof ZodError) {
+      // TODO: There's no information which field caused which error. We could
+      // do some generic prefixing, e.g., `{name}: {message}`.
+      return error.issues.map(issue => issue.message);
+    }
+
+    if (error instanceof Error) {
+      return [error.message];
+    }
+
+    return [];
+  }
+
   getField(name: string) {
     let field: ZodType = this.schema;
     for (const key of joinName(null, name)) {

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -33,6 +33,10 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
     return error.issues.find(issue => name === joinName(issue.path)) || null;
   }
 
+  getErrorMessage(name: string, error: unknown) {
+    return this.getError(name, error)?.message || '';
+  }
+
   getField(name: string) {
     let field: ZodType = this.schema;
     for (const key of joinName(null, name)) {

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -1,7 +1,16 @@
 import invariant from 'invariant';
 import memoize from 'lodash/memoize';
 import { Bridge, joinName } from 'uniforms';
-import { ZodArray, ZodObject, ZodRawShape, ZodType } from 'zod';
+import {
+  ZodArray,
+  ZodBoolean,
+  ZodDate,
+  ZodNumber,
+  ZodObject,
+  ZodRawShape,
+  ZodString,
+  ZodType,
+} from 'zod';
 
 function fieldInvariant(name: string, condition: boolean): asserts condition {
   invariant(condition, 'Field not found in schema: "%s"', name);
@@ -41,5 +50,34 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
     }
 
     return [];
+  }
+
+  getType(name: string) {
+    const field = this.getField(name);
+    if (field instanceof ZodArray) {
+      return Array;
+    }
+
+    if (field instanceof ZodBoolean) {
+      return Boolean;
+    }
+
+    if (field instanceof ZodDate) {
+      return Date;
+    }
+
+    if (field instanceof ZodNumber) {
+      return Number;
+    }
+
+    if (field instanceof ZodObject) {
+      return Object;
+    }
+
+    if (field instanceof ZodString) {
+      return String;
+    }
+
+    invariant(false, 'Field "%s" has an unknown type', name);
   }
 }

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -1,20 +1,45 @@
+import invariant from 'invariant';
 import memoize from 'lodash/memoize';
-import { Bridge } from 'uniforms';
-import { ZodObject, ZodRawShape } from 'zod';
+import { Bridge, joinName } from 'uniforms';
+import { ZodArray, ZodObject, ZodRawShape, ZodType } from 'zod';
+
+function fieldInvariant(name: string, condition: boolean): asserts condition {
+  invariant(condition, 'Field not found in schema: "%s"', name);
+}
 
 export default class ZodBridge<T extends ZodRawShape> extends Bridge {
   constructor(public schema: ZodObject<T>) {
     super();
 
+    this.getField = memoize(this.getField.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
   }
 
-  getSubfields(name?: string): string[] {
-    if (name === undefined) {
-      return Object.keys(this.schema.shape);
+  getField(name: string) {
+    let field: ZodType = this.schema;
+    for (const key of joinName(null, name)) {
+      if (key === '$' || key === '' + parseInt(key, 10)) {
+        fieldInvariant(name, field instanceof ZodArray);
+        field = field.element;
+      } else {
+        fieldInvariant(name, field instanceof ZodObject);
+        field = field.shape[joinName.unescape(key)];
+      }
     }
 
-    // TODO.
+    return field;
+  }
+
+  getSubfields(name = '') {
+    const field = this.getField(name);
+    if (field instanceof ZodArray) {
+      return ['$'];
+    }
+
+    if (field instanceof ZodObject) {
+      return Object.keys(field.shape);
+    }
+
     return [];
   }
 }

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -80,4 +80,13 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
 
     invariant(false, 'Field "%s" has an unknown type', name);
   }
+
+  getValidator() {
+    return (model: Record<string, unknown>) => {
+      // TODO: What about async schemas?
+      // eslint-disable-next-line react/no-this-in-sfc
+      const result = this.schema.safeParse(model);
+      return result.success ? null : result.error;
+    };
+  }
 }

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -7,6 +7,7 @@ import {
   ZodArray,
   ZodBoolean,
   ZodDate,
+  ZodDefault,
   ZodEnum,
   ZodError,
   ZodNativeEnum,
@@ -63,7 +64,9 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
   getField(name: string) {
     let field: ZodType = this.schema;
     for (const key of joinName(null, name)) {
-      if (field instanceof ZodOptional) {
+      if (field instanceof ZodDefault) {
+        field = field.removeDefault();
+      } else if (field instanceof ZodOptional) {
         field = field.unwrap();
       }
 
@@ -92,6 +95,10 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
 
       const length = field._def.minLength?.value || 0;
       return Array.from({ length }, () => item);
+    }
+
+    if (field instanceof ZodDefault) {
+      return field._def.defaultValue();
     }
 
     if (field instanceof ZodEnum) {
@@ -126,7 +133,10 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
     };
 
     let field = this.getField(name);
-    if (field instanceof ZodOptional) {
+    if (field instanceof ZodDefault) {
+      field = field.removeDefault();
+      props.required = false;
+    } else if (field instanceof ZodOptional) {
       field = field.unwrap();
       props.required = false;
     }
@@ -145,7 +155,9 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
 
   getSubfields(name = '') {
     let field = this.getField(name);
-    if (field instanceof ZodOptional) {
+    if (field instanceof ZodDefault) {
+      field = field.removeDefault();
+    } else if (field instanceof ZodOptional) {
       field = field.unwrap();
     }
 
@@ -162,7 +174,9 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
 
   getType(name: string) {
     let field = this.getField(name);
-    if (field instanceof ZodOptional) {
+    if (field instanceof ZodDefault) {
+      field = field.removeDefault();
+    } else if (field instanceof ZodOptional) {
       field = field.unwrap();
     }
 

--- a/packages/uniforms-bridge-zod/src/index.ts
+++ b/packages/uniforms-bridge-zod/src/index.ts
@@ -1,0 +1,1 @@
+export { default, default as ZodBridge } from './ZodBridge';

--- a/packages/uniforms-bridge-zod/src/index.ts
+++ b/packages/uniforms-bridge-zod/src/index.ts
@@ -1,1 +1,2 @@
+import './register';
 export { default, default as ZodBridge } from './ZodBridge';

--- a/packages/uniforms-bridge-zod/src/register.ts
+++ b/packages/uniforms-bridge-zod/src/register.ts
@@ -1,0 +1,11 @@
+import { filterDOMProps } from 'uniforms';
+
+// There's no possibility to retrieve them at runtime.
+declare module 'uniforms' {
+  interface FilterDOMProps {
+    minCount: never;
+    maxCount: never;
+  }
+}
+
+filterDOMProps.register('minCount', 'maxCount');

--- a/packages/uniforms-bridge-zod/tsconfig.cjs.json
+++ b/packages/uniforms-bridge-zod/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "outDir": "cjs",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bridge-zod.cjs.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../uniforms/tsconfig.cjs.json" }]
+}

--- a/packages/uniforms-bridge-zod/tsconfig.esm.json
+++ b/packages/uniforms-bridge-zod/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "outDir": "esm",
+    "rootDir": "src",
+    "module": "ES6",
+    "tsBuildInfoFile": "../../node_modules/.cache/uniforms-bridge-zod.esm.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../uniforms/tsconfig.esm.json" }]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -20,6 +20,8 @@
     { "path": "packages/uniforms-bridge-simple-schema/tsconfig.esm.json" },
     { "path": "packages/uniforms-bridge-simple-schema-2/tsconfig.cjs.json" },
     { "path": "packages/uniforms-bridge-simple-schema-2/tsconfig.esm.json" },
+    { "path": "packages/uniforms-bridge-zod/tsconfig.cjs.json" },
+    { "path": "packages/uniforms-bridge-zod/tsconfig.esm.json" },
     { "path": "packages/uniforms-material/tsconfig.cjs.json" },
     { "path": "packages/uniforms-material/tsconfig.esm.json" },
     { "path": "packages/uniforms-mui/tsconfig.cjs.json" },

--- a/tsconfig.global.json
+++ b/tsconfig.global.json
@@ -31,6 +31,8 @@
     { "path": "packages/uniforms-bridge-simple-schema/tsconfig.cjs.json" },
     { "path": "packages/uniforms-bridge-simple-schema-2/tsconfig.esm.json" },
     { "path": "packages/uniforms-bridge-simple-schema-2/tsconfig.cjs.json" },
+    { "path": "packages/uniforms-bridge-zod/tsconfig.esm.json" },
+    { "path": "packages/uniforms-bridge-zod/tsconfig.cjs.json" },
     { "path": "packages/uniforms-material/tsconfig.esm.json" },
     { "path": "packages/uniforms-material/tsconfig.cjs.json" },
     { "path": "packages/uniforms-mui/tsconfig.esm.json" },

--- a/website/lib/presets.ts
+++ b/website/lib/presets.ts
@@ -112,6 +112,18 @@ const presets = {
     )
   `,
 
+  'Address (Zod)': preset`
+    new ZodBridge(
+      z.object({
+        // TODO: Make it optional.
+        city: z.string().max(50),
+        state: z.string(),
+        street: z.string().max(100),
+        zip: z.string().regex(/^[0-9]{5}$/),
+      })
+    )
+  `,
+
   'All Fields (SimpleSchema)': preset`
     new SimpleSchema2Bridge(
       new SimpleSchema({
@@ -145,6 +157,24 @@ const presets = {
             ],
           },
         },
+      })
+    )
+  `,
+
+  'All Fields (Zod)': preset`
+    new ZodBridge(
+      z.object({
+        text: z.string(),
+        num: z.number(),
+        bool: z.boolean(),
+        nested: z.object({ text: z.string() }),
+        date: z.date(),
+        // TODO: Custom label and placeholder.
+        list: z.array(z.string()),
+        // TODO: Enums.
+        select: z.string(),
+        // TODO: Enums with custom props.
+        radio: z.string(),
       })
     )
   `,

--- a/website/lib/presets.ts
+++ b/website/lib/presets.ts
@@ -115,8 +115,7 @@ const presets = {
   'Address (Zod)': preset`
     new ZodBridge(
       z.object({
-        // TODO: Make it optional.
-        city: z.string().max(50),
+        city: z.string().max(50).optional(),
         state: z.string(),
         street: z.string().max(100),
         zip: z.string().regex(/^[0-9]{5}$/),

--- a/website/lib/presets.ts
+++ b/website/lib/presets.ts
@@ -171,10 +171,9 @@ const presets = {
         date: z.date(),
         // TODO: Custom label and placeholder.
         list: z.array(z.string()),
-        // TODO: Enums.
-        select: z.string(),
+        select: z.enum(['a', 'b']),
         // TODO: Enums with custom props.
-        radio: z.string(),
+        radio: z.enum(['a', 'b']),
       })
     )
   `,

--- a/website/lib/schema.ts
+++ b/website/lib/schema.ts
@@ -6,6 +6,8 @@ import { filterDOMProps } from 'uniforms';
 import { GraphQLBridge } from 'uniforms-bridge-graphql';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 import { SimpleSchema2Bridge } from 'uniforms-bridge-simple-schema-2';
+import { ZodBridge } from 'uniforms-bridge-zod';
+import { z } from 'zod';
 
 import presets from './presets';
 import { themes } from './universal';
@@ -32,8 +34,10 @@ scope.GraphQLBridge = GraphQLBridge;
 scope.JSONSchemaBridge = JSONSchemaBridge;
 scope.SimpleSchema = SimpleSchema;
 scope.SimpleSchema2Bridge = SimpleSchema2Bridge;
+scope.ZodBridge = ZodBridge;
 scope.buildASTSchema = buildASTSchema;
 scope.parse = parse;
+scope.z = z;
 
 // Dynamic field error.
 MessageBox.defaults({ messages: { en: { syntax: '' } } });

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,7 @@
     "uniforms-bridge-json-schema": "^3.10.0-rc.0",
     "uniforms-bridge-simple-schema": "^3.10.0-rc.0",
     "uniforms-bridge-simple-schema-2": "^3.10.0-rc.0",
+    "uniforms-bridge-zod": "^3.10.0-rc.0",
     "uniforms-material": "^3.10.0-rc.0",
     "uniforms-mui": "^3.10.0-rc.0",
     "uniforms-semantic": "^3.10.0-rc.0",


### PR DESCRIPTION
In this pull request, I added a new package: `uniforms-bridge-zod`, closing #1159. The implementation is really straightforward and documented in a step-by-step tutorial on my blog: [_"On uniforms Integration With Zod"_](https://radekmie.dev/blog/on-uniforms-integration-with-zod/).

Open topics:
1. **How to switch between sync and async validation?** Zod allows both, but before you actually run it, you don't know if it's going to be async or not. Doing it async by default is not ideal either, as it results in multiple renders for sync schemas.
    * We can handle it with an option passed to the `ZodBridge` constructor.
2. **Is `ZodError` the only accepted error format?** I think it does - it's well documented and typed. But maybe we should handle others as well?
3. **How to implement `getErrorMessages`?** Right now it does the same thing as `getErrorMessage`, resulting in messages like "Value should be greater than or equal to 10000" which makes sense for inline errors, but doesn't work for the `ErrorsField` component.
    * We can prefix them with the field's label, but it won't be useful for list fields. But maybe that's OK?
4. **What additional schema-specific props are useful?** For now I added `maxCount`/`minCount` for arrays and `max`/`min`/`step` for numbers. I'm thinking about things like `.email()` for string schemas being mapped to [`type: 'email'`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email). It may be handy for some themes but problematic in others.
5. **How to pass custom props through the schema?** There's no thing like that in Zod, or at least nothing I found out of the box. There's https://github.com/colinhacks/zod/issues/507, and while it's not entirely that use case, I agree that it doesn't make sense to add it there.
    * A workaround for now is to provide the props directly in the JSX **or** subclassing the `ZodBridge` and extending the `getProps` function.

I've marked is at v3.x, but I'd rather see it as a v4.0 beta thing, due to bridge methods (see comments in the code).