### PR TITLE
Loosened NumField `inputRef` type (closes #1230).

### DIFF
--- a/packages/uniforms-antd/src/NumField.tsx
+++ b/packages/uniforms-antd/src/NumField.tsx
@@ -8,7 +8,8 @@ export type NumFieldProps = FieldProps<
   number,
   // FIXME: Why `onReset` fails with `wrapField`?
   Omit<InputNumberProps, 'onReset'>,
-  { decimal?: boolean; inputRef?: Ref<typeof InputNumber> }
+  // FIXME: `unknown` ref; see https://github.com/vazco/uniforms/discussions/1230#discussioncomment-5158439
+  { decimal?: boolean; inputRef?: Ref<unknown> }
 >;
 
 function Num(props: NumFieldProps) {


### PR DESCRIPTION
As I wrote in https://github.com/vazco/uniforms/discussions/1230#discussioncomment-5240698, we'd need to update AntD to at least 4.19.0 to use the new `InputRef` type. However, when I tried to update it, I was not able to make it work in an `iframe` in our playground - it failed due to using `findDOMNode` from the top frame, i.e., incorrect `HTMLElement` class.

This workaround is not ideal, but should fix the problem reported in #1230.