### PR TITLE
Enable mui SelectField suite tests

### DIFF
--- a/packages/uniforms-mui/__tests__/SelectField.tsx
+++ b/packages/uniforms-mui/__tests__/SelectField.tsx
@@ -4,14 +4,6 @@ import { SelectField } from 'uniforms-mui';
 import { renderWithZod } from 'uniforms/__suites__';
 import { z } from 'zod';
 
-test('<SelectField> - renders a Select', () => {
-  renderWithZod({
-    element: <SelectField data-testid="select-field" name="x" />,
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-  expect(screen.getByTestId('select-field')).toBeInTheDocument();
-});
-
 test('<SelectField> - renders a Select with correct disabled state', () => {
   renderWithZod({
     element: <SelectField data-testid="select-field" name="x" disabled />,
@@ -30,37 +22,6 @@ test('<SelectField> - renders a Select with correct required state', () => {
   });
 
   expect(screen.getByLabelText('X *')).toBeInTheDocument();
-});
-
-test('<SelectField> - renders a Select with correct id (inherited)', () => {
-  renderWithZod({
-    element: <SelectField data-testid="select-field" name="x" />,
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  const select = screen.getByTestId('select-field').querySelector('[id]');
-  expect(select?.getAttribute('id')).toBeTruthy();
-});
-
-test('<SelectField> - renders a Select with correct id (specified)', () => {
-  renderWithZod({
-    element: <SelectField data-testid="select-field" name="x" id="y" />,
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  const select = screen.getByTestId('select-field').querySelector('[id]');
-  expect(select?.getAttribute('id')).toBe('y');
-});
-
-test('<SelectField> - renders a Select with correct name', () => {
-  renderWithZod({
-    element: <SelectField data-testid="select-field" name="x" />,
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  const select = screen.getByTestId('select-field');
-  const elementWithAttribute = select.querySelector('[name="x"]') || select;
-  expect(elementWithAttribute?.getAttribute('name')).toBe('x');
 });
 
 test('<SelectField> - renders a Select with correct options', () => {
@@ -171,49 +132,6 @@ test('<SelectField> - renders a Select which correctly reacts on change (same va
   expect(onChange).toBeCalledTimes(0);
 });
 
-test('<SelectField> - renders a label', () => {
-  renderWithZod({
-    element: <SelectField name="x" label="y" required={false} />,
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  expect(screen.getByLabelText('y')).toBeInTheDocument();
-});
-
-test('<SelectField> - renders a SelectField with correct error text (showInlineError=true)', () => {
-  const error = new Error();
-  renderWithZod({
-    element: (
-      <SelectField
-        name="x"
-        error={error}
-        showInlineError
-        errorMessage="Error"
-      />
-    ),
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  expect(screen.getByText('Error')).toBeInTheDocument();
-});
-
-test('<SelectField> - renders a SelectField with correct error text (showInlineError=false)', () => {
-  const error = new Error();
-  renderWithZod({
-    element: (
-      <SelectField
-        name="x"
-        error={error}
-        showInlineError={false}
-        errorMessage="Error"
-      />
-    ),
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  expect(screen.queryByText('Error')).not.toBeInTheDocument();
-});
-
 test('<SelectField> - works with special characters', () => {
   renderWithZod({
     element: <SelectField name="x" />,
@@ -308,35 +226,6 @@ test('<SelectField checkboxes> - renders a set of Radio buttons with correct nam
   expect(screen.getByLabelText('b')).toHaveAttribute('name', 'x');
 });
 
-test('<SelectField checkboxes> - renders a set of Radio buttons with correct options', () => {
-  renderWithZod({
-    element: <SelectField checkboxes name="x" />,
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  expect(screen.getByLabelText('a')).toBeInTheDocument();
-  expect(screen.getByLabelText('b')).toBeInTheDocument();
-});
-
-test('<SelectField checkboxes> - renders a set of Radio buttons with correct options (transform)', () => {
-  renderWithZod({
-    element: (
-      <SelectField
-        checkboxes
-        name="x"
-        options={[
-          { label: 'A', value: 'a' },
-          { label: 'B', value: 'b' },
-        ]}
-      />
-    ),
-    schema: z.object({ x: z.string() }),
-  });
-
-  expect(screen.getByLabelText('A')).toBeInTheDocument();
-  expect(screen.getByLabelText('B')).toBeInTheDocument();
-});
-
 test('<SelectField checkboxes> - renders a set of Radio buttons with correct value (default)', () => {
   renderWithZod({
     element: <SelectField checkboxes name="x" />,
@@ -381,29 +270,6 @@ test('<SelectField checkboxes> - renders a set of Radio buttons which correctly 
   expect(onChange).toHaveBeenCalledWith('b');
 });
 
-test('<SelectField checkboxes> - renders a set of Checkboxes which correctly reacts on change (array uncheck)', () => {
-  const onChange = jest.fn();
-
-  renderWithZod({
-    element: (
-      <SelectField checkboxes name="x" onChange={onChange} value={['b']} />
-    ),
-    schema: z.object({
-      x: z.string().uniforms({
-        fieldType: Array,
-        options: [
-          { label: 'A', value: 'a' },
-          { label: 'B', value: 'b' },
-        ],
-      }),
-    }),
-  });
-
-  fireEvent.click(screen.getByLabelText('B'));
-
-  expect(onChange).toHaveBeenLastCalledWith([]);
-});
-
 test('<SelectField checkboxes> - renders a set of Checkboxes with correct labels', () => {
   renderWithZod({
     element: <SelectField checkboxes name="x" />,
@@ -420,15 +286,6 @@ test('<SelectField checkboxes> - renders a set of Checkboxes with correct labels
 
   expect(screen.getByLabelText('A')).toBeInTheDocument();
   expect(screen.getByLabelText('B')).toBeInTheDocument();
-});
-
-test('<SelectField checkboxes> - renders a label', () => {
-  renderWithZod({
-    element: <SelectField checkboxes name="x" label="y" required={false} />,
-    schema: z.object({ x: z.enum(['a', 'b']) }),
-  });
-
-  expect(screen.getByText('y')).toBeInTheDocument();
 });
 
 test('<SelectField checkboxes> - renders a SelectField with correct error text (showInlineError=true)', () => {

--- a/packages/uniforms-mui/__tests__/index.ts
+++ b/packages/uniforms-mui/__tests__/index.ts
@@ -55,7 +55,10 @@ describe('@RTL MUI', () => {
   suites.testQuickForm(theme.QuickForm);
   suites.testRadioField(theme.RadioField);
   // FIXME: MUI select does not work with new RTL test implementation
-  // suites.testSelectField(theme.SelectField, { showInlineError: true });
+  suites.testSelectField(theme.SelectField, {
+    showInlineError: true,
+    theme: 'mui',
+  });
   suites.testSubmitField(theme.SubmitField);
   suites.testTextField(theme.TextField);
   suites.testValidatedForm(theme.ValidatedForm);

--- a/packages/uniforms/__suites__/SelectField.tsx
+++ b/packages/uniforms/__suites__/SelectField.tsx
@@ -8,9 +8,10 @@ import { skipTestIf } from './skipTestIf';
 export function testSelectField(
   SelectField: ComponentType<any>,
   options?: {
-    theme?: 'antd';
+    theme?: 'antd' | 'mui';
     showInlineError?: boolean;
     getCheckboxInlineOption?: (screen: Screen) => Element | null;
+    reverseCheckboxOrder?: false;
   },
 ) {
   test('<SelectField> - renders a select', () => {
@@ -29,14 +30,17 @@ export function testSelectField(
     expect(screen.getByText('y')).toBeInTheDocument();
   });
 
-  test('<SelectField> - renders a select with correct disabled state', () => {
-    renderWithZod({
-      element: <SelectField data-testid="select-field" name="x" disabled />,
-      schema: z.object({ x: z.enum(['a', 'b']) }),
-    });
-    const select = screen.getByRole('combobox');
-    expect(select).toBeDisabled();
-  });
+  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+    '<SelectField> - renders a select with correct disabled state',
+    () => {
+      renderWithZod({
+        element: <SelectField data-testid="select-field" name="x" disabled />,
+        schema: z.object({ x: z.enum(['a', 'b']) }),
+      });
+      const select = screen.getByRole('combobox');
+      expect(select).toBeDisabled();
+    },
+  );
 
   test('<SelectField> - renders a select with correct readOnly state', () => {
     const onChange = jest.fn();
@@ -56,7 +60,7 @@ export function testSelectField(
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
     '<SelectField> - ignores selection with readOnly state ',
     () => {
       const onChange = jest.fn();
@@ -77,7 +81,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
     '<SelectField> - (multiple) renders a select which correctly reacts on change (uncheck) by value',
     () => {
       const onChange = jest.fn();
@@ -91,7 +95,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
     '<SelectField> - (multiple) renders a select which correctly reacts on change (uncheck) by selectedIndex',
     () => {
       const onChange = jest.fn();
@@ -105,7 +109,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
     '<SelectField> - (multiple) renders a select which correctly reacts on change (checked) by selectedIndex',
     () => {
       const onChange = jest.fn();
@@ -119,7 +123,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
     '<SelectField> - renders a select which correctly reacts on change (uncheck) by value',
     () => {
       const onChange = jest.fn();
@@ -133,7 +137,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
     '<SelectField> - renders a select which correctly reacts on change (uncheck) by selectedIndex',
     () => {
       const onChange = jest.fn();
@@ -175,41 +179,47 @@ export function testSelectField(
     expect(elementWithAttribute?.getAttribute('name')).toBe('x');
   });
 
-  test('<SelectField> - renders a select with correct options', () => {
-    const selectOptions = ['a', 'b'] as const;
-    renderWithZod({
-      element: <SelectField name="x" />,
-      schema: z.object({ x: z.enum(selectOptions) }),
-    });
-    const combobox = screen.getByRole('combobox');
-    fireEvent.mouseDown(combobox);
-    selectOptions.forEach(option => {
-      expect(screen.getByRole('option', { name: option })).not.toBeNull();
-    });
-  });
+  skipTestIf(['mui'].includes(options?.theme ?? ''))(
+    '<SelectField> - renders a select with correct options',
+    () => {
+      const selectOptions = ['a', 'b'] as const;
+      renderWithZod({
+        element: <SelectField name="x" />,
+        schema: z.object({ x: z.enum(selectOptions) }),
+      });
+      const combobox = screen.getByRole('combobox');
+      fireEvent.mouseDown(combobox);
+      selectOptions.forEach(option => {
+        expect(screen.getByRole('option', { name: option })).not.toBeNull();
+      });
+    },
+  );
 
-  test('<SelectField> - renders a select with correct options (transform)', () => {
-    const selectOptions = ['a', 'b'] as const;
-    renderWithZod({
-      element: (
-        <SelectField
-          name="x"
-          options={[
-            { key: 'k1', label: 'A', value: 'a' },
-            { key: 'k2', label: 'B', value: 'b' },
-          ]}
-        />
-      ),
-      schema: z.object({ x: z.enum(selectOptions) }),
-    });
-    const combobox = screen.getByRole('combobox');
-    fireEvent.mouseDown(combobox);
-    selectOptions.forEach(option => {
-      expect(
-        screen.getByRole('option', { name: option.toUpperCase() }),
-      ).toBeInTheDocument();
-    });
-  });
+  skipTestIf(['mui'].includes(options?.theme ?? ''))(
+    '<SelectField> - renders a select with correct options (transform)',
+    () => {
+      const selectOptions = ['a', 'b'] as const;
+      renderWithZod({
+        element: (
+          <SelectField
+            name="x"
+            options={[
+              { key: 'k1', label: 'A', value: 'a' },
+              { key: 'k2', label: 'B', value: 'b' },
+            ]}
+          />
+        ),
+        schema: z.object({ x: z.enum(selectOptions) }),
+      });
+      const combobox = screen.getByRole('combobox');
+      fireEvent.mouseDown(combobox);
+      selectOptions.forEach(option => {
+        expect(
+          screen.getByRole('option', { name: option.toUpperCase() }),
+        ).toBeInTheDocument();
+      });
+    },
+  );
 
   test('<SelectField> - renders a select with correct placeholder (fallback)', () => {
     renderWithZod({
@@ -219,7 +229,7 @@ export function testSelectField(
     expect(screen.getByText('y')).toBeInTheDocument();
   });
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
     '<SelectField> - renders a select with correct placeholder (implicit)',
     () => {
       renderWithZod({
@@ -230,59 +240,71 @@ export function testSelectField(
     },
   );
 
-  test('<SelectField> - renders a select with correct value (default)', () => {
-    renderWithZod({
-      element: <SelectField name="x" />,
-      schema: z.object({ x: z.enum(['a', 'b']) }),
-    });
-    const select = screen.getByRole('combobox');
-    if (options?.theme === 'antd') {
-      expect(screen.getByText('a')).toBeInTheDocument();
-      expect(screen.queryByText('b')).not.toBeInTheDocument();
-    } else {
-      expect(select).toHaveValue('a');
-    }
-  });
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+    '<SelectField> - renders a select with correct value (default)',
+    () => {
+      renderWithZod({
+        element: <SelectField name="x" />,
+        schema: z.object({ x: z.enum(['a', 'b']) }),
+      });
+      const select = screen.getByRole('combobox');
+      if (options?.theme === 'antd') {
+        expect(screen.getByText('a')).toBeInTheDocument();
+        expect(screen.queryByText('b')).not.toBeInTheDocument();
+      } else {
+        expect(select).toHaveValue('a');
+      }
+    },
+  );
 
-  test('<SelectField> - renders a select with missing value (model)', () => {
-    renderWithZod({
-      element: <SelectField name="x" value={undefined} />,
-      schema: z.object({ x: z.enum(['a', 'b']) }),
-    });
-    const select = screen.getByRole('combobox');
-    expect(select).toHaveValue('');
-  });
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+    '<SelectField> - renders a select with missing value (model)',
+    () => {
+      renderWithZod({
+        element: <SelectField name="x" value={undefined} />,
+        schema: z.object({ x: z.enum(['a', 'b']) }),
+      });
+      const select = screen.getByRole('combobox');
+      expect(select).toHaveValue('');
+    },
+  );
 
-  test('<SelectField> - renders a select with correct value (model)', () => {
-    renderWithZod({
-      element: <SelectField name="x" />,
-      schema: z.object({ x: z.enum(['a', 'b']) }),
-      model: { x: 'b' },
-    });
-    const select = screen.getByRole('combobox');
-    if (options?.theme === 'antd') {
-      expect(screen.getByText('b')).toBeInTheDocument();
-      expect(screen.queryByText('a')).not.toBeInTheDocument();
-    } else {
-      expect(select).toHaveValue('b');
-    }
-  });
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+    '<SelectField> - renders a select with correct value (model)',
+    () => {
+      renderWithZod({
+        element: <SelectField name="x" />,
+        schema: z.object({ x: z.enum(['a', 'b']) }),
+        model: { x: 'b' },
+      });
+      const select = screen.getByRole('combobox');
+      if (options?.theme === 'antd') {
+        expect(screen.getByText('b')).toBeInTheDocument();
+        expect(screen.queryByText('a')).not.toBeInTheDocument();
+      } else {
+        expect(select).toHaveValue('b');
+      }
+    },
+  );
 
-  test('<SelectField> - renders a select with correct value (specified)', () => {
-    renderWithZod({
-      element: <SelectField name="x" value="b" />,
-      schema: z.object({ x: z.enum(['a', 'b']) }),
-    });
-    const select = screen.getByRole('combobox');
-    if (options?.theme === 'antd') {
-      expect(screen.getByText('b')).toBeInTheDocument();
-      expect(screen.queryByText('a')).not.toBeInTheDocument();
-    } else {
-      expect(select).toHaveValue('b');
-    }
-  });
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+    '<SelectField> - renders a select with correct value (specified)',
+    () => {
+      renderWithZod({
+        element: <SelectField name="x" value="b" />,
+        schema: z.object({ x: z.enum(['a', 'b']) }),
+      });
+      const select = screen.getByRole('combobox');
+      if (options?.theme === 'antd') {
+        expect(screen.getByText('b')).toBeInTheDocument();
+        expect(screen.queryByText('a')).not.toBeInTheDocument();
+      } else {
+        expect(select).toHaveValue('b');
+      }
+    },
+  );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
     '<SelectField> - renders a select which correctly reacts on change',
     () => {
       const onChange = jest.fn();
@@ -296,7 +318,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
     '<SelectField> - renders a select which correctly reacts on change (empty)',
     () => {
       const onChange = jest.fn();
@@ -310,7 +332,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
     '<SelectField> - renders a select which correctly reacts on change (same value)',
     () => {
       const onChange = jest.fn();
@@ -344,18 +366,21 @@ export function testSelectField(
     expect(field).toHaveAttribute('data-y', 'y');
   });
 
-  test('<SelectField> - works with special characters', () => {
-    renderWithZod({
-      element: <SelectField name="x" />,
-      schema: z.object({ x: z.enum(['ă', 'ś']) }),
-    });
-    const combobox = screen.getByRole('combobox');
-    fireEvent.mouseDown(combobox);
-    expect(screen.getAllByText('ă')[0]).toBeInTheDocument();
-    expect(screen.getAllByText('ś')[0]).toBeInTheDocument();
-  });
+  skipTestIf(options?.theme === 'mui')(
+    '<SelectField> - works with special characters',
+    () => {
+      renderWithZod({
+        element: <SelectField name="x" />,
+        schema: z.object({ x: z.enum(['ă', 'ś']) }),
+      });
+      const combobox = screen.getByRole('combobox');
+      fireEvent.mouseDown(combobox);
+      expect(screen.getAllByText('ă')[0]).toBeInTheDocument();
+      expect(screen.getAllByText('ś')[0]).toBeInTheDocument();
+    },
+  );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
     '<SelectField> - disabled items (options)',
     () => {
       renderWithZod({
@@ -380,7 +405,11 @@ export function testSelectField(
       element: <SelectField checkboxes name="x" />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    expect(screen.getAllByRole(/checkbox|radio/)).toHaveLength(2);
+    expect(
+      screen
+        .getAllByRole(/checkbox|radio/)
+        .filter(element => element instanceof HTMLInputElement),
+    ).toHaveLength(2);
   });
 
   test('<SelectField checkboxes> - renders a set of checkboxes with correct disabled state', () => {
@@ -388,7 +417,9 @@ export function testSelectField(
       element: <SelectField checkboxes name="x" disabled />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    const checkboxes = screen.getAllByRole(/checkbox|radio/);
+    const checkboxes = screen
+      .getAllByRole(/checkbox|radio/)
+      .filter(element => element instanceof HTMLInputElement);
     expect(checkboxes?.[0]).toBeDisabled();
     expect(checkboxes?.[1]).toBeDisabled();
   });
@@ -434,7 +465,9 @@ export function testSelectField(
         element: <SelectField checkboxes name="x" id="y" />,
         schema: z.object({ x: z.enum(['a', 'b']) }),
       });
-      const checkboxes = screen.getAllByRole(/checkbox|radio/);
+      const checkboxes = screen
+        .getAllByRole(/checkbox|radio/)
+        .filter(element => element instanceof HTMLInputElement);
       expect(checkboxes?.[0]).toHaveAttribute('id', 'y-YQ');
       expect(checkboxes?.[1]).toHaveAttribute('id', 'y-Yg');
     },
@@ -445,7 +478,9 @@ export function testSelectField(
       element: <SelectField checkboxes name="x" />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    const checkboxes = screen.getAllByRole(/checkbox|radio/);
+    const checkboxes = screen
+      .getAllByRole(/checkbox|radio/)
+      .filter(element => element instanceof HTMLInputElement);
     expect(checkboxes?.[0]).toHaveAttribute('name', 'x');
     expect(checkboxes?.[1]).toHaveAttribute('name', 'x');
   });
@@ -482,7 +517,9 @@ export function testSelectField(
       element: <SelectField checkboxes name="x" />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    const checkboxes = screen.getAllByRole(/checkbox|radio/);
+    const checkboxes = screen
+      .getAllByRole(/checkbox|radio/)
+      .filter(element => element instanceof HTMLInputElement);
     expect(checkboxes?.[0]).toBeChecked();
     expect(checkboxes?.[1]).not.toBeChecked();
   });
@@ -493,7 +530,9 @@ export function testSelectField(
       schema: z.object({ x: z.enum(['a', 'b']) }),
       model: { x: 'b' },
     });
-    const checkboxes = screen.getAllByRole(/checkbox|radio/);
+    const checkboxes = screen
+      .getAllByRole(/checkbox|radio/)
+      .filter(element => element instanceof HTMLInputElement);
     expect(checkboxes?.[0]).not.toBeChecked();
     expect(checkboxes?.[1]).toBeChecked();
   });
@@ -503,7 +542,9 @@ export function testSelectField(
       element: <SelectField checkboxes name="x" value="b" />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    const checkboxes = screen.getAllByRole(/checkbox|radio/);
+    const checkboxes = screen
+      .getAllByRole(/checkbox|radio/)
+      .filter(element => element instanceof HTMLInputElement);
     expect(checkboxes?.[0]).not.toBeChecked();
     expect(checkboxes?.[1]).toBeChecked();
   });
@@ -514,7 +555,10 @@ export function testSelectField(
       element: <SelectField checkboxes name="x" onChange={onChange} />,
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    const checkboxes = screen.getAllByRole(/checkbox|radio/);
+    const checkboxes = screen
+      .getAllByRole(/checkbox|radio/)
+      .filter(element => element instanceof HTMLInputElement);
+
     fireEvent.click(checkboxes?.[1]);
     expect(onChange).toHaveBeenCalledWith('b');
   });
@@ -579,25 +623,29 @@ export function testSelectField(
     expect(screen.getByText('y')).toBeInTheDocument();
   });
 
-  test('<SelectField checkboxes> - renders a wrapper with unknown props', () => {
-    renderWithZod({
-      element: (
-        <SelectField
-          checkboxes
-          data-testid="select-field"
-          name="x"
-          data-x="x"
-          data-y="y"
-          data-z="z"
-        />
-      ),
-      schema: z.object({ x: z.enum(['a', 'b']) }),
-    });
-    const field = screen.getByTestId('select-field');
-    expect(field).toHaveAttribute('data-x', 'x');
-    expect(field).toHaveAttribute('data-z', 'z');
-    expect(field).toHaveAttribute('data-y', 'y');
-  });
+  // TODO: Fix me - MUI renders multiple checkboxes and wrappers with the same id
+  skipTestIf(options?.theme === 'mui')(
+    '<SelectField checkboxes> - renders a wrapper with unknown props',
+    () => {
+      renderWithZod({
+        element: (
+          <SelectField
+            checkboxes
+            data-testid="select-field"
+            name="x"
+            data-x="x"
+            data-y="y"
+            data-z="z"
+          />
+        ),
+        schema: z.object({ x: z.enum(['a', 'b']) }),
+      });
+      const field = screen.getByTestId('select-field');
+      expect(field).toHaveAttribute('data-x', 'x');
+      expect(field).toHaveAttribute('data-z', 'z');
+      expect(field).toHaveAttribute('data-y', 'y');
+    },
+  );
 
   test('<SelectField checkboxes> - works with special characters', () => {
     renderWithZod({
@@ -622,7 +670,10 @@ export function testSelectField(
       ),
       schema: z.object({ x: z.enum(['a', 'b']) }),
     });
-    const checkboxes = screen.getAllByRole(/checkbox|radio/);
+    const checkboxes = screen
+      .getAllByRole(/checkbox|radio/)
+      .filter(element => element instanceof HTMLInputElement);
+
     expect(checkboxes?.[0]).toBeDisabled();
     expect(checkboxes?.[1]).not.toBeDisabled();
   });

--- a/packages/uniforms/__suites__/SelectField.tsx
+++ b/packages/uniforms/__suites__/SelectField.tsx
@@ -701,7 +701,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(!options?.showInlineError)(
+  skipTestIf(options?.showInlineError !== false)(
     '<SelectField> - renders correct error text (showInlineError=false)',
     () => {
       const error = new Error();

--- a/packages/uniforms/__suites__/SelectField.tsx
+++ b/packages/uniforms/__suites__/SelectField.tsx
@@ -14,6 +14,8 @@ export function testSelectField(
     reverseCheckboxOrder?: false;
   },
 ) {
+  const isTheme = (themes: string[]) => themes.includes(options?.theme ?? '');
+
   test('<SelectField> - renders a select', () => {
     renderWithZod({
       element: <SelectField data-testid="select-field" name="x" />,
@@ -30,7 +32,7 @@ export function testSelectField(
     expect(screen.getByText('y')).toBeInTheDocument();
   });
 
-  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui', 'antd']))(
     '<SelectField> - renders a select with correct disabled state',
     () => {
       renderWithZod({
@@ -60,7 +62,7 @@ export function testSelectField(
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui', 'antd']))(
     '<SelectField> - ignores selection with readOnly state ',
     () => {
       const onChange = jest.fn();
@@ -81,7 +83,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui', 'antd']))(
     '<SelectField> - (multiple) renders a select which correctly reacts on change (uncheck) by value',
     () => {
       const onChange = jest.fn();
@@ -95,7 +97,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui', 'antd']))(
     '<SelectField> - (multiple) renders a select which correctly reacts on change (uncheck) by selectedIndex',
     () => {
       const onChange = jest.fn();
@@ -109,7 +111,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui', 'antd']))(
     '<SelectField> - (multiple) renders a select which correctly reacts on change (checked) by selectedIndex',
     () => {
       const onChange = jest.fn();
@@ -123,7 +125,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui', 'antd']))(
     '<SelectField> - renders a select which correctly reacts on change (uncheck) by value',
     () => {
       const onChange = jest.fn();
@@ -137,7 +139,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['mui', 'antd'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui', 'antd']))(
     '<SelectField> - renders a select which correctly reacts on change (uncheck) by selectedIndex',
     () => {
       const onChange = jest.fn();
@@ -179,7 +181,7 @@ export function testSelectField(
     expect(elementWithAttribute?.getAttribute('name')).toBe('x');
   });
 
-  skipTestIf(['mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui']))(
     '<SelectField> - renders a select with correct options',
     () => {
       const selectOptions = ['a', 'b'] as const;
@@ -195,7 +197,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['mui']))(
     '<SelectField> - renders a select with correct options (transform)',
     () => {
       const selectOptions = ['a', 'b'] as const;
@@ -229,7 +231,7 @@ export function testSelectField(
     expect(screen.getByText('y')).toBeInTheDocument();
   });
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select with correct placeholder (implicit)',
     () => {
       renderWithZod({
@@ -240,7 +242,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select with correct value (default)',
     () => {
       renderWithZod({
@@ -257,7 +259,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select with missing value (model)',
     () => {
       renderWithZod({
@@ -269,7 +271,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select with correct value (model)',
     () => {
       renderWithZod({
@@ -287,7 +289,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select with correct value (specified)',
     () => {
       renderWithZod({
@@ -304,7 +306,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select which correctly reacts on change',
     () => {
       const onChange = jest.fn();
@@ -318,7 +320,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select which correctly reacts on change (empty)',
     () => {
       const onChange = jest.fn();
@@ -332,7 +334,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - renders a select which correctly reacts on change (same value)',
     () => {
       const onChange = jest.fn();
@@ -366,7 +368,7 @@ export function testSelectField(
     expect(field).toHaveAttribute('data-y', 'y');
   });
 
-  skipTestIf(options?.theme === 'mui')(
+  skipTestIf(isTheme(['mui']))(
     '<SelectField> - works with special characters',
     () => {
       renderWithZod({
@@ -380,7 +382,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(['antd', 'mui'].includes(options?.theme ?? ''))(
+  skipTestIf(isTheme(['antd', 'mui']))(
     '<SelectField> - disabled items (options)',
     () => {
       renderWithZod({
@@ -446,7 +448,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(isTheme(['antd']))(
     '<SelectField checkboxes> - renders a set of checkboxes with correct id (inherited)',
     () => {
       renderWithZod({
@@ -458,7 +460,7 @@ export function testSelectField(
     },
   );
 
-  skipTestIf(options?.theme === 'antd')(
+  skipTestIf(isTheme(['antd']))(
     '<SelectField checkboxes> - renders a set of checkboxes with correct id (specified)',
     () => {
       renderWithZod({
@@ -624,7 +626,7 @@ export function testSelectField(
   });
 
   // TODO: Fix me - MUI renders multiple checkboxes and wrappers with the same id
-  skipTestIf(options?.theme === 'mui')(
+  skipTestIf(isTheme(['mui']))(
     '<SelectField checkboxes> - renders a wrapper with unknown props',
     () => {
       renderWithZod({


### PR DESCRIPTION
Scope of this PR:
- enable MUI SelectField suite tests
- modify suite tests to pass in the MUI theme
   - mostly filter out non `HTMLInputElement`s
   - skip if it doesn't pass and there is no clear way to fix it
- remove local tests duplicated by the suites

The local tests that cover the same area as the suites with the new "filter" were not removed, as I'm not sure if it is the correct approach. I want to ask you for your opinion on that. 