### PR TITLE
Fixed unmounted `setState` warning (fixes #1152).

### DIFF
--- a/packages/uniforms/__tests__/BaseForm.tsx
+++ b/packages/uniforms/__tests__/BaseForm.tsx
@@ -384,5 +384,16 @@ describe('BaseForm', () => {
 
       await expect(wrapper.instance().submit()).resolves.toBe(value);
     });
+
+    it('works when unmounted on submit', () => {
+      const spy = jest.spyOn(console, 'error');
+      const wrapper = createWrapper();
+      onSubmit.mockImplementationOnce(async () => wrapper.unmount());
+      wrapper.find('form').simulate('submit');
+
+      expect(spy).not.toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/uniforms/__tests__/ValidatedForm.tsx
+++ b/packages/uniforms/__tests__/ValidatedForm.tsx
@@ -485,7 +485,7 @@ describe('ValidatedForm', () => {
         expect(onValidate).toHaveBeenCalledTimes(run);
 
         if (hasValidationError) {
-          expect(onSubmit).toHaveBeenCalledTimes(0);
+          expect(onSubmit).not.toHaveBeenCalled();
           expect(wrapper.instance().getContext().error).toBe(error);
         } else {
           expect(onSubmit).toHaveBeenCalledTimes(run);

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -94,6 +94,14 @@ export class BaseForm<
     if (this.delayId) {
       clearTimeout(this.delayId);
     }
+
+    // There are at least 4 places where we'd need to check, whether or not we
+    // actually perform `setState` after the component gets unmounted. Instead,
+    // we override it to hide the React warning. Also because React no longer
+    // will raise it in the newer versions.
+    // https://github.com/facebook/react/pull/22114
+    // https://github.com/vazco/uniforms/issues/1152
+    this.setState = () => {};
   }
 
   delayId?: any;


### PR DESCRIPTION
In this pull request, I fixed https://github.com/vazco/uniforms/issues/1152. There are at least 4 places where we'd need to check, whether or not we actually perform `setState` after the component gets unmounted. Instead, I overridden it to hide the React warning. Mostly because React no longer will raise it in the newer versions anyway (https://github.com/facebook/react/pull/22114).