### PR TITLE
Fixed optional array fields (Zod bridge)

### DIFF
--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -132,7 +132,12 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
   }
 
   getInitialValue(name: string): unknown {
-    const field = this.getField(name);
+    let field = this.getField(name);
+
+    if (field instanceof ZodOptional) {
+      field = field.unwrap();
+    }
+
     if (field instanceof ZodArray) {
       const item = this.getInitialValue(joinName(name, '$'));
       if (item === undefined) {


### PR DESCRIPTION
Closes #1331

- Unwrap field if it is `ZodOptional`

Tested with:
- `z.string().array().optional()`
- `z.array(z.string()).optional()`
- other fields in the playground (All Fields (Zod))