### PR TITLE
Update uniforms docs

### DIFF
--- a/docs/api-fields.md
+++ b/docs/api-fields.md
@@ -110,7 +110,8 @@ A checkbox.
 ```tsx
 import { BoolField } from 'uniforms-unstyled';
 import { useRef } from 'react'
-const ref = useRef()
+
+const inputRef = useRef();
 
 <BoolField
   appearance="checkbox" // Renders a material-ui Checkbox
@@ -125,7 +126,7 @@ const ref = useRef()
   helpClassName="a b c"
   inline
   inputClassName="a b c"
-  inputRef={ref}
+  inputRef={inputRef}
   labelBefore="Label"
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
@@ -170,7 +171,8 @@ const ref = useRef()
 ```tsx
 import { DateField } from 'uniforms-unstyled';
 import { useRef } from 'react'
-const ref = useRef()
+
+const inputRef = useRef();
 
 <DateField
   extra="Extra Feedback or Help"
@@ -185,7 +187,7 @@ const ref = useRef()
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref}
+  inputRef={inputRef}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -367,7 +369,8 @@ A textarea.
 ```tsx
 import { LongTextField } from 'uniforms-unstyled';
 import { useRef } from 'react'
-const ref = useRef()
+
+const inputRef = useRef();
 
 <LongTextField
   extra="Extra Feedback or Help"
@@ -381,7 +384,7 @@ const ref = useRef()
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref}
+  inputRef={inputRef}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -445,7 +448,8 @@ A numeric input field.
 ```tsx
 import { NumField } from 'uniforms-unstyled';
 import { useRef } from 'react'
-const ref = useRef()
+
+const inputRef = useRef();
 
 <NumField
   decimal
@@ -460,7 +464,7 @@ const ref = useRef()
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref}
+  inputRef={inputRef}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -541,7 +545,8 @@ import { RadioField } from 'uniforms-unstyled';
 ```tsx
 import { SelectField } from 'uniforms-unstyled';
 import { useRef } from 'react'
-const ref = useRef()
+
+const inputRef = useRef();
 
 <SelectField
   allowedValues={[value1, value2 /* ... */]}
@@ -552,7 +557,7 @@ const ref = useRef()
   helpClassName="a b c"
   inline
   inputClassName="a b c"
-  inputRef={ref}
+  inputRef={inputRef}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -579,10 +584,11 @@ const ref = useRef()
 
 ```tsx
 import { SubmitField } from 'uniforms-unstyled';
-import { useRef } from 'react'
-const ref = useRef()
+import { useRef } from 'react';
 
-<SubmitField inputClassName="a b c" inputRef={ref} />;
+const inputRef = useRef();
+
+<SubmitField inputClassName="a b c" inputRef={inputRef} />;
 ```
 
 ### `TextField`
@@ -612,7 +618,8 @@ const ref = useRef()
 ```tsx
 import { TextField } from 'uniforms-unstyled';
 import { useRef } from 'react'
-const ref = useRef()
+
+const inputRef = useRef();
 
 <TextField
   extra="Extra Feedback or Help"
@@ -626,7 +633,7 @@ const ref = useRef()
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref}
+  inputRef={inputRef}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label

--- a/docs/api-fields.md
+++ b/docs/api-fields.md
@@ -109,6 +109,8 @@ A checkbox.
 
 ```tsx
 import { BoolField } from 'uniforms-unstyled';
+import { useRef } from 'react'
+const ref = useRef()
 
 <BoolField
   appearance="checkbox" // Renders a material-ui Checkbox
@@ -123,7 +125,7 @@ import { BoolField } from 'uniforms-unstyled';
   helpClassName="a b c"
   inline
   inputClassName="a b c"
-  inputRef={ref => {}}
+  inputRef={ref}
   labelBefore="Label"
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
@@ -167,6 +169,8 @@ import { BoolField } from 'uniforms-unstyled';
 
 ```tsx
 import { DateField } from 'uniforms-unstyled';
+import { useRef } from 'react'
+const ref = useRef()
 
 <DateField
   extra="Extra Feedback or Help"
@@ -181,7 +185,7 @@ import { DateField } from 'uniforms-unstyled';
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref => {}}
+  inputRef={ref}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -362,6 +366,8 @@ A textarea.
 
 ```tsx
 import { LongTextField } from 'uniforms-unstyled';
+import { useRef } from 'react'
+const ref = useRef()
 
 <LongTextField
   extra="Extra Feedback or Help"
@@ -375,7 +381,7 @@ import { LongTextField } from 'uniforms-unstyled';
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref => {}}
+  inputRef={ref}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -438,6 +444,8 @@ A numeric input field.
 
 ```tsx
 import { NumField } from 'uniforms-unstyled';
+import { useRef } from 'react'
+const ref = useRef()
 
 <NumField
   decimal
@@ -452,7 +460,7 @@ import { NumField } from 'uniforms-unstyled';
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref => {}}
+  inputRef={ref}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -532,6 +540,8 @@ import { RadioField } from 'uniforms-unstyled';
 
 ```tsx
 import { SelectField } from 'uniforms-unstyled';
+import { useRef } from 'react'
+const ref = useRef()
 
 <SelectField
   allowedValues={[value1, value2 /* ... */]}
@@ -542,7 +552,7 @@ import { SelectField } from 'uniforms-unstyled';
   helpClassName="a b c"
   inline
   inputClassName="a b c"
-  inputRef={ref => {}}
+  inputRef={ref}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label
@@ -569,8 +579,10 @@ import { SelectField } from 'uniforms-unstyled';
 
 ```tsx
 import { SubmitField } from 'uniforms-unstyled';
+import { useRef } from 'react'
+const ref = useRef()
 
-<SubmitField inputClassName="a b c" inputRef={ref => {}} />;
+<SubmitField inputClassName="a b c" inputRef={ref} />;
 ```
 
 ### `TextField`
@@ -599,6 +611,8 @@ import { SubmitField } from 'uniforms-unstyled';
 
 ```tsx
 import { TextField } from 'uniforms-unstyled';
+import { useRef } from 'react'
+const ref = useRef()
 
 <TextField
   extra="Extra Feedback or Help"
@@ -612,7 +626,7 @@ import { TextField } from 'uniforms-unstyled';
   iconLeft="user"
   iconProps={{onClick() {}}}
   inputClassName="a b c"
-  inputRef={ref => {}}
+  inputRef={ref}
   labelClassName="a b c" // You can either specify them as a single string
   labelClassName=[ 'a', 'b', 'c' ] // or as an array of strings
   labelCol={{offset: 2}} // 'ant-col-offset-2' on label

--- a/docs/api-forms.md
+++ b/docs/api-forms.md
@@ -72,6 +72,26 @@ however, there will be validation checks.
 
 ```tsx
 import { ValidatedForm } from 'uniforms'; // Or from the theme package.
+import { useRef } from 'react';
+
+const formRef = useRef();
+
+const formAction = () => {
+  // Reset form.
+  //   It will reset changed state, model state in AutoForm, validation
+  //   state in ValidatedForm and rerender.
+  formRef.reset();
+
+  // Trigger form change.
+  //   It's a programmatic equivalent of a change event.
+  formRef.change(key, value);
+
+  // Submit form.
+  //   It's a programmatic equivalent of a submit event. Returns a promise,
+  //   which will either resolve with submitted form or reject with
+  //   validation error in ValidatedForm.
+  formRef.submit();
+};
 
 <ValidatedForm
   onValidate={async (model, error) => {
@@ -90,23 +110,7 @@ import { ValidatedForm } from 'uniforms'; // Or from the theme package.
   }}
   validate="onChangeAfterSubmit"
   validator={{ clean: true }}
-  ref={form => {
-    // Validate form with the current model.
-    //   Returns a Promise, which rejects with a validation error or
-    //   resolves without any value. Note, that it resolves/rejects AFTER
-    //   the component is rerendered.
-    form.validate();
-
-    // Validate form with key set to value.
-    //   You can use it to check, if a given value will pass the
-    //   validation or not. Returns validation Promise, as described above.
-    form.validate(key, value);
-
-    // Validate form with the given model.
-    //   Rather internal function. Returns validation Promise, as described
-    //   above.
-    form.validateModel(model);
-  }}
+  ref={formRef}
 />;
 ```
 
@@ -167,6 +171,26 @@ However, `BaseForm` is not self-managed, so you won't be able to type anything u
 
 ```tsx
 import { BaseForm } from 'uniforms'; // Or from the theme package.
+import { useRef } from 'react';
+
+const formRef = useRef();
+
+const formAction = () => {
+  // Reset form.
+  //   It will reset changed state, model state in AutoForm, validation
+  //   state in ValidatedForm and rerender.
+  formRef.reset();
+
+  // Trigger form change.
+  //   It's a programmatic equivalent of a change event.
+  formRef.change(key, value);
+
+  // Submit form.
+  //   It's a programmatic equivalent of a submit event. Returns a promise,
+  //   which will either resolve with submitted form or reject with
+  //   validation error in ValidatedForm.
+  formRef.submit();
+};
 
 <BaseForm
   autosaveDelay={0}
@@ -204,22 +228,7 @@ import { BaseForm } from 'uniforms'; // Or from the theme package.
   readOnly={false}
   schema={myFormSchema}
   showInlineError
-  ref={form => {
-    // Reset form.
-    //   It will reset changed state, model state in AutoForm, validation
-    //   state in ValidatedForm and rerender.
-    form.reset();
-
-    // Trigger form change.
-    //   It's a programmatic equivalent of a change event.
-    form.change(key, value);
-
-    // Submit form.
-    //   It's a programmatic equivalent of a submit event. Returns a promise,
-    //   which will either resolve with submitted form or reject with
-    //   validation error in ValidatedForm.
-    form.submit();
-  }}
+  ref={formRef}
 />;
 ```
 
