### PR TITLE
Blank `TextField` and `LongTextField`

### DIFF
--- a/packages/uniforms-antd/src/LongTextField.tsx
+++ b/packages/uniforms-antd/src/LongTextField.tsx
@@ -17,7 +17,11 @@ function LongText({ rows = 5, ...props }: LongTextFieldProps) {
     <TextArea
       disabled={props.disabled}
       name={props.name}
-      onChange={event => props.onChange(event.target.value)}
+      onChange={event =>
+        props.onChange(
+          event.target.value === '' ? undefined : event.target.value,
+        )
+      }
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-antd/src/TextField.tsx
+++ b/packages/uniforms-antd/src/TextField.tsx
@@ -16,7 +16,11 @@ function Text(props: TextFieldProps) {
     <Input
       disabled={props.disabled}
       name={props.name}
-      onChange={event => props.onChange(event.target.value)}
+      onChange={event =>
+        props.onChange(
+          event.target.value === '' ? undefined : event.target.value,
+        )
+      }
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-bootstrap4/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap4/src/LongTextField.tsx
@@ -21,7 +21,11 @@ function LongText(props: LongTextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event => props.onChange(event.target.value)}
+      onChange={event =>
+        props.onChange(
+          event.target.value === '' ? undefined : event.target.value,
+        )
+      }
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-bootstrap4/src/TextField.tsx
+++ b/packages/uniforms-bootstrap4/src/TextField.tsx
@@ -23,7 +23,11 @@ function Text(props: TextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event => props.onChange(event.target.value)}
+      onChange={event =>
+        props.onChange(
+          event.target.value === '' ? undefined : event.target.value,
+        )
+      }
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-bootstrap5/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap5/src/LongTextField.tsx
@@ -22,7 +22,11 @@ function LongText(props: LongTextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event => props.onChange(event.target.value)}
+      onChange={event =>
+        props.onChange(
+          event.target.value === '' ? undefined : event.target.value,
+        )
+      }
       placeholder={props.placeholder}
       minLength={props.minLength}
       maxLength={props.maxLength}

--- a/packages/uniforms-bootstrap5/src/TextField.tsx
+++ b/packages/uniforms-bootstrap5/src/TextField.tsx
@@ -23,7 +23,11 @@ function Text(props: TextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event => props.onChange(event.target.value)}
+      onChange={event =>
+        props.onChange(
+          event.target.value === '' ? undefined : event.target.value,
+        )
+      }
       placeholder={props.placeholder}
       minLength={props.minLength}
       maxLength={props.maxLength}

--- a/packages/uniforms-mui/src/LongTextField.tsx
+++ b/packages/uniforms-mui/src/LongTextField.tsx
@@ -31,7 +31,10 @@ const LongText = ({
       margin="dense"
       multiline
       name={name}
-      onChange={event => disabled || onChange(event.target.value)}
+      onChange={event =>
+        disabled ||
+        onChange(event.target.value === '' ? undefined : event.target.value)
+      }
       placeholder={placeholder}
       ref={inputRef}
       type={type}

--- a/packages/uniforms-mui/src/TextField.tsx
+++ b/packages/uniforms-mui/src/TextField.tsx
@@ -32,7 +32,10 @@ function Text({
       label={label}
       margin="dense"
       name={name}
-      onChange={event => disabled || onChange(event.target.value)}
+      onChange={event =>
+        disabled ||
+        onChange(event.target.value === '' ? undefined : event.target.value)
+      }
       placeholder={placeholder}
       ref={inputRef}
       type={type}

--- a/packages/uniforms-semantic/src/LongTextField.tsx
+++ b/packages/uniforms-semantic/src/LongTextField.tsx
@@ -36,7 +36,9 @@ function LongText({
         disabled={disabled}
         id={id}
         name={name}
-        onChange={event => onChange(event.target.value)}
+        onChange={event =>
+          onChange(event.target.value === '' ? undefined : event.target.value)
+        }
         placeholder={placeholder}
         readOnly={readOnly}
         ref={inputRef}

--- a/packages/uniforms-semantic/src/TextField.tsx
+++ b/packages/uniforms-semantic/src/TextField.tsx
@@ -57,7 +57,9 @@ function Text({
           disabled={disabled}
           id={id}
           name={name}
-          onChange={event => onChange(event.target.value)}
+          onChange={event =>
+            onChange(event.target.value === '' ? undefined : event.target.value)
+          }
           placeholder={placeholder}
           readOnly={readOnly}
           ref={inputRef}

--- a/packages/uniforms-unstyled/src/LongTextField.tsx
+++ b/packages/uniforms-unstyled/src/LongTextField.tsx
@@ -27,7 +27,9 @@ function LongText({
         disabled={disabled}
         id={id}
         name={name}
-        onChange={event => onChange(event.target.value)}
+        onChange={event =>
+          onChange(event.target.value === '' ? undefined : event.target.value)
+        }
         placeholder={placeholder}
         readOnly={readOnly}
         ref={inputRef}

--- a/packages/uniforms-unstyled/src/TextField.tsx
+++ b/packages/uniforms-unstyled/src/TextField.tsx
@@ -30,7 +30,9 @@ function Text({
         disabled={disabled}
         id={id}
         name={name}
-        onChange={event => onChange(event.target.value)}
+        onChange={event =>
+          onChange(event.target.value === '' ? undefined : event.target.value)
+        }
         placeholder={placeholder}
         readOnly={readOnly}
         ref={inputRef}

--- a/packages/uniforms/__suites__/LongTextField.tsx
+++ b/packages/uniforms/__suites__/LongTextField.tsx
@@ -110,7 +110,7 @@ export function testLongTextField(
       schema: z.object({ x: z.string() }),
     });
     await userEvent.type(screen.getByRole('textbox'), '{Backspace}');
-    expect(onChange).toHaveBeenLastCalledWith('x', '');
+    expect(onChange).toHaveBeenLastCalledWith('x', undefined);
   });
 
   test('<LongTextField> - renders a label', () => {

--- a/packages/uniforms/__suites__/TextField.tsx
+++ b/packages/uniforms/__suites__/TextField.tsx
@@ -148,7 +148,7 @@ export function testTextField(
       schema: z.object({ x: z.string() }),
     });
     await userEvent.type(screen.getByRole('textbox'), '{Backspace}');
-    expect(onChange).toHaveBeenLastCalledWith('x', '');
+    expect(onChange).toHaveBeenLastCalledWith('x', undefined);
   });
 
   test('<TextField> - renders a label', () => {


### PR DESCRIPTION
Closes #1332

- Deleting input from `TextField` and `LongTextField` sets `undefined` instead of empty string in the model
- This behavior is already implemented in other fields ([playground](https://uniforms.tools/playground/#?N4IgDgTgpgzlAuIBcICCAbdACAYgSynQBMYsAKALQHsiBKEAGnAirBmVAEMBXeKmTgDcoyAGad0cJjz4DhAEUKcAnsgCMABg1MieAQCN0UImIlSQ6TvsLJ4EblCZhLAYygALKsSgRTkxyDQnEQA8gB26KpI4v5MMJ4A7gCSEXhhUACiECy-0WYBnDDKYS7hAMrc-gC2eIh5sSCFxaVhAGoSeESc8CL15jAu7lBVnMgg6QlY1EQAQhCdAOZQZMAAOmFYWANDI0hYAF4AdFT6AFZQLvAr65u3WD0AHvB7RzB2aQtktIc1YWQATN9WPA8FQwhIvgwbncsGFuFUXoc4VVrBAvj80gCgWAQWCIbQoRtbgBfWjrUkgYlMeA7XogOAjMIglyUoA) with optional `TextField` and `NumField`)