### PR TITLE
Removed props from `Bridge.getProps`

### DIFF
--- a/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/__tests__/GraphQLBridge.ts
@@ -260,59 +260,6 @@ describe('GraphQLBridge', () => {
               placeholder: 'Post ID',
               required: true,
             });
-            expect(bridgeT.getProps('id', { label: true })).toEqual({
-              allowedValues: [1, 2, 3],
-              label: 'Post ID',
-              placeholder: 'Post ID',
-              required: true,
-            });
-          });
-        });
-      });
-
-      describe('when props.label is a string', () => {
-        it('should use label from props', () => {
-          expect(bridgeT.getProps('title', { label: 'Overriden' })).toEqual({
-            allowedValues: ['a', 'b', 'Some Title'],
-            label: false,
-            required: false,
-            transform: expect.any(Function),
-            options: [
-              { label: 1, value: 'a' },
-              { label: 2, value: 'b' },
-              { label: 3, value: 'Some Title' },
-            ],
-            initialValue: 'Some Title',
-          });
-          expect(bridgeT.getProps('title', { label: '' })).toEqual({
-            allowedValues: ['a', 'b', 'Some Title'],
-            label: false,
-            required: false,
-            transform: expect.any(Function),
-            options: [
-              { label: 1, value: 'a' },
-              { label: 2, value: 'b' },
-              { label: 3, value: 'Some Title' },
-            ],
-            initialValue: 'Some Title',
-          });
-        });
-      });
-
-      describe('when props.label is false or null (unset)', () => {
-        it('should display empty label', () => {
-          expect(bridgeT.getProps('id', { label: false })).toEqual({
-            allowedValues: [1, 2, 3],
-            label: 'Post ID',
-            placeholder: 'Post ID',
-            required: true,
-          });
-
-          expect(bridgeT.getProps('id', { label: null })).toEqual({
-            allowedValues: [1, 2, 3],
-            label: 'Post ID',
-            placeholder: 'Post ID',
-            required: true,
           });
         });
       });
@@ -327,89 +274,11 @@ describe('GraphQLBridge', () => {
       });
     });
 
-    it('works with allowedValues from props', () => {
-      expect(bridgeI.getProps('id', { allowedValues: [1] })).toEqual({
-        label: 'Post ID',
-        placeholder: 'Post ID',
-        required: true,
-        allowedValues: [1, 2, 3],
-      });
-    });
-
     it('works with custom component', () => {
       expect(bridgeI.getProps('author')).toEqual({
         label: 'Author',
         required: true,
         component: 'div',
-      });
-    });
-
-    it('works with label (custom)', () => {
-      expect(bridgeI.getProps('id', { label: 'ID' })).toEqual({
-        label: 'Post ID',
-        placeholder: 'Post ID',
-        required: true,
-        allowedValues: [1, 2, 3],
-      });
-    });
-
-    it('works with label (true)', () => {
-      expect(bridgeI.getProps('id', { label: true })).toEqual({
-        label: 'Post ID',
-        placeholder: 'Post ID',
-        required: true,
-        allowedValues: [1, 2, 3],
-      });
-    });
-
-    it('works with label (falsy)', () => {
-      expect(bridgeI.getProps('id', { label: null })).toEqual({
-        label: 'Post ID',
-        placeholder: 'Post ID',
-        required: true,
-        allowedValues: [1, 2, 3],
-      });
-    });
-
-    it('works with placeholder (custom)', () => {
-      expect(bridgeI.getProps('id', { placeholder: 'Post ID' })).toEqual({
-        label: 'Post ID',
-        placeholder: 'Post ID',
-        required: true,
-        allowedValues: [1, 2, 3],
-      });
-    });
-
-    it('works with placeholder (true)', () => {
-      expect(bridgeI.getProps('id', { placeholder: true })).toEqual({
-        label: 'Post ID',
-        placeholder: 'Post ID',
-        required: true,
-        allowedValues: [1, 2, 3],
-      });
-    });
-
-    it('works with placeholder (falsy)', () => {
-      expect(bridgeI.getProps('id', { placeholder: null })).toEqual({
-        label: 'Post ID',
-        placeholder: 'Post ID',
-        required: true,
-        allowedValues: [1, 2, 3],
-      });
-    });
-
-    it('works with placeholder (extra.placeholder === undefined)', () => {
-      expect(bridgeI.getProps('title', { placeholder: true })).toEqual({
-        allowedValues: ['a', 'b', 'Some Title'],
-        label: false,
-        required: false,
-        transform: expect.any(Function),
-        options: [
-          { label: 1, value: 'a' },
-          { label: 2, value: 'b' },
-          { label: 3, value: 'Some Title' },
-        ],
-        initialValue: 'Some Title',
       });
     });
 
@@ -439,28 +308,6 @@ describe('GraphQLBridge', () => {
       expect(bridgeI.getProps('votes').transform('b')).toBe(2);
       expect(bridgeI.getProps('votes').allowedValues[0]).toBe('a');
       expect(bridgeI.getProps('votes').allowedValues[1]).toBe('b');
-    });
-
-    it('works with options from props', () => {
-      expect(
-        bridgeI.getProps('votes', { options: { c: 1, d: 2 } }).transform('c'),
-      ).toBe(1);
-      expect(
-        bridgeI.getProps('votes', { options: { c: 1, d: 2 } }).transform('d'),
-      ).toBe(2);
-      expect(
-        bridgeI.getProps('votes', { options: { c: 1, d: 2 } }).allowedValues[0],
-      ).toBe('c');
-      expect(
-        bridgeI.getProps('votes', { options: { c: 1, d: 2 } }).allowedValues[1],
-      ).toBe('d');
-    });
-
-    it('works with other props', () => {
-      expect(bridgeI.getProps('category', { x: 1, y: 1 })).toEqual({
-        label: 'Category',
-        required: true,
-      });
     });
 
     describe('when enum', () => {

--- a/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
+++ b/packages/uniforms-bridge-graphql/src/GraphQLBridge.ts
@@ -30,6 +30,7 @@ export default class GraphQLBridge extends Bridge {
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
     this.getInitialValue = memoize(this.getInitialValue.bind(this));
+    this.getProps = memoize(this.getProps.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
   }
@@ -103,7 +104,7 @@ export default class GraphQLBridge extends Bridge {
     return defaultValue ?? this.extras[name]?.initialValue;
   }
 
-  getProps(nameNormal: string, fieldProps?: Record<string, any>) {
+  getProps(nameNormal: string) {
     const nameGeneric = nameNormal.replace(/\.\d+/g, '.$');
 
     const field = this.getField(nameGeneric);
@@ -123,7 +124,7 @@ export default class GraphQLBridge extends Bridge {
     type OptionDict = Record<string, string>;
     type OptionList = { label: string; value: unknown }[];
     type Options = OptionDict | OptionList;
-    const options: Options = fieldProps?.options || props.options;
+    const options: Options = props.options;
     if (options) {
       if (Array.isArray(options)) {
         props.allowedValues = options.map(option => option.value);

--- a/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/__tests__/JSONSchemaBridge.ts
@@ -673,17 +673,7 @@ describe('JSONSchemaBridge', () => {
       });
     });
 
-    it('works with allowedValues from props', () => {
-      expect(
-        bridge.getProps('shippingAddress.type', { allowedValues: [1] }),
-      ).toEqual({
-        allowedValues: ['residential', 'business'],
-        label: 'Type',
-        required: true,
-      });
-    });
-
-    it('works with allowedValues from props', () => {
+    it('works with custom props', () => {
       expect(bridge.getProps('forcedRequired')).toEqual({
         label: 'Forced required',
         required: true,
@@ -702,67 +692,6 @@ describe('JSONSchemaBridge', () => {
       expect(bridge.getProps('withLabel')).toEqual({
         label: 'Example',
         required: false,
-      });
-    });
-
-    it('works with label (custom)', () => {
-      expect(bridge.getProps('dateOfBirth', { label: 'Death' })).toEqual({
-        label: 'Date of birth',
-        required: true,
-      });
-    });
-
-    it('works with label (true)', () => {
-      expect(bridge.getProps('dateOfBirth', { label: true })).toEqual({
-        label: 'Date of birth',
-        required: true,
-      });
-    });
-
-    it('works with property title as default label', () => {
-      expect(bridge.getProps('hasAJob', { label: true })).toEqual({
-        allowedValues: undefined,
-        label: 'Currently Employed',
-        options: undefined,
-        placeholder: undefined,
-        required: false,
-      });
-    });
-
-    it('works with placeholder (custom)', () => {
-      expect(bridge.getProps('email.work', { placeholder: 'Email' })).toEqual({
-        label: 'Work',
-        required: true,
-      });
-    });
-
-    it('works with placeholder (true)', () => {
-      expect(bridge.getProps('email.work', { placeholder: true })).toEqual({
-        label: 'Work',
-        required: true,
-      });
-    });
-
-    it('works with placeholder (falsy)', () => {
-      expect(bridge.getProps('email.work', { placeholder: null })).toEqual({
-        label: 'Work',
-        required: true,
-      });
-    });
-
-    it('works with placeholder (label falsy)', () => {
-      expect(
-        bridge.getProps('email.work', { label: null, placeholder: true }),
-      ).toEqual({
-        label: 'Work',
-        required: true,
-      });
-
-      expect(
-        bridge.getProps('email.work', { label: false, placeholder: true }),
-      ).toEqual({
-        label: 'Work',
-        required: true,
       });
     });
 
@@ -799,14 +728,6 @@ describe('JSONSchemaBridge', () => {
       expect(bridge.getProps('salary').allowedValues[1]).toBe('medium');
     });
 
-    it('works with options from props', () => {
-      const props = { options: { minimal: 4000, avarage: 8000 } };
-      expect(bridge.getProps('salary', props).transform('minimal')).toBe(4000);
-      expect(bridge.getProps('salary', props).transform('avarage')).toBe(8000);
-      expect(bridge.getProps('salary', props).allowedValues[0]).toBe('minimal');
-      expect(bridge.getProps('salary', props).allowedValues[1]).toBe('avarage');
-    });
-
     it('works with type', () => {
       expect(bridge.getProps('password')).toEqual({
         label: 'Password',
@@ -826,12 +747,10 @@ describe('JSONSchemaBridge', () => {
     });
 
     it('works with other props', () => {
-      expect(bridge.getProps('personalData.firstName', { x: 1, y: 1 })).toEqual(
-        {
-          label: 'First name',
-          required: false,
-        },
-      );
+      expect(bridge.getProps('personalData.firstName')).toEqual({
+        label: 'First name',
+        required: false,
+      });
     });
 
     it('works with allOf in items', () => {

--- a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
+++ b/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts
@@ -242,7 +242,7 @@ export default class JSONSchemaBridge extends Bridge {
     return undefined;
   }
 
-  getProps(name: string, fieldProps?: Record<string, any>) {
+  getProps(name: string) {
     const field = this.getField(name);
     const props = Object.assign(
       {},
@@ -273,7 +273,7 @@ export default class JSONSchemaBridge extends Bridge {
     type OptionDict = Record<string, string>;
     type OptionList = { label: string; value: unknown }[];
     type Options = OptionDict | OptionList;
-    const options: Options = fieldProps?.options || props.options;
+    const options: Options = props.options;
     if (options) {
       if (Array.isArray(options)) {
         props.allowedValues = options.map(option => option.value);

--- a/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/__tests__/SimpleSchema2Bridge.ts
@@ -189,13 +189,6 @@ describe('SimpleSchema2Bridge', () => {
       });
     });
 
-    it('works with allowedValues from props', () => {
-      expect(bridge.getProps('o', { allowedValues: ['O'] })).toEqual({
-        label: 'O',
-        required: true,
-      });
-    });
-
     it('works with custom component', () => {
       expect(bridge.getProps('l')).toEqual({
         label: 'L',
@@ -246,33 +239,11 @@ describe('SimpleSchema2Bridge', () => {
       expect(bridge.getProps('r').allowedValues[1]).toBe('b');
     });
 
-    it('works with options from props', () => {
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).transform('c'),
-      ).toBe(1);
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).transform('d'),
-      ).toBe(2);
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).allowedValues[0],
-      ).toBe('c');
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).allowedValues[1],
-      ).toBe('d');
-    });
-
     it('works with transform', () => {
       expect(bridge.getProps('p')).toEqual({
         label: 'P',
         required: true,
         transform: noopTransform,
-      });
-    });
-
-    it('works with transform from props', () => {
-      expect(bridge.getProps('p', { transform: () => {} })).toEqual({
-        label: 'P',
-        required: true,
       });
     });
 

--- a/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
+++ b/packages/uniforms-bridge-simple-schema-2/src/SimpleSchema2Bridge.ts
@@ -17,6 +17,7 @@ export default class SimpleSchema2Bridge extends Bridge {
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
     this.getInitialValue = memoize(this.getInitialValue.bind(this));
+    this.getProps = memoize(this.getProps.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
   }
@@ -105,8 +106,7 @@ export default class SimpleSchema2Bridge extends Bridge {
     return undefined;
   }
 
-  // eslint-disable-next-line complexity
-  getProps(name: string, fieldProps?: Record<string, any>) {
+  getProps(name: string) {
     const { type: fieldType, ...props } = this.getField(name);
     props.required = !props.optional;
 
@@ -126,7 +126,7 @@ export default class SimpleSchema2Bridge extends Bridge {
     type OptionDict = Record<string, string>;
     type OptionList = { label: string; value: unknown }[];
     type Options = OptionDict | OptionList | (() => OptionDict | OptionList);
-    let options: Options = fieldProps?.options || props.options;
+    let options: Options = props.options;
     if (options) {
       if (typeof options === 'function') {
         options = options();
@@ -142,12 +142,12 @@ export default class SimpleSchema2Bridge extends Bridge {
       }
     } else if (fieldType === Array) {
       try {
-        const itemProps = this.getProps(`${name}.$`, fieldProps);
-        if (itemProps.allowedValues && !fieldProps?.allowedValues) {
+        const itemProps = this.getProps(`${name}.$`);
+        if (itemProps.allowedValues) {
           props.allowedValues = itemProps.allowedValues;
         }
 
-        if (itemProps.transform && !fieldProps?.transform) {
+        if (itemProps.transform) {
           props.transform = itemProps.transform;
         }
       } catch (_) {

--- a/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/__tests__/SimpleSchemaBridge.ts
@@ -214,13 +214,6 @@ describe('SimpleSchemaBridge', () => {
       });
     });
 
-    it('works with allowedValues from props', () => {
-      expect(bridge.getProps('o', { allowedValues: ['O'] })).toEqual({
-        label: 'O',
-        required: true,
-      });
-    });
-
     it('works with custom component', () => {
       expect(bridge.getProps('l')).toEqual({
         label: 'L',
@@ -263,33 +256,11 @@ describe('SimpleSchemaBridge', () => {
       expect(bridge.getProps('r').allowedValues[1]).toBe('b');
     });
 
-    it('works with options from props', () => {
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).transform('c'),
-      ).toBe(1);
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).transform('d'),
-      ).toBe(2);
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).allowedValues[0],
-      ).toBe('c');
-      expect(
-        bridge.getProps('s', { options: { c: 1, d: 2 } }).allowedValues[1],
-      ).toBe('d');
-    });
-
     it('works with transform', () => {
       expect(bridge.getProps('p')).toEqual({
         label: 'P',
         required: true,
         transform: noopTransform,
-      });
-    });
-
-    it('works with transform from props', () => {
-      expect(bridge.getProps('p', { transform: () => {} })).toEqual({
-        label: 'P',
-        required: true,
       });
     });
 

--- a/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
+++ b/packages/uniforms-bridge-simple-schema/src/SimpleSchemaBridge.ts
@@ -14,6 +14,7 @@ export default class SimpleSchemaBridge extends Bridge {
     // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
     this.getInitialValue = memoize(this.getInitialValue.bind(this));
+    this.getProps = memoize(this.getProps.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
     this.getType = memoize(this.getType.bind(this));
   }
@@ -96,8 +97,7 @@ export default class SimpleSchemaBridge extends Bridge {
     return undefined;
   }
 
-  // eslint-disable-next-line complexity
-  getProps(name: string, fieldProps?: Record<string, any>) {
+  getProps(name: string) {
     const { type: fieldType, ...props } = this.getField(name);
     props.required = !props.optional;
 
@@ -113,7 +113,7 @@ export default class SimpleSchemaBridge extends Bridge {
     type OptionDict = Record<string, string>;
     type OptionList = { label: string; value: unknown }[];
     type Options = OptionDict | OptionList | (() => OptionDict | OptionList);
-    let options: Options = fieldProps?.options || props.options;
+    let options: Options = props.options;
     if (options) {
       if (typeof options === 'function') {
         options = options();
@@ -129,12 +129,12 @@ export default class SimpleSchemaBridge extends Bridge {
       }
     } else if (fieldType === Array) {
       try {
-        const itemProps = this.getProps(`${name}.$`, fieldProps);
-        if (itemProps.allowedValues && !fieldProps?.allowedValues) {
+        const itemProps = this.getProps(`${name}.$`);
+        if (itemProps.allowedValues) {
           props.allowedValues = itemProps.allowedValues;
         }
 
-        if (itemProps.transform && !fieldProps?.transform) {
+        if (itemProps.transform) {
           props.transform = itemProps.transform;
         }
       } catch (_) {

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -32,8 +32,12 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
   constructor(public schema: ZodObject<T>) {
     super();
 
+    // Memoize for performance and referential equality.
     this.getField = memoize(this.getField.bind(this));
+    this.getInitialValue = memoize(this.getInitialValue.bind(this));
+    this.getProps = memoize(this.getProps.bind(this));
     this.getSubfields = memoize(this.getSubfields.bind(this));
+    this.getType = memoize(this.getType.bind(this));
   }
 
   getError(name: string, error: unknown) {
@@ -83,10 +87,7 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
     return field;
   }
 
-  // TODO: The `fieldProps` argument will be removed in v4. See
-  // https://github.com/vazco/uniforms/issues/1048 for details.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getInitialValue(name: string, fieldProps?: Record<string, unknown>): unknown {
+  getInitialValue(name: string): unknown {
     const field = this.getField(name);
     if (field instanceof ZodArray) {
       const item = this.getInitialValue(joinName(name, '$'));
@@ -125,10 +126,7 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
     return undefined;
   }
 
-  // TODO: The `props` argument could be removed in v4, just like in the
-  // `getInitialValue` function.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getProps(name: string, fieldProps?: Record<string, unknown>) {
+  getProps(name: string) {
     const props: Record<string, unknown> = {
       label: upperFirst(lowerCase(joinName(null, name).slice(-1)[0])),
       required: true,

--- a/packages/uniforms/src/Bridge.ts
+++ b/packages/uniforms/src/Bridge.ts
@@ -89,12 +89,12 @@ export abstract class Bridge {
   // Additionally, `props` are this field instance props. If a field is rendered
   // multiple times, this function will be called multiple times, possibly with
   // different `props`.
-  getProps(name: string, props: Record<string, any>): Record<string, any> {
+  getProps(name: string): Record<string, any> {
     return invariant(
       false,
       '%s have not implemented `getProps` method (args=%o).',
       this.constructor.name,
-      { name, props },
+      { name },
     );
   }
 

--- a/packages/uniforms/src/useField.tsx
+++ b/packages/uniforms/src/useField.tsx
@@ -56,7 +56,7 @@ export function useField<
   const errorMessage = context.schema.getErrorMessage(name, context.error);
   const fieldType = context.schema.getType(name);
   const fields = context.schema.getSubfields(name);
-  const schemaProps = context.schema.getProps(name, { ...state, ...props });
+  const schemaProps = context.schema.getProps(name);
 
   const [label, labelFallback] = propagate(
     props.label,


### PR DESCRIPTION
In this pull request, I removed the second argument from `Bridge.getProps`, which is the same as we did with `getInitialValue` in #1185. The immediate benefit is that it becomes memoizable (and thus yields better performance), but also it wasn't really used for anything else than the `options`/`allowedValues`+`transform` handling, which we'll move to the components anyway via #806. (If you'll read the tests I removed you'll see they weren't really helpful.)