### PR TITLE
Adjusted prettier command to work on Windows command shell.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "install": "lerna bootstrap --hoist && npm run build && husky install",
     "lint": "npm run lint:code && npm run lint:text && npm run lint:types",
     "lint:code": "eslint --cache --cache-location node_modules/.cache/eslint --cache-strategy content --ext js,ts,tsx .",
-    "lint:text": "prettier --check '**/*.{json,md,mdx,yml}'",
+    "lint:text": "prettier --check \"**/*.{json,md,mdx,yml}\"",
     "lint:types": "npm run build",
     "prereset": "npm run clean",
     "pretest": "npm run lint",


### PR DESCRIPTION
Single quotes were not parsed correctly and always reported that there are no files to check on Windows command shell. Using double quotes instead makes it work on the relevant shell environments.