### PR TITLE
Fixed Bootstrap 5 ListField controls (closes #1226).

### DIFF
--- a/packages/uniforms-bootstrap5/__tests__/ListAddField.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/ListAddField.tsx
@@ -27,7 +27,7 @@ test('<ListAddField> - prevents onClick when disabled', () => {
   const element = <ListAddField name="x.1" disabled />;
   const wrapper = mount(element, context());
 
-  expect(wrapper.find('[role="button"]').simulate('click')).toBeTruthy();
+  expect(wrapper.find('button').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
@@ -35,7 +35,7 @@ test('<ListAddField> - prevents onClick when limit reached', () => {
   const element = <ListAddField name="x.1" />;
   const wrapper = mount(element, context({ x: { maxCount: 0 } }));
 
-  expect(wrapper.find('[role="button"]').simulate('click')).toBeTruthy();
+  expect(wrapper.find('button').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
@@ -43,16 +43,6 @@ test('<ListAddField> - correctly reacts on click', () => {
   const element = <ListAddField name="x.1" value="y" />;
   const wrapper = mount(element, context());
 
-  expect(wrapper.find('[role="button"]').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
-});
-
-test('<ListAddField> - correctly reacts on keyboard enter key', () => {
-  const element = <ListAddField name="x.1" value="y" />;
-  const wrapper = mount(element, context());
-
-  expect(
-    wrapper.find('[role="button"]').simulate('keydown', { key: 'Enter' }),
-  ).toBeTruthy();
+  expect(wrapper.find('button').simulate('click')).toBeTruthy();
   expect(onChange).toHaveBeenLastCalledWith('x', ['y']);
 });

--- a/packages/uniforms-bootstrap5/__tests__/ListDelField.tsx
+++ b/packages/uniforms-bootstrap5/__tests__/ListDelField.tsx
@@ -27,7 +27,7 @@ test('<ListDelField> - prevents onClick when disabled', () => {
   const element = <ListDelField name="x.1" disabled />;
   const wrapper = mount(element, context());
 
-  expect(wrapper.find('[role="button"]').simulate('click')).toBeTruthy();
+  expect(wrapper.find('button').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
@@ -35,7 +35,7 @@ test('<ListDelField> - prevents onClick when limit reached', () => {
   const element = <ListDelField name="x.1" />;
   const wrapper = mount(element, context({ x: { minCount: 3 } }));
 
-  expect(wrapper.find('[role="button"]').simulate('click')).toBeTruthy();
+  expect(wrapper.find('button').simulate('click')).toBeTruthy();
   expect(onChange).not.toHaveBeenCalled();
 });
 
@@ -43,16 +43,6 @@ test('<ListDelField> - correctly reacts on click', () => {
   const element = <ListDelField name="x.1" />;
   const wrapper = mount(element, context());
 
-  expect(wrapper.find('[role="button"]').simulate('click')).toBeTruthy();
-  expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
-});
-
-test('<ListDelField> - correctly reacts on keyboard enter key', () => {
-  const element = <ListDelField name="x.1" />;
-  const wrapper = mount(element, context());
-
-  expect(
-    wrapper.find('[role="button"]').simulate('keydown', { key: 'Enter' }),
-  ).toBeTruthy();
+  expect(wrapper.find('button').simulate('click')).toBeTruthy();
   expect(onChange).toHaveBeenLastCalledWith('x', ['x', 'z']);
 });

--- a/packages/uniforms-bootstrap5/src/ListAddField.tsx
+++ b/packages/uniforms-bootstrap5/src/ListAddField.tsx
@@ -11,7 +11,7 @@ import {
 
 export type ListAddFieldProps = HTMLFieldProps<
   unknown,
-  HTMLDivElement,
+  HTMLButtonElement,
   { addIcon?: ReactNode }
 >;
 
@@ -32,30 +32,24 @@ function ListAdd({
     { absoluteName: true },
   )[0];
 
-  const limitNotReached =
-    !disabled && !(parent.maxCount! <= parent.value!.length);
-
-  function onAction(event: React.KeyboardEvent | React.MouseEvent) {
-    if (
-      limitNotReached &&
-      !readOnly &&
-      (!('key' in event) || event.key === 'Enter')
-    ) {
+  disabled ||= readOnly || parent.maxCount! <= parent.value!.length;
+  function onAction() {
+    if (!disabled) {
       parent.onChange(parent.value!.concat([cloneDeep(value)]));
     }
   }
 
   return (
-    <div
+    <button
       {...filterDOMProps(props)}
-      className={classnames('badge rounded-pill float-end', className)}
+      className={classnames('btn btn-secondary btn-sm float-end', className)}
+      disabled={disabled}
       onClick={onAction}
-      onKeyDown={onAction}
-      role="button"
       tabIndex={0}
+      type="button"
     >
       {addIcon}
-    </div>
+    </button>
   );
 }
 

--- a/packages/uniforms-bootstrap5/src/ListDelField.tsx
+++ b/packages/uniforms-bootstrap5/src/ListDelField.tsx
@@ -10,7 +10,7 @@ import {
 
 export type ListDelFieldProps = HTMLFieldProps<
   unknown,
-  HTMLSpanElement,
+  HTMLButtonElement,
   { removeIcon?: ReactNode }
 >;
 
@@ -31,19 +31,9 @@ function ListDel({
     { absoluteName: true },
   )[0];
 
-  const limitNotReached =
-    !disabled && !(parent.minCount! >= parent.value!.length);
-
-  function onAction(
-    event:
-      | React.KeyboardEvent<HTMLSpanElement>
-      | React.MouseEvent<HTMLSpanElement, MouseEvent>,
-  ) {
-    if (
-      limitNotReached &&
-      !readOnly &&
-      (!('key' in event) || event.key === 'Enter')
-    ) {
+  disabled ||= readOnly || parent.minCount! >= parent.value!.length;
+  function onAction() {
+    if (!disabled) {
       const value = parent.value!.slice();
       value.splice(nameIndex, 1);
       parent.onChange(value);
@@ -51,16 +41,16 @@ function ListDel({
   }
 
   return (
-    <span
+    <button
       {...filterDOMProps(props)}
-      className={classnames('badge rounded-pill', className)}
+      className={classnames('btn btn-secondary btn-sm', className)}
+      disabled={disabled}
       onClick={onAction}
-      onKeyDown={onAction}
-      role="button"
       tabIndex={0}
+      type="button"
     >
       {removeIcon}
-    </span>
+    </button>
   );
 }
 

--- a/packages/uniforms-bootstrap5/src/ListItemField.tsx
+++ b/packages/uniforms-bootstrap5/src/ListItemField.tsx
@@ -12,12 +12,12 @@ export type ListItemFieldProps = {
 };
 
 function ListItem({
-  children = <AutoField className="col-11" label={null} name="" />,
+  children = <AutoField className="col" label={null} name="" />,
   removeIcon,
 }: ListItemFieldProps) {
   return (
     <div className="row">
-      <div className="col-1">
+      <div className="col-auto">
         <ListDelField name="" removeIcon={removeIcon} />
       </div>
       {children}

--- a/reproductions/index.html
+++ b/reproductions/index.html
@@ -12,7 +12,7 @@
 
     <!--
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css" integrity="sha256-9mbkOfVho3ZPXfM7W8sV2SndrGDuh7wuyLjtsWeTI1Q=" crossorigin="anonymous" />
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.0.0-beta3/css/bootstrap.min.css" integrity="sha512-N415hCJJdJx+1UBfULt+i+ihvOn42V/kOjOpp1UTh4CZ70Hx5bDlKryWaqEKfY/8EYOu/C2MuyaluJryK1Lb5Q==" crossorigin="anonymous" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.3/css/bootstrap.min.css" integrity="sha512-N415hCJJdJx+1UBfULt+i+ihvOn42V/kOjOpp1UTh4CZ70Hx5bDlKryWaqEKfY/8EYOu/C2MuyaluJryK1Lb5Q==" crossorigin="anonymous" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha256-L/W5Wfqfa0sdBNIKN9cG6QA5F2qx4qICmU2VgLruv9Y=" crossorigin="anonymous" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha256-bZLfwXAP04zRMK2BjiO8iu9pf4FbLqX6zitd+tIvLhE=" crossorigin="anonymous" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/antd/3.25.3/antd.min.css" integrity="sha256-ezkI8P4X6ooQyI-cpiqtQZpWVOYRtagYu4DAHG7viflQ=" crossorigin="anonymous" />

--- a/website/lib/styles.tsx
+++ b/website/lib/styles.tsx
@@ -38,7 +38,7 @@ const styles = {
 
   bootstrap5: style([
     'https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css',
-    'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.0.0-beta3/css/bootstrap.min.css',
+    'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.3/css/bootstrap.min.css',
   ]),
 
   material: style([]),


### PR DESCRIPTION
In this pull request, I changed the `ListAddField` and `ListDelField` components in the Bootstrap 5 theme to use `button`s instead of `div`s, together with button-native styles.

I also updated the CDN link to the latest CSS version, and improved layouting in `ListItemField` (lefthand side is now as wide as it needs, not 1/12).