### PR TITLE
Removed setting initial value for enum type

### DIFF
--- a/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/__tests__/ZodBridge.ts
@@ -278,7 +278,7 @@ describe('ZodBridge', () => {
     it('works with enum (array)', () => {
       const schema = object({ a: enum_(['x', 'y', 'z']) });
       const bridge = new ZodBridge({ schema });
-      expect(bridge.getInitialValue('a')).toEqual('x');
+      expect(bridge.getInitialValue('a')).toEqual(undefined);
     });
 
     it('works with enum (native, numbers)', () => {

--- a/packages/uniforms-bridge-zod/src/ZodBridge.ts
+++ b/packages/uniforms-bridge-zod/src/ZodBridge.ts
@@ -152,10 +152,6 @@ export default class ZodBridge<T extends ZodRawShape> extends Bridge {
       return field._def.defaultValue();
     }
 
-    if (field instanceof ZodEnum) {
-      return field.options[0];
-    }
-
     if (field instanceof ZodNativeEnum) {
       const values = Object.values(field.enum as Record<string, unknown>);
       return values.find(isNativeEnumValue) ?? values[0];

--- a/packages/uniforms-mui/__tests__/SelectField.tsx
+++ b/packages/uniforms-mui/__tests__/SelectField.tsx
@@ -77,7 +77,7 @@ describe('@RTL - SelectField tests', () => {
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
 
-    expect(screen.getByText('a')).not.toBeInTheDocument();
+    expect(screen.queryByText('a')).not.toBeInTheDocument();
     expect(screen.queryByText('b')).not.toBeInTheDocument();
   });
 

--- a/packages/uniforms-mui/__tests__/SelectField.tsx
+++ b/packages/uniforms-mui/__tests__/SelectField.tsx
@@ -77,7 +77,7 @@ describe('@RTL - SelectField tests', () => {
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
 
-    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('a')).not.toBeInTheDocument();
     expect(screen.queryByText('b')).not.toBeInTheDocument();
   });
 
@@ -233,7 +233,7 @@ describe('@RTL - SelectField tests', () => {
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
 
-    expect(screen.getByLabelText('a *')).toBeChecked();
+    expect(screen.getByLabelText('a *')).not.toBeChecked();
     expect(screen.getByLabelText('b *')).not.toBeChecked();
   });
 

--- a/packages/uniforms/__suites__/RadioField.tsx
+++ b/packages/uniforms/__suites__/RadioField.tsx
@@ -116,7 +116,7 @@ export function testRadioField(
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
 
-    expect(screen.getAllByRole('radio')[0]).toHaveAttribute('checked');
+    expect(screen.getAllByRole('radio')[0]).not.toHaveAttribute('checked');
     expect(screen.getAllByRole('radio')[1]).not.toHaveAttribute('checked');
   });
 
@@ -161,8 +161,9 @@ export function testRadioField(
       onChange,
     });
     await userEvent.click(screen.getByRole('radio', { name: 'a' }));
+    await userEvent.click(screen.getByRole('radio', { name: 'a' }));
 
-    expect(onChange).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   test('<RadioField> - renders a label', () => {

--- a/packages/uniforms/__suites__/SelectField.tsx
+++ b/packages/uniforms/__suites__/SelectField.tsx
@@ -38,7 +38,7 @@ export function testSelectField(
       element: <SelectField name="x" label="y" />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    expect(screen.getByText('y')).toBeInTheDocument();
+    expect(screen.getByLabelText(/y\*?/)).toBeInTheDocument();
   });
 
   skipTestIf(isTheme(['mui', 'antd']))(
@@ -237,7 +237,7 @@ export function testSelectField(
       element: <SelectField name="x" label="y" placeholder="" />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    expect(screen.getByText('y')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('y')).not.toBeInTheDocument();
   });
 
   skipTestIf(isTheme(['antd', 'mui']))(
@@ -260,10 +260,10 @@ export function testSelectField(
       });
       const select = screen.getByRole('combobox');
       if (options?.theme === 'antd') {
-        expect(screen.getByText('a')).toBeInTheDocument();
+        expect(screen.queryByText('a')).not.toBeInTheDocument();
         expect(screen.queryByText('b')).not.toBeInTheDocument();
       } else {
-        expect(select).toHaveValue('a');
+        expect(select).not.toHaveValue();
       }
     },
   );
@@ -538,7 +538,7 @@ export function testSelectField(
     const checkboxes = fields.filter(
       element => element instanceof HTMLInputElement,
     );
-    expect(checkboxes?.[0]).toBeChecked();
+    expect(checkboxes?.[0]).not.toBeChecked();
     expect(checkboxes?.[1]).not.toBeChecked();
   });
 


### PR DESCRIPTION
- Removed setting initial value for enum type (`SelectField`). This is the same behavior as we have for example in the `SimpleSchema2Bridge`

### Before

<img width="829" alt="image" src="https://github.com/vazco/uniforms/assets/37746259/a83f320b-7fea-4392-8b39-be9fd97059ef">


### After

<img width="829" alt="image" src="https://github.com/vazco/uniforms/assets/37746259/b0aaa054-543e-416d-9082-21bfe5081ef6">

### Future work

- Update tests. As the `SelectField` tests will be changed (#1351), I will do it after the PR merge. For this reason, I open this as a draft.