@@ -270,16 +279,14 @@ Every form has autosave functionality. If you set an `autosave` prop, then every
 You can use [React `ref` prop](https://facebook.github.io/react/docs/more-about-refs.html) to manually access form methods. Example usage:
 
 ```tsx
+import { useRef } from 'react';
+
 const MyForm = ({ schema, onSubmit }) => {
-  let formRef;
+  const ref = useRef();
 
   return (
     <section>
-      <AutoForm
-        ref={ref => (formRef = ref)}
-        schema={schema}
-        onSubmit={onSubmit}
-      />
+      <AutoForm ref={ref} schema={schema} onSubmit={onSubmit} />
       <small onClick={() => formRef.reset()}>Reset</small>
       <small onClick={() => formRef.submit()}>Submit</small>
     </section>

--- a/docs/api-forms.md
+++ b/docs/api-forms.md
@@ -282,11 +282,11 @@ You can use [React `ref` prop](https://facebook.github.io/react/docs/more-about-
 import { useRef } from 'react';
 
 const MyForm = ({ schema, onSubmit }) => {
-  const ref = useRef();
+  const formRef = useRef();
 
   return (
     <section>
-      <AutoForm ref={ref} schema={schema} onSubmit={onSubmit} />
+      <AutoForm ref={formRef} schema={schema} onSubmit={onSubmit} />
       <small onClick={() => formRef.reset()}>Reset</small>
       <small onClick={() => formRef.submit()}>Submit</small>
     </section>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -219,11 +219,11 @@ function transform(mode, model) {
 You can take a reference to the field and manually trigger `.focus()`:
 
 ```tsx
-import { useRef } from 'react'
+import { useRef } from 'react';
 
-const ref = useRef()
+const inputRef = useRef();
 
-<AutoField name="firstName" inputRef={ref} />
+<AutoField name="firstName" inputRef={inputRef} />;
 ```
 
 ### How can I create a multi-step form?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -138,16 +138,14 @@ These methods are:
 - `validate()` _(added in `ValidatedForm`)_
 
 ```tsx
+import { useRef } from 'react';
+
 const MyForm = ({ schema, onSubmit }) => {
-  let formRef;
+  const formRef = useRef();
 
   return (
     <section>
-      <AutoForm
-        ref={ref => (formRef = ref)}
-        schema={schema}
-        onSubmit={onSubmit}
-      />
+      <AutoForm ref={formRef} schema={schema} onSubmit={onSubmit} />
       <small onClick={() => formRef.reset()}>Reset</small>
       <small onClick={() => formRef.submit()}>Submit</small>
     </section>
@@ -221,7 +219,11 @@ function transform(mode, model) {
 You can take a reference to the field and manually trigger `.focus()`:
 
 ```tsx
-<AutoField name="firstName" inputRef={field => field.focus()} />
+import { useRef } from 'react'
+
+const ref = useRef()
+
+<AutoField name="firstName" inputRef={ref} />
 ```
 
 ### How can I create a multi-step form?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -304,14 +304,12 @@ The provider for this context is rendered by `BaseForm`, and in turn all the oth
 
 There are two most common issues causing this problem:
 
-1. The component calling this function does not have a Form component above it anywhere in the component tree. To fix
+1. **The component calling this function does not have a Form component above it anywhere in the component tree.**
 
-   this, wrap this component within a parent Form component (does not have to be direct).
+   To fix this, wrap this component within a parent Form component (does not have to be direct).
 
-2. There are multiple versions of `uniforms` installed in your `node_modules`. This usually happens when you have
+2. **There are multiple versions of `uniforms` installed in your `node_modules`**.
 
-   more than one version of the core `uniforms` package installed which can happen when you have a mismatch of
+   This usually happens when you have installed more than one version of the core `uniforms` package. It can happen when you have a mismatch of versions between any of your `uniforms` related dependencies.
 
-   versions between any of your `uniforms` related dependencies. Ensure all your versions are matching,
-
-   clean any `node_modules` directories and reinstall dependencies to resolve this error.
+   Ensure all your versions match, clean any `node_modules` directories and reinstall dependencies to resolve this error.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -312,4 +312,4 @@ There are two most common issues causing this problem:
 
    This usually happens when you have installed more than one version of the core `uniforms` package. It can happen when you have a mismatch of versions between any of your `uniforms` related dependencies.
 
-   Ensure all your versions match, clean any `node_modules` directories and reinstall dependencies to resolve this error.
+   Ensure all your uniforms packages versions, clean any `node_modules` directories and reinstall dependencies to resolve this error.


### PR DESCRIPTION
## Changes
- Fixed typos
- Replaced legacy ref with `useRef`

### Notes & problems
In reality, if you use the `useForm` without passing in the type (for example, to `AutoForm`), you won't have it typed correctly - you won't be able to call, for example, `formRef.current.reset()`. An explicit type needs to be given to access the methods of the referenced element.