### PR TITLE
Documentation: Add warnings about Ajv strict keywords to tutorial

### DIFF
--- a/docs/tutorials-basic-uniforms-usage.mdx
+++ b/docs/tutorials-basic-uniforms-usage.mdx
@@ -74,7 +74,13 @@ However, **there's small caveat with using the JSONSchemaBridge**.
 Because of its simplicity, JSONSchema doesn't provide any validation checkers, so in order to properly validate our submitted data,
 we need to **manually define a validator**, and that is required by the uniforms `JSONSchemaBrigde` constructor.
 
-To manually create the validator, we will use the [ajv](https://github.com/epoberezkin/ajv) package:
+To manually create the validator, we will use the [Ajv](https://github.com/ajv-validator/ajv) package:
+
+:::caution
+
+Ajv executes in [strict mode by default](https://ajv.js.org/options.html#strict) since version 7. To avoid errors at schema compilation phase, we have to register the `uniforms` keyword (see [Unknown keywords](https://ajv.js.org/strict-mode.html#unknown-keywords) for more details).
+
+:::
 
 <CodeSection
   language="tsx"

--- a/docs/tutorials-using-predefined-fields.mdx
+++ b/docs/tutorials-using-predefined-fields.mdx
@@ -99,8 +99,21 @@ Instead of having to type the React component by ourselves inside our form, we c
   source={require('!!raw-loader!../website/pages-parts/Tutorial/GuestSchema3')}
 />
 
-What's changed is that now we've included the available options inside the `profession` property definition -
+What's changed is that now we've included the available `options` inside the `profession` property definition -
 uniforms are smart enough to deduce result field type, thanks to the [`AutoField` algorithm](/docs/uth-autofield-algorithm).
+
+:::caution
+
+Remember to register the `uniforms` and `options` keyword (see [Unknown keywords](https://ajv.js.org/strict-mode.html#unknown-keywords) for more details).
+
+<CodeSection
+  language="tsx"
+  section="keywords"
+  source={require('!!raw-loader!../website/pages-parts/Tutorial/GuestSchema3')}
+/>
+
+:::
+
 When it comes to the `additionalInfo`, there is a slightly different approach applied - we can explicitly tell the `AutoForm` what field should be rendered.
 Just don't forget to import the desired one!
 

--- a/website/pages-parts/Tutorial/GuestSchema.ts
+++ b/website/pages-parts/Tutorial/GuestSchema.ts
@@ -8,11 +8,11 @@ import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 // </bridgeImport>
 
 // <schema>
-interface FormData {
+type FormData = {
   firstName: string;
   lastName: string;
-  workExperience?: number;
-}
+  workExperience: number;
+};
 
 const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
@@ -25,7 +25,6 @@ const schema: JSONSchemaType<FormData> = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
-      nullable: true,
     },
   },
   required: ['firstName', 'lastName'],
@@ -39,7 +38,7 @@ const ajv = new Ajv({
   keywords: ['uniforms'],
 });
 
-function createValidator(schema: JSONSchemaType<FormData>) {
+function createValidator<T>(schema: JSONSchemaType<T>) {
   const validator = ajv.compile(schema);
 
   return (model: Record<string, unknown>) => {

--- a/website/pages-parts/Tutorial/GuestSchema.ts
+++ b/website/pages-parts/Tutorial/GuestSchema.ts
@@ -1,12 +1,20 @@
+// <schema>
 // <validator>
-import Ajv from 'ajv';
+import Ajv, { JSONSchemaType } from 'ajv';
 // </validator>
+// </schema>
 // <bridgeImport>
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 // </bridgeImport>
 
 // <schema>
-const schema = {
+interface FormData {
+  firstName: string;
+  lastName: string;
+  workExperience?: number;
+}
+
+const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
   type: 'object',
   properties: {
@@ -17,6 +25,7 @@ const schema = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
+      nullable: true,
     },
   },
   required: ['firstName', 'lastName'],
@@ -24,12 +33,16 @@ const schema = {
 // </schema>
 
 // <validator>
-const ajv = new Ajv({ allErrors: true, useDefaults: true });
+const ajv = new Ajv({
+  allErrors: true,
+  useDefaults: true,
+  keywords: ['uniforms'],
+});
 
-function createValidator(schema: object) {
+function createValidator(schema: JSONSchemaType<FormData>) {
   const validator = ajv.compile(schema);
 
-  return (model: object) => {
+  return (model: Record<string, unknown>) => {
     validator(model);
     return validator.errors?.length ? { details: validator.errors } : null;
   };

--- a/website/pages-parts/Tutorial/GuestSchema2.ts
+++ b/website/pages-parts/Tutorial/GuestSchema2.ts
@@ -10,13 +10,13 @@ const ajv = new Ajv({
 });
 
 // <schema>
-interface FormData {
+type FormData = {
   firstName: string;
   lastName: string;
-  workExperience?: number;
-  profession?: string;
-  additionalInfo?: string;
-}
+  workExperience: number;
+  profession: string;
+  additionalInfo: string;
+};
 
 const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
@@ -29,19 +29,18 @@ const schema: JSONSchemaType<FormData> = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
-      nullable: true,
     },
-    profession: { type: 'string', nullable: true },
-    additionalInfo: { type: 'string', nullable: true },
+    profession: { type: 'string' },
+    additionalInfo: { type: 'string' },
   },
   required: ['firstName', 'lastName'],
 };
 // </schema>
 
-function createValidator(schema: JSONSchemaType<FormData>) {
+function createValidator<T>(schema: JSONSchemaType<T>) {
   const validator = ajv.compile(schema);
 
-  return (model: object) => {
+  return (model: Record<string, unknown>) => {
     validator(model);
     return validator.errors?.length ? { details: validator.errors } : null;
   };

--- a/website/pages-parts/Tutorial/GuestSchema2.ts
+++ b/website/pages-parts/Tutorial/GuestSchema2.ts
@@ -1,10 +1,24 @@
-import Ajv from 'ajv';
+// <schema>
+import Ajv, { JSONSchemaType } from 'ajv';
+// </schema>
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 
-const ajv = new Ajv({ allErrors: true, useDefaults: true });
+const ajv = new Ajv({
+  allErrors: true,
+  useDefaults: true,
+  keywords: ['uniforms'],
+});
 
 // <schema>
-const schema = {
+interface FormData {
+  firstName: string;
+  lastName: string;
+  workExperience?: number;
+  profession?: string;
+  additionalInfo?: string;
+}
+
+const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
   type: 'object',
   properties: {
@@ -15,15 +29,16 @@ const schema = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
+      nullable: true,
     },
-    profession: { type: 'string' },
-    additionalInfo: { type: 'string' },
+    profession: { type: 'string', nullable: true },
+    additionalInfo: { type: 'string', nullable: true },
   },
   required: ['firstName', 'lastName'],
 };
 // </schema>
 
-function createValidator(schema: object) {
+function createValidator(schema: JSONSchemaType<FormData>) {
   const validator = ajv.compile(schema);
 
   return (model: object) => {

--- a/website/pages-parts/Tutorial/GuestSchema3.ts
+++ b/website/pages-parts/Tutorial/GuestSchema3.ts
@@ -1,12 +1,25 @@
-import Ajv from 'ajv';
+// <schema>
+import Ajv, { JSONSchemaType } from 'ajv';
+// </schema>
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 import { LongTextField } from 'uniforms-unstyled';
 
 const ajv = new Ajv({ allErrors: true, useDefaults: true });
+// <keywords>
+// Required by Ajv strict mode
 ajv.addVocabulary(['options', 'uniforms']);
+// </keywords>
 
 // <schema>
-const schema = {
+interface FormData {
+  firstName: string;
+  lastName: string;
+  workExperience?: number;
+  profession?: string;
+  additionalInfo?: string;
+}
+
+const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
   type: 'object',
   properties: {
@@ -17,9 +30,11 @@ const schema = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
+      nullable: true,
     },
     profession: {
       type: 'string',
+      nullable: true,
       options: [
         {
           label: 'Developer',
@@ -45,6 +60,7 @@ const schema = {
     },
     additionalInfo: {
       type: 'string',
+      nullable: true,
       uniforms: { component: LongTextField },
     },
   },

--- a/website/pages-parts/Tutorial/GuestSchema3.ts
+++ b/website/pages-parts/Tutorial/GuestSchema3.ts
@@ -11,13 +11,13 @@ ajv.addVocabulary(['options', 'uniforms']);
 // </keywords>
 
 // <schema>
-interface FormData {
+type FormData = {
   firstName: string;
   lastName: string;
-  workExperience?: number;
-  profession?: string;
-  additionalInfo?: string;
-}
+  workExperience: number;
+  profession: string;
+  additionalInfo: string;
+};
 
 const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
@@ -30,11 +30,9 @@ const schema: JSONSchemaType<FormData> = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
-      nullable: true,
     },
     profession: {
       type: 'string',
-      nullable: true,
       options: [
         {
           label: 'Developer',
@@ -60,7 +58,6 @@ const schema: JSONSchemaType<FormData> = {
     },
     additionalInfo: {
       type: 'string',
-      nullable: true,
       uniforms: { component: LongTextField },
     },
   },
@@ -68,10 +65,10 @@ const schema: JSONSchemaType<FormData> = {
 };
 // </schema>
 
-function createValidator(schema: object) {
+function createValidator<T>(schema: JSONSchemaType<T>) {
   const validator = ajv.compile(schema);
 
-  return (model: object) => {
+  return (model: Record<string, unknown>) => {
     validator(model);
     return validator.errors?.length ? { details: validator.errors } : null;
   };

--- a/website/pages-parts/Tutorial/GuestSchema4.ts
+++ b/website/pages-parts/Tutorial/GuestSchema4.ts
@@ -1,4 +1,6 @@
-import Ajv from 'ajv';
+// <schema>
+import Ajv, { JSONSchemaType } from 'ajv';
+// </schema>
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 import { LongTextField } from 'uniforms-unstyled';
 
@@ -8,7 +10,16 @@ const ajv = new Ajv({ allErrors: true, useDefaults: true });
 ajv.addVocabulary(['options', 'uniforms']);
 
 // <schema>
-const schema = {
+interface FormData {
+  firstName: string;
+  lastName: string;
+  workExperience?: number;
+  profession?: string;
+  additionalInfo?: string;
+  pictureUrl?: string;
+}
+
+const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
   type: 'object',
   properties: {
@@ -19,9 +30,11 @@ const schema = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
+      nullable: true,
     },
     profession: {
       type: 'string',
+      nullable: true,
       options: [
         {
           label: 'Developer',
@@ -47,10 +60,12 @@ const schema = {
     },
     additionalInfo: {
       type: 'string',
+      nullable: true,
       uniforms: { component: LongTextField },
     },
     pictureUrl: {
       type: 'string',
+      nullable: true,
       uniforms: { component: ImageField },
     },
   },

--- a/website/pages-parts/Tutorial/GuestSchema4.ts
+++ b/website/pages-parts/Tutorial/GuestSchema4.ts
@@ -10,14 +10,14 @@ const ajv = new Ajv({ allErrors: true, useDefaults: true });
 ajv.addVocabulary(['options', 'uniforms']);
 
 // <schema>
-interface FormData {
+type FormData = {
   firstName: string;
   lastName: string;
-  workExperience?: number;
-  profession?: string;
-  additionalInfo?: string;
-  pictureUrl?: string;
-}
+  workExperience: number;
+  profession: string;
+  additionalInfo: string;
+  pictureUrl: string;
+};
 
 const schema: JSONSchemaType<FormData> = {
   title: 'Guest',
@@ -30,11 +30,9 @@ const schema: JSONSchemaType<FormData> = {
       type: 'integer',
       minimum: 0,
       maximum: 100,
-      nullable: true,
     },
     profession: {
       type: 'string',
-      nullable: true,
       options: [
         {
           label: 'Developer',
@@ -60,12 +58,10 @@ const schema: JSONSchemaType<FormData> = {
     },
     additionalInfo: {
       type: 'string',
-      nullable: true,
       uniforms: { component: LongTextField },
     },
     pictureUrl: {
       type: 'string',
-      nullable: true,
       uniforms: { component: ImageField },
     },
   },
@@ -73,10 +69,10 @@ const schema: JSONSchemaType<FormData> = {
 };
 // </schema>
 
-function createValidator(schema: object) {
+function createValidator<T>(schema: JSONSchemaType<T>) {
   const validator = ajv.compile(schema);
 
-  return (model: object) => {
+  return (model: Record<string, unknown>) => {
     validator(model);
     return validator.errors?.length ? { details: validator.errors } : null;
   };


### PR DESCRIPTION
## Description
This PR closes #1145 by adding warnings about Ajv strict keywords to the tutorial.

## Changes
- Added warning (caution) [admonitions](https://docusaurus.io/docs/next/markdown-features/admonitions) to [_Basic uniforms usage_](https://uniforms.tools/docs/tutorials-basic-uniforms-usage/) and [_Using predefined fields_](https://uniforms.tools/docs/tutorials-using-predefined-fields/) about Ajv strict keywords
- Modified `GuestSchema`(s) to use Ajv [utility types](https://ajv.js.org/guide/typescript.html#utility-types-for-schemas)

<details>
<summary>Click to see screenshots...</summary>

## Basic uniforms usage
![image](https://user-images.githubusercontent.com/13087338/194711817-2e4026e5-cdf4-453e-a6d4-f658194ea577.png)

## Using predefined fields
![image](https://user-images.githubusercontent.com/13087338/194711785-e9cf5e44-75a1-438d-baed-a090f02a9e6b.png)


</details>