### PR TITLE
Drop support for `initialCount` in bridges and `ListField`s

### DIFF
--- a/docs/migrating-3-to-4.md
+++ b/docs/migrating-3-to-4.md
@@ -1,0 +1,8 @@
+---
+id: migrating-3-to-4
+title: Migrating v3 to v4
+---
+
+This guide is designed to help you through the migration. If you went through it and encountered any problems - do let us know. For more information on _why_ certain changes were made, see the [`CHANGELOG.md`](https://github.com/vazco/uniforms/blob/master/CHANGELOG.md). When migrating to v4, use the newest version. Gradual updates will take more time and won't ease this process.
+
+## Breaking API changes

--- a/docs/migrating-3-to-4.md
+++ b/docs/migrating-3-to-4.md
@@ -6,3 +6,5 @@ title: Migrating v3 to v4
 This guide is designed to help you through the migration. If you went through it and encountered any problems - do let us know. For more information on _why_ certain changes were made, see the [`CHANGELOG.md`](https://github.com/vazco/uniforms/blob/master/CHANGELOG.md). When migrating to v4, use the newest version. Gradual updates will take more time and won't ease this process.
 
 ## Breaking API changes
+
+- Dropped support for `initialCount` in bridges and `ListField`s. Pass a model object to the form with the appropriate amount of initial items instead.

--- a/packages/uniforms-antd/__tests__/ListField.tsx
+++ b/packages/uniforms-antd/__tests__/ListField.tsx
@@ -59,23 +59,25 @@ test('<ListField> - renders correct label (specified)', () => {
   );
 });
 
-test('<ListField> - renders correct numer of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
+test('<ListField> - renders correct numer of items with model (specified)', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
   );
 
   expect(wrapper.find('input')).toHaveLength(3);
 });
 
 test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -85,14 +87,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -102,13 +106,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -116,10 +122,12 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
@@ -169,16 +177,17 @@ test('<ListField> - renders correct error style (with specified style prop)', ()
   );
 });
 
-test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
-  const element = (
-    <ListField name="x" initialCount={3} label="ListFieldLabel" />
-  );
+test('<ListField> - renders proper number of optional values after add new value', () => {
+  const element = <ListField name="x" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,
     createContext(
       { x: { type: Array, optional: true }, 'x.$': { type: String } },
       { onChange },
+      {
+        x: [undefined, undefined, undefined],
+      },
     ),
   );
 

--- a/packages/uniforms-antd/__tests__/_createContext.ts
+++ b/packages/uniforms-antd/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-antd/src/ListAddField.tsx
+++ b/packages/uniforms-antd/src/ListAddField.tsx
@@ -11,18 +11,13 @@ import {
   useField,
 } from 'uniforms';
 
-export type ListAddFieldProps = FieldProps<
-  unknown,
-  ButtonProps,
-  { initialCount?: number }
->;
+export type ListAddFieldProps = FieldProps<unknown, ButtonProps>;
 
 const defaultStyle = { width: '100%' };
 
 function ListAdd({
   disabled,
   icon = <PlusSquareOutlined />,
-  initialCount,
   name,
   readOnly,
   size = 'small',
@@ -33,10 +28,11 @@ function ListAdd({
 }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<
-    { initialCount?: number; maxCount?: number },
-    unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-antd/src/ListField.tsx
+++ b/packages/uniforms-antd/src/ListField.tsx
@@ -19,7 +19,6 @@ export type ListFieldProps = HTMLFieldProps<
     addIcon?: ReactNode;
     children?: ReactNode;
     info?: string;
-    initialCount?: number;
     itemProps?: object;
     labelCol?: any;
     wrapperCol?: any;
@@ -40,7 +39,6 @@ function List({
   error,
   errorMessage,
   info,
-  initialCount,
   itemProps,
   label,
   labelCol,
@@ -92,7 +90,7 @@ function List({
         ),
       )}
 
-      <ListAddField name="$" initialCount={initialCount} />
+      <ListAddField name="$" />
     </div>
   );
 }

--- a/packages/uniforms-bootstrap3/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListField.tsx
@@ -46,13 +46,25 @@ test('<ListField> - renders correct label (specified)', () => {
   );
 });
 
-test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+test('<ListField> - renders correct numer of items with model (specified)', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
+  );
+
+  expect(wrapper.find('input')).toHaveLength(3);
+});
+
+test('<ListField> - passes itemProps to its children', () => {
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -62,14 +74,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -79,13 +93,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -93,10 +109,12 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
@@ -142,15 +160,16 @@ test('<ListField> - renders correct error text (showInlineError=false)', () => {
 });
 
 test('<ListField> - renders proper number of optional values after add new value', () => {
-  const element = (
-    <ListField name="x" initialCount={3} addIcon="+" label="ListFieldLabel" />
-  );
+  const element = <ListField name="x" addIcon="+" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,
     createContext(
       { x: { type: Array, optional: true }, 'x.$': { type: String } },
       { onChange },
+      {
+        x: [undefined, undefined, undefined],
+      },
     ),
   );
 

--- a/packages/uniforms-bootstrap3/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap3/__tests__/ListField.tsx
@@ -46,16 +46,6 @@ test('<ListField> - renders correct label (specified)', () => {
   );
 });
 
-test('<ListField> - renders correct numer of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
-  const wrapper = mount(
-    element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
-  );
-
-  expect(wrapper.find('input')).toHaveLength(3);
-});
-
 test('<ListField> - passes itemProps to its children', () => {
   const element = (
     <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
@@ -151,7 +141,7 @@ test('<ListField> - renders correct error text (showInlineError=false)', () => {
   expect(wrapper.find('.help-block')).toHaveLength(0);
 });
 
-test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
+test('<ListField> - renders proper number of optional values after add new value', () => {
   const element = (
     <ListField name="x" initialCount={3} addIcon="+" label="ListFieldLabel" />
   );

--- a/packages/uniforms-bootstrap3/__tests__/_createContext.ts
+++ b/packages/uniforms-bootstrap3/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-bootstrap3/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListAddField.tsx
@@ -12,14 +12,13 @@ import {
 export type ListAddFieldProps = HTMLFieldProps<
   unknown,
   HTMLDivElement,
-  { addIcon?: ReactNode; initialCount?: number }
+  { addIcon?: ReactNode }
 >;
 
 function ListAdd({
   addIcon,
   className,
   disabled,
-  initialCount,
   name,
   readOnly,
   value,
@@ -29,11 +28,10 @@ function ListAdd({
   const parentName = joinName(nameParts.slice(0, -1));
   const parent = useField<
     {
-      initialCount?: number;
       maxCount?: number;
     },
     unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  >(parentName, {}, { absoluteName: true })[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-bootstrap3/src/ListField.tsx
+++ b/packages/uniforms-bootstrap3/src/ListField.tsx
@@ -15,7 +15,6 @@ export type ListFieldProps = HTMLFieldProps<
   HTMLDivElement,
   {
     addIcon?: ReactNode;
-    initialCount?: number;
     itemProps?: object;
     removeIcon?: ReactNode;
   }
@@ -27,7 +26,6 @@ function List({
   className,
   error,
   errorMessage,
-  initialCount,
   itemProps,
   label,
   removeIcon,
@@ -49,11 +47,7 @@ function List({
           <div className={classnames('panel-heading', { 'has-error': error })}>
             <label className="control-label">{label}&nbsp;</label>
 
-            <ListAddField
-              addIcon={addIcon}
-              initialCount={initialCount}
-              name="$"
-            />
+            <ListAddField addIcon={addIcon} name="$" />
 
             {!!(error && showInlineError) && (
               <span className="help-block">{errorMessage}</span>

--- a/packages/uniforms-bootstrap4/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap4/__tests__/ListField.tsx
@@ -46,23 +46,25 @@ test('<ListField> - renders correct label (specified)', () => {
   );
 });
 
-test('<ListField> - renders correct numer of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
+test('<ListField> - renders correct numer of items with model (specified)', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
   );
 
   expect(wrapper.find('input')).toHaveLength(3);
 });
 
 test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -72,14 +74,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -89,13 +93,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -103,10 +109,12 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
@@ -151,16 +159,17 @@ test('<ListField> - renders correct error text (showInlineError=false)', () => {
   expect(wrapper.find('.text-danger')).toHaveLength(0);
 });
 
-test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
-  const element = (
-    <ListField name="x" initialCount={3} addIcon="+" label="ListFieldLabel" />
-  );
+test('<ListField> - renders proper number of optional values after add new value', () => {
+  const element = <ListField name="x" addIcon="+" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,
     createContext(
       { x: { type: Array, optional: true }, 'x.$': { type: String } },
       { onChange },
+      {
+        x: [undefined, undefined, undefined],
+      },
     ),
   );
 

--- a/packages/uniforms-bootstrap4/__tests__/_createContext.ts
+++ b/packages/uniforms-bootstrap4/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-bootstrap4/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListAddField.tsx
@@ -12,14 +12,13 @@ import {
 export type ListAddFieldProps = HTMLFieldProps<
   unknown,
   HTMLDivElement,
-  { addIcon?: ReactNode; initialCount?: number }
+  { addIcon?: ReactNode }
 >;
 
 function ListAdd({
   addIcon,
   className,
   disabled,
-  initialCount,
   name,
   readOnly,
   value,
@@ -27,10 +26,11 @@ function ListAdd({
 }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<
-    { initialCount?: number; maxCount?: number },
-    unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-bootstrap4/src/ListField.tsx
+++ b/packages/uniforms-bootstrap4/src/ListField.tsx
@@ -15,7 +15,6 @@ export type ListFieldProps = HTMLFieldProps<
   HTMLDivElement,
   {
     addIcon?: ReactNode;
-    initialCount?: number;
     itemProps?: object;
     removeIcon?: ReactNode;
   }
@@ -27,7 +26,6 @@ function List({
   className,
   error,
   errorMessage,
-  initialCount,
   itemProps,
   label,
   removeIcon,
@@ -45,11 +43,7 @@ function List({
           <div className="card-title">
             <label className="col-form-label">{label}&nbsp;</label>
 
-            <ListAddField
-              addIcon={addIcon}
-              initialCount={initialCount}
-              name="$"
-            />
+            <ListAddField addIcon={addIcon} name="$" />
 
             {!!(error && showInlineError) && (
               <span className="text-danger">{errorMessage}</span>

--- a/packages/uniforms-bootstrap5/__tests__/ListField.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/ListField.tsx
@@ -46,23 +46,25 @@ test('<ListField> - renders correct label (specified)', () => {
   );
 });
 
-test('<ListField> - renders correct numer of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
+test('<ListField> - renders correct numer of items with model (specified)', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
   );
 
   expect(wrapper.find('input')).toHaveLength(3);
 });
 
 test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -72,14 +74,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -89,13 +93,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -103,10 +109,12 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
@@ -151,16 +159,17 @@ test('<ListField> - renders correct error text (showInlineError=false)', () => {
   expect(wrapper.find('.text-danger')).toHaveLength(0);
 });
 
-test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
-  const element = (
-    <ListField name="x" initialCount={3} addIcon="+" label="ListFieldLabel" />
-  );
+test('<ListField> - renders proper number of optional values after add new value', () => {
+  const element = <ListField name="x" addIcon="+" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,
     createContext(
       { x: { type: Array, optional: true }, 'x.$': { type: String } },
       { onChange },
+      {
+        x: [undefined, undefined, undefined],
+      },
     ),
   );
 

--- a/packages/uniforms-bootstrap5/__tests__/_createContext.ts
+++ b/packages/uniforms-bootstrap5/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-bootstrap5/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap5/src/ListAddField.tsx
@@ -12,14 +12,13 @@ import {
 export type ListAddFieldProps = HTMLFieldProps<
   unknown,
   HTMLDivElement,
-  { addIcon?: ReactNode; initialCount?: number }
+  { addIcon?: ReactNode }
 >;
 
 function ListAdd({
   addIcon,
   className,
   disabled,
-  initialCount,
   name,
   readOnly,
   value,
@@ -27,10 +26,11 @@ function ListAdd({
 }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<
-    { initialCount?: number; maxCount?: number },
-    unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-bootstrap5/src/ListField.tsx
+++ b/packages/uniforms-bootstrap5/src/ListField.tsx
@@ -15,7 +15,6 @@ export type ListFieldProps = HTMLFieldProps<
   HTMLDivElement,
   {
     addIcon?: ReactNode;
-    initialCount?: number;
     itemProps?: object;
     removeIcon?: ReactNode;
   }
@@ -27,7 +26,6 @@ function List({
   className,
   error,
   errorMessage,
-  initialCount,
   itemProps,
   label,
   removeIcon,
@@ -45,11 +43,7 @@ function List({
           <div className="card-title">
             <label className="col-form-label">{label}&nbsp;</label>
 
-            <ListAddField
-              addIcon={addIcon}
-              initialCount={initialCount}
-              name="$"
-            />
+            <ListAddField addIcon={addIcon} name="$" />
 
             {!!(error && showInlineError) && (
               <span className="text-danger">{errorMessage}</span>

--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -199,9 +199,6 @@ describe('GraphQLBridge', () => {
   describe('#getInitialValue', () => {
     it('works with arrays', () => {
       expect(bridgeI.getInitialValue('author.tags')).toEqual([]);
-      expect(
-        bridgeI.getInitialValue('author.tags', { initialCount: 1 }),
-      ).toEqual([undefined]);
     });
 
     it('works with objects', () => {

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -29,9 +29,9 @@ export default class GraphQLBridge extends Bridge {
 
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
-    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -31,6 +31,7 @@ export default class GraphQLBridge extends Bridge {
     this.getField = memoize(this.getField.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {
@@ -80,13 +81,11 @@ export default class GraphQLBridge extends Bridge {
     );
   }
 
-  getInitialValue(name: string, props?: Record<string, any>): any {
+  getInitialValue(name: string): any {
     const type = this.getType(name);
 
     if (type === Array) {
-      const item = this.getInitialValue(joinName(name, '0'));
-      const items = props?.initialCount || 0;
-      return Array.from({ length: items }, () => item);
+      return [];
     }
 
     if (type === Object) {

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -633,12 +633,6 @@ describe('JSONSchemaBridge', () => {
   describe('#getInitialValue', () => {
     it('works with arrays', () => {
       expect(bridge.getInitialValue('friends')).toEqual([]);
-      expect(bridge.getInitialValue('friends', { initialCount: 1 })).toEqual([
-        { firstName: 'John', lastName: 'John' },
-      ]);
-      expect(
-        bridge.getInitialValue('friends.0.firstName', { initialCount: 1 }),
-      ).toBe('John');
     });
 
     it('works with objects', () => {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -94,6 +94,7 @@ export default class JSONSchemaBridge extends Bridge {
     this.getField = memoize(this.getField.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {
@@ -206,7 +207,7 @@ export default class JSONSchemaBridge extends Bridge {
     }, this.schema);
   }
 
-  getInitialValue(name: string, props?: Record<string, any>): any {
+  getInitialValue(name: string): any {
     const field = this.getField(name);
     const {
       default: defaultValue = field.default ?? get(this.schema.default, name),
@@ -218,9 +219,7 @@ export default class JSONSchemaBridge extends Bridge {
     }
 
     if (type === 'array') {
-      const item = this.getInitialValue(joinName(name, '0'));
-      const items = props?.initialCount || 0;
-      return Array.from({ length: items }, () => item);
+      return [];
     }
 
     if (type === 'object') {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -92,9 +92,9 @@ export default class JSONSchemaBridge extends Bridge {
 
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
-    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -153,12 +153,6 @@ describe('SimpleSchema2Bridge', () => {
       expect(bridge.getInitialValue('k')).toEqual([]);
     });
 
-    it('works with arrays (initialCount)', () => {
-      expect(bridge.getInitialValue('k', { initialCount: 1 })).toEqual([
-        undefined,
-      ]);
-    });
-
     it('works with arrays (minCount)', () => {
       expect(bridge.getInitialValue('j')).toEqual([
         undefined,

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -12,9 +12,9 @@ export default class SimpleSchema2Bridge extends Bridge {
 
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
-    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -14,6 +14,7 @@ export default class SimpleSchema2Bridge extends Bridge {
     this.getField = memoize(this.getField.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {
@@ -69,7 +70,7 @@ export default class SimpleSchema2Bridge extends Bridge {
     return merged;
   }
 
-  getInitialValue(name: string, props?: Record<string, any>): any {
+  getInitialValue(name: string): any {
     const field = this.getField(name);
     const defaultValue = field.defaultValue;
     if (defaultValue !== undefined) {
@@ -78,8 +79,7 @@ export default class SimpleSchema2Bridge extends Bridge {
 
     if (field.type === Array) {
       const item = this.getInitialValue(joinName(name, '0'));
-      const items = Math.max(props?.initialCount || 0, field.minCount || 0);
-      return Array.from({ length: items }, () => item);
+      return Array.from({ length: field.minCount || 0 }, () => item);
     }
 
     if (field.type === Object || field.type instanceof SimpleSchema) {

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -174,12 +174,6 @@ describe('SimpleSchemaBridge', () => {
       expect(bridge.getInitialValue('k')).toEqual([]);
     });
 
-    it('works with arrays (initialCount)', () => {
-      expect(bridge.getInitialValue('k', { initialCount: 1 })).toEqual([
-        undefined,
-      ]);
-    });
-
     it('works with arrays (minCount)', () => {
       expect(bridge.getInitialValue('j')).toEqual([
         undefined,

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -13,9 +13,9 @@ export default class SimpleSchemaBridge extends Bridge {
 
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
-    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -15,6 +15,7 @@ export default class SimpleSchemaBridge extends Bridge {
     this.getField = memoize(this.getField.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
   }
 
   getError(name: string, error: any) {
@@ -64,7 +65,7 @@ export default class SimpleSchemaBridge extends Bridge {
     return definition;
   }
 
-  getInitialValue(name: string, props?: Record<string, any>): any {
+  getInitialValue(name: string): any {
     const field = this.getField(name);
     const defaultValue = field.defaultValue;
     if (defaultValue !== undefined) {
@@ -73,8 +74,7 @@ export default class SimpleSchemaBridge extends Bridge {
 
     if (field.type === Array) {
       const item = this.getInitialValue(joinName(name, '0'));
-      const items = Math.max(props?.initialCount || 0, field.minCount || 0);
-      return Array.from({ length: items }, () => item);
+      return Array.from({ length: field.minCount || 0 }, () => item);
     }
 
     if (field.type === Object) {

--- a/packages/uniforms-material/__tests__/ListField.tsx
+++ b/packages/uniforms-material/__tests__/ListField.tsx
@@ -46,23 +46,25 @@ test('<ListField> - renders correct label (specified)', () => {
   expect(wrapper.find(ListSubheader).text()).toBe('ListFieldLabel');
 });
 
-test('<ListField> - renders correct number of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
+test('<ListField> - renders correct number of items with model', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField)).toHaveLength(3);
 });
 
 test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -72,14 +74,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -89,13 +93,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -103,26 +109,29 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
   expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
-test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
-  const element = (
-    <ListField name="x" initialCount={3} label="ListFieldLabel" />
-  );
+test('<ListField> - renders proper number of optional values after add new value', () => {
+  const element = <ListField name="x" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,
     createContext(
       { x: { type: Array, optional: true }, 'x.$': { type: String } },
       { onChange },
+      {
+        x: [undefined, undefined, undefined],
+      },
     ),
   );
   expect(

--- a/packages/uniforms-material/__tests__/_createContext.ts
+++ b/packages/uniforms-material/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-material/src/ListAddField.tsx
+++ b/packages/uniforms-material/src/ListAddField.tsx
@@ -16,7 +16,6 @@ export type ListAddFieldProps = FieldProps<
   {
     fullWidth?: FormControlProps['fullWidth'];
     icon?: ReactNode;
-    initialCount?: number;
     margin?: FormControlProps['margin'];
     variant?: FormControlProps['variant'];
   }
@@ -26,7 +25,6 @@ function ListAdd({
   disabled,
   fullWidth = true,
   icon = '+',
-  initialCount,
   margin = 'dense',
   name,
   readOnly,
@@ -36,10 +34,11 @@ function ListAdd({
 }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<
-    { initialCount?: number; maxCount?: number },
-    unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-material/src/ListField.tsx
+++ b/packages/uniforms-material/src/ListField.tsx
@@ -14,13 +14,12 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = FieldProps<
   unknown[],
   ListProps,
-  { addIcon?: ReactNode; initialCount?: number; itemProps?: object }
+  { addIcon?: ReactNode; itemProps?: object }
 >;
 
 function List({
   addIcon,
   children = <ListItemField name="$" />,
-  initialCount,
   itemProps,
   label,
   value,
@@ -49,7 +48,7 @@ function List({
           ),
         )}
       </ListMaterial>
-      <ListAddField icon={addIcon} initialCount={initialCount} name="$" />
+      <ListAddField icon={addIcon} name="$" />
     </>
   );
 }

--- a/packages/uniforms-mui/__tests__/ListField.tsx
+++ b/packages/uniforms-mui/__tests__/ListField.tsx
@@ -46,23 +46,25 @@ test('<ListField> - renders correct label (specified)', () => {
   expect(wrapper.find(ListSubheader).text()).toBe('ListFieldLabel');
 });
 
-test('<ListField> - renders correct number of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
+test('<ListField> - renders correct number of items with model (specified)', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField)).toHaveLength(3);
 });
 
 test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -72,14 +74,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -89,13 +93,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -103,10 +109,12 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
@@ -116,9 +124,7 @@ test('<ListField> - renders children with correct name (value)', () => {
 // Strange enzyme behavior
 // TypeError: Cannot read properties of null (reading '__reactFiber$my72orhzzz9')
 test.skip('<ListField> - renders proper number of optional values after add new value (with initialCount)', async () => {
-  const element = (
-    <ListField name="x" initialCount={3} label="ListFieldLabel" />
-  );
+  const element = <ListField name="x" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,

--- a/packages/uniforms-mui/__tests__/_createContext.ts
+++ b/packages/uniforms-mui/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-mui/src/ListAddField.tsx
+++ b/packages/uniforms-mui/src/ListAddField.tsx
@@ -16,7 +16,6 @@ export type ListAddFieldProps = FieldProps<
   {
     fullWidth?: FormControlProps['fullWidth'];
     icon?: ReactNode;
-    initialCount?: number;
     margin?: FormControlProps['margin'];
     variant?: FormControlProps['variant'];
   }
@@ -26,7 +25,6 @@ function ListAdd({
   disabled,
   fullWidth = true,
   icon = '+',
-  initialCount,
   margin = 'dense',
   name,
   readOnly,
@@ -36,10 +34,11 @@ function ListAdd({
 }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<
-    { initialCount?: number; maxCount?: number },
-    unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-mui/src/ListField.tsx
+++ b/packages/uniforms-mui/src/ListField.tsx
@@ -14,13 +14,12 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = FieldProps<
   unknown[],
   ListProps,
-  { addIcon?: ReactNode; initialCount?: number; itemProps?: object }
+  { addIcon?: ReactNode; itemProps?: object }
 >;
 
 function List({
   addIcon,
   children = <ListItemField name="$" />,
-  initialCount,
   itemProps,
   label,
   value,
@@ -49,7 +48,7 @@ function List({
           ),
         )}
       </ListMaterial>
-      <ListAddField icon={addIcon} initialCount={initialCount} name="$" />
+      <ListAddField icon={addIcon} name="$" />
     </>
   );
 }

--- a/packages/uniforms-semantic/__tests__/ListField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListField.tsx
@@ -46,23 +46,27 @@ test('<ListField> - renders correct label (specified)', () => {
   );
 });
 
-test('<ListField> - renders correct number of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
+test('<ListField> - renders correct number of items with model (specified)', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, [
+      undefined,
+      undefined,
+      undefined,
+    ]),
   );
 
   expect(wrapper.find('input')).toHaveLength(3);
 });
 
 test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -72,14 +76,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -89,13 +95,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -103,10 +111,12 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
@@ -116,13 +126,7 @@ test('<ListField> - renders children with correct name (value)', () => {
 test('<ListField> - renders correct error text (specified)', () => {
   const error = new Error();
   const element = (
-    <ListField
-      name="x"
-      initialCount={1}
-      error={error}
-      showInlineError
-      errorMessage="Error"
-    />
+    <ListField name="x" error={error} showInlineError errorMessage="Error" />
   );
   const wrapper = mount(
     element,
@@ -137,7 +141,6 @@ test('<ListField> - renders correct error text (showInlineError=false)', () => {
   const element = (
     <ListField
       name="x"
-      initialCount={1}
       error={error}
       showInlineError={false}
       errorMessage="Error"
@@ -151,16 +154,17 @@ test('<ListField> - renders correct error text (showInlineError=false)', () => {
   expect(wrapper.children().first().text()).not.toBe('Error');
 });
 
-test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
-  const element = (
-    <ListField name="x" initialCount={3} label="ListFieldLabel" />
-  );
+test('<ListField> - renders proper number of optional values after add new value', () => {
+  const element = <ListField name="x" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,
     createContext(
       { x: { type: Array, optional: true }, 'x.$': { type: String } },
       { onChange },
+      {
+        x: [undefined, undefined, undefined],
+      },
     ),
   );
   expect(wrapper.find(ListAddField).simulate('click')).toBeTruthy();

--- a/packages/uniforms-semantic/__tests__/ListField.tsx
+++ b/packages/uniforms-semantic/__tests__/ListField.tsx
@@ -50,11 +50,9 @@ test('<ListField> - renders correct number of items with model (specified)', () 
   const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, [
-      undefined,
-      undefined,
-      undefined,
-    ]),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
   );
 
   expect(wrapper.find('input')).toHaveLength(3);

--- a/packages/uniforms-semantic/__tests__/_createContext.ts
+++ b/packages/uniforms-semantic/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-semantic/src/ListAddField.tsx
+++ b/packages/uniforms-semantic/src/ListAddField.tsx
@@ -9,15 +9,10 @@ import {
   useField,
 } from 'uniforms';
 
-export type ListAddFieldProps = HTMLFieldProps<
-  unknown,
-  HTMLSpanElement,
-  { initialCount?: number }
->;
+export type ListAddFieldProps = HTMLFieldProps<unknown, HTMLSpanElement>;
 
 function ListAdd({
   disabled,
-  initialCount,
   name,
   readOnly,
   value,
@@ -25,10 +20,11 @@ function ListAdd({
 }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<
-    { initialCount?: number; maxCount?: number },
-    unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-semantic/src/ListField.tsx
+++ b/packages/uniforms-semantic/src/ListField.tsx
@@ -8,7 +8,7 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = HTMLFieldProps<
   unknown[],
   HTMLDivElement,
-  { initialCount?: number; itemProps?: object }
+  { itemProps?: object }
 >;
 
 function List({
@@ -17,7 +17,6 @@ function List({
   disabled,
   error,
   errorMessage,
-  initialCount,
   itemProps,
   label,
   required,
@@ -39,11 +38,7 @@ function List({
         <div className={classnames({ error, required }, 'field item')}>
           <label className="left floated">{label}</label>
 
-          <ListAddField
-            className="right floated"
-            initialCount={initialCount}
-            name="$"
-          />
+          <ListAddField className="right floated" name="$" />
         </div>
       )}
 

--- a/packages/uniforms-unstyled/__tests__/ListField.tsx
+++ b/packages/uniforms-unstyled/__tests__/ListField.tsx
@@ -46,23 +46,25 @@ test('<ListField> - renders correct label (specified)', () => {
   );
 });
 
-test('<ListField> - renders correct numer of items with initialCount (specified)', () => {
-  const element = <ListField name="x" initialCount={3} />;
+test('<ListField> - renders correct numer of items with model (specified)', () => {
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined, undefined],
+    }),
   );
 
   expect(wrapper.find('input')).toHaveLength(3);
 });
 
 test('<ListField> - passes itemProps to its children', () => {
-  const element = (
-    <ListField name="x" initialCount={3} itemProps={{ 'data-xyz': 1 }} />
-  );
+  const element = <ListField name="x" itemProps={{ 'data-xyz': 1 }} />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).first().prop('data-xyz')).toBe(1);
@@ -72,14 +74,16 @@ test('<ListField> - renders children (specified)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child />
       PlainText
     </ListField>
   );
   mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(Child).toHaveBeenCalledTimes(2);
@@ -89,13 +93,15 @@ test('<ListField> - renders children with correct name (children)', () => {
   const Child = jest.fn(() => <div />) as React.FC<any>;
 
   const element = (
-    <ListField name="x" initialCount={2}>
+    <ListField name="x">
       <Child name="$" />
     </ListField>
   );
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(Child).at(0).prop('name')).toBe('0');
@@ -103,26 +109,29 @@ test('<ListField> - renders children with correct name (children)', () => {
 });
 
 test('<ListField> - renders children with correct name (value)', () => {
-  const element = <ListField name="x" initialCount={2} />;
+  const element = <ListField name="x" />;
   const wrapper = mount(
     element,
-    createContext({ x: { type: Array }, 'x.$': { type: String } }),
+    createContext({ x: { type: Array }, 'x.$': { type: String } }, undefined, {
+      x: [undefined, undefined],
+    }),
   );
 
   expect(wrapper.find(ListItemField).at(0).prop('name')).toBe('0');
   expect(wrapper.find(ListItemField).at(1).prop('name')).toBe('1');
 });
 
-test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
-  const element = (
-    <ListField name="x" initialCount={3} label="ListFieldLabel" />
-  );
+test('<ListField> - renders proper number of optional values after add new value', () => {
+  const element = <ListField name="x" label="ListFieldLabel" />;
   const onChange = jest.fn();
   const wrapper = mount(
     element,
     createContext(
       { x: { type: Array, optional: true }, 'x.$': { type: String } },
       { onChange },
+      {
+        x: [undefined, undefined, undefined],
+      },
     ),
   );
   expect(wrapper.find(ListAddField).simulate('click')).toBeTruthy();

--- a/packages/uniforms-unstyled/__tests__/_createContext.ts
+++ b/packages/uniforms-unstyled/__tests__/_createContext.ts
@@ -7,13 +7,14 @@ const randomId = randomIds();
 export default function createContext(
   schema?: object,
   context?: Partial<Context<any>>,
+  model?: object,
 ): { context: Context<any> } {
   return {
     context: {
       changed: false,
       changedMap: {},
       error: null,
-      model: {},
+      model: model ?? {},
       name: [],
       onChange() {},
       onSubmit() {},

--- a/packages/uniforms-unstyled/src/ListAddField.tsx
+++ b/packages/uniforms-unstyled/src/ListAddField.tsx
@@ -8,15 +8,10 @@ import {
   useField,
 } from 'uniforms';
 
-export type ListAddFieldProps = HTMLFieldProps<
-  unknown,
-  HTMLSpanElement,
-  { initialCount?: number }
->;
+export type ListAddFieldProps = HTMLFieldProps<unknown, HTMLSpanElement>;
 
 function ListAdd({
   disabled,
-  initialCount,
   name,
   readOnly,
   value,
@@ -24,10 +19,11 @@ function ListAdd({
 }: ListAddFieldProps) {
   const nameParts = joinName(null, name);
   const parentName = joinName(nameParts.slice(0, -1));
-  const parent = useField<
-    { initialCount?: number; maxCount?: number },
-    unknown[]
-  >(parentName, { initialCount }, { absoluteName: true })[0];
+  const parent = useField<{ maxCount?: number }, unknown[]>(
+    parentName,
+    {},
+    { absoluteName: true },
+  )[0];
 
   const limitNotReached =
     !disabled && !(parent.maxCount! <= parent.value!.length);

--- a/packages/uniforms-unstyled/src/ListField.tsx
+++ b/packages/uniforms-unstyled/src/ListField.tsx
@@ -7,12 +7,11 @@ import ListItemField from './ListItemField';
 export type ListFieldProps = HTMLFieldProps<
   unknown[],
   HTMLUListElement,
-  { initialCount?: number; itemProps?: object }
+  { itemProps?: object }
 >;
 
 function List({
   children = <ListItemField name="$" />,
-  initialCount,
   itemProps,
   label,
   value,
@@ -23,7 +22,7 @@ function List({
       {label && (
         <label>
           {label}
-          <ListAddField initialCount={initialCount} name="$" />
+          <ListAddField name="$" />
         </label>
       )}
 

--- a/packages/uniforms/__suites__/ListField.tsx
+++ b/packages/uniforms/__suites__/ListField.tsx
@@ -29,11 +29,16 @@ export function testListField(
     expect(screen.getByText(/ListFieldLabel.*/)).toBeInTheDocument();
   });
 
-  test('<ListField> - renders correct numer of items with initialCount (specified)', () => {
-    render(<ListField name="x" initialCount={3} />, {
-      x: Array,
-      'x.$': String,
-    });
+  test('<ListField> - renders correct numer of items with model (specified)', () => {
+    render(
+      <ListField name="x" />,
+      {
+        x: Array,
+        'x.$': String,
+      },
+      undefined,
+      { x: [undefined, undefined, undefined] },
+    );
 
     expect(screen.getAllByRole('textbox')).toHaveLength(3);
   });
@@ -42,10 +47,12 @@ export function testListField(
     const itemProps = { 'data-xyz': 1 };
     const Child = jest.fn(() => <div />) as FC<any>;
     render(
-      <ListField name="x" initialCount={2} itemProps={itemProps}>
+      <ListField name="x" itemProps={itemProps}>
         <Child />
       </ListField>,
       { x: Array, 'x.$': String },
+      undefined,
+      { x: [undefined, undefined] },
     );
 
     expect(Child).toHaveBeenCalledTimes(2);
@@ -56,11 +63,13 @@ export function testListField(
   test('<ListField> - renders children (specified)', () => {
     const Child = jest.fn(() => <div />) as FC<any>;
     render(
-      <ListField name="x" initialCount={2}>
+      <ListField name="x">
         <Child />
         PlainText
       </ListField>,
       { x: Array, 'x.$': String },
+      undefined,
+      { x: [undefined, undefined] },
     );
 
     expect(Child).toHaveBeenCalledTimes(2);
@@ -69,10 +78,12 @@ export function testListField(
   test('<ListField> - renders children with correct name (children)', () => {
     const Child = jest.fn(() => <div data-testid="field" />) as FC<any>;
     render(
-      <ListField name="x" initialCount={2}>
+      <ListField name="x">
         <Child name="$" />
       </ListField>,
       { x: Array, 'x.$': String },
+      undefined,
+      { x: [undefined, undefined] },
     );
 
     expect(Child).toHaveBeenNthCalledWith(1, { name: '0' }, {});
@@ -80,20 +91,25 @@ export function testListField(
   });
 
   test('<ListField> - renders children with correct name (value)', () => {
-    render(<ListField name="x" initialCount={2} />, {
-      x: Array,
-      'x.$': String,
-    });
+    render(
+      <ListField name="x" />,
+      {
+        x: Array,
+        'x.$': String,
+      },
+      undefined,
+      { x: [undefined, undefined] },
+    );
 
     const inputs = screen.getAllByRole('textbox');
     expect(inputs[0]).toHaveAttribute('name', 'x.0');
     expect(inputs[1]).toHaveAttribute('name', 'x.1');
   });
 
-  test('<ListField> - renders proper number of optional values after add new value (with initialCount)', () => {
+  test('<ListField> - renders proper number of optional values after add new value', () => {
     const onChange = jest.fn();
     render(
-      <ListField name="x" initialCount={3} label="ListFieldLabel" />,
+      <ListField name="x" label="ListFieldLabel" />,
       { x: { type: Array, optional: true }, 'x.$': String },
       { onChange },
     );
@@ -102,11 +118,6 @@ export function testListField(
     expect(addField).toBeTruthy();
     userEvent.click(addField!);
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenLastCalledWith('x', [
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    ]);
+    expect(onChange).toHaveBeenLastCalledWith('x', [undefined]);
   });
 }

--- a/packages/uniforms/__suites__/render.tsx
+++ b/packages/uniforms/__suites__/render.tsx
@@ -10,12 +10,13 @@ export function render(
   element: ReactElement,
   schema: SimpleSchemaDefinition,
   contextValueExtension?: Partial<Context<unknown>>,
+  initialModel?: object,
 ) {
   const contextValue = {
     changed: false,
     changedMap: {},
     error: null,
-    model: {},
+    model: initialModel ?? {},
     name: [],
     onChange() {},
     onSubmit() {},

--- a/packages/uniforms/src/Bridge.ts
+++ b/packages/uniforms/src/Bridge.ts
@@ -75,12 +75,12 @@ export abstract class Bridge {
   // `props` are this field instance props. If a field is rendered multiple
   // times, this function will be called multiple times, possibly with different
   // `props`.
-  getInitialValue(name: string, props: Record<string, any>): any {
+  getInitialValue(name: string): any {
     return invariant(
       false,
       '%s have not implemented `getInitialValue` method (args=%o).',
       this.constructor.name,
-      { name, props },
+      { name },
     );
   }
 

--- a/packages/uniforms/src/filterDOMProps.ts
+++ b/packages/uniforms/src/filterDOMProps.ts
@@ -40,7 +40,6 @@ filterDOMProps.register(
   'field',
   'fieldType',
   'fields',
-  'initialCount',
   'name',
   'onChange',
   'transform',

--- a/packages/uniforms/src/types.ts
+++ b/packages/uniforms/src/types.ts
@@ -92,7 +92,6 @@ declare module '.' {
     field: never;
     fieldType: never;
     fields: never;
-    initialCount: never;
     label: never;
     name: never;
     onChange: never;

--- a/packages/uniforms/src/useField.tsx
+++ b/packages/uniforms/src/useField.tsx
@@ -89,7 +89,7 @@ export function useField<
   if (usesInitialValue) {
     if (!onChangeCalled.current) {
       if (value === undefined) {
-        value = context.schema.getInitialValue(name, props);
+        value = context.schema.getInitialValue(name);
         initialValue = value;
       } else if (props.value !== undefined && props.value !== valueFromModel) {
         initialValue = props.value;

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Introduction": ["what-are-uniforms", "motivation", "compare-matrix"],
-    "Getting Started": ["installation", "faq", "migrating-2-to-3"],
+    "Getting Started": ["installation", "faq", "migrating-3-to-4", "migrating-2-to-3"],
     "Tutorials": [
       "tutorials-basic-uniforms-usage",
       "tutorials-customizing-your-form-layout",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,12 @@
 {
   "docs": {
     "Introduction": ["what-are-uniforms", "motivation", "compare-matrix"],
-    "Getting Started": ["installation", "faq", "migrating-3-to-4", "migrating-2-to-3"],
+    "Getting Started": [
+      "installation",
+      "faq",
+      "migrating-3-to-4",
+      "migrating-2-to-3"
+    ],
     "Tutorials": [
       "tutorials-basic-uniforms-usage",
       "tutorials-customizing-your-form-layout",


### PR DESCRIPTION
Fixes #1048

Removed support for `initialCount` property on list fields and bridges. `getInitialValue` now doesn't require props being passed to it so it is now memoized. It has also been removed from `filterDomProps`.

Note: Reopened for Hacktoberfest contribution.