### PR TITLE
Turborepo typescript fix build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/react": "12.1.5",
         "@testing-library/user-event": "14.4.3",
         "@types/jest": "26.0.20",
+        "@types/node": "18.19.50",
         "eslint-config-vazco": "7.4.0",
         "eslint-import-resolver-alias": "1.1.2",
         "eslint-import-resolver-typescript": "2.3.0",
@@ -2399,10 +2400,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
-      "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
-      "dev": true
+      "version": "18.19.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
+      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -12803,6 +12808,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.0.tgz",
@@ -15389,10 +15401,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
-      "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
-      "dev": true
+      "version": "18.19.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
+      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -22752,6 +22767,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unified": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.3",
     "@types/jest": "26.0.20",
+    "@types/node": "18.19.50",
     "eslint-config-vazco": "7.4.0",
     "eslint-import-resolver-alias": "1.1.2",
     "eslint-import-resolver-typescript": "2.3.0",

--- a/packages/uniforms/src/BaseForm.tsx
+++ b/packages/uniforms/src/BaseForm.tsx
@@ -167,9 +167,9 @@ export class BaseForm<
   getNativeFormProps(): {
     [key: string]: unknown;
     children?: React.ReactNode;
-    id?: BaseFormProps<Model>['id'];
+    id?: string;
     key: string;
-    noValidate: BaseFormProps<Model>['noValidate'];
+    noValidate: boolean;
     onSubmit: BaseForm<Model, Props, State>['onSubmit'];
   } {
     const props = omit(this.props, [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "paths": { "uniforms": ["uniforms/src"], "uniforms-*": ["uniforms-*/src"] },
     "strict": true,
-    "target": "ES6"
+    "target": "ES6",
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Shell dumps:

<details>
<summary>1. List `@types/node` package</summary>

```
npm ls @types/node
uniforms-repository@ /Users/adrianmucha/uniforms
├─┬ @types/jest@26.0.20
│ ├─┬ jest-diff@26.6.2
│ │ └─┬ pretty-format@26.6.2
│ │   └─┬ @jest/types@26.6.2
│ │     └── @types/node@17.0.18 deduped
│ └─┬ pretty-format@26.6.2
│   └─┬ @jest/types@26.6.2
│     └── @types/node@17.0.18 deduped
├─┬ jest-environment-jsdom@29.7.0
│ ├─┬ @jest/environment@29.7.0
│ │ └── @types/node@17.0.18 deduped
│ ├─┬ @jest/fake-timers@29.7.0
│ │ └── @types/node@17.0.18 deduped
│ ├─┬ @jest/types@29.6.3
│ │ └── @types/node@17.0.18 deduped
│ ├─┬ @types/jsdom@20.0.1
│ │ └── @types/node@17.0.18 deduped
│ ├── @types/node@17.0.18
│ ├─┬ jest-mock@29.7.0
│ │ └── @types/node@17.0.18 deduped
│ └─┬ jest-util@29.7.0
│   └── @types/node@17.0.18 deduped
├─┬ jest@29.7.0
│ └─┬ @jest/core@29.7.0
│   ├─┬ @jest/console@29.7.0
│   │ └── @types/node@17.0.18 deduped
│   ├─┬ @jest/reporters@29.7.0
│   │ ├── @types/node@17.0.18 deduped
│   │ └─┬ jest-worker@29.7.0
│   │   └── @types/node@17.0.18 deduped
│   ├── @types/node@17.0.18 deduped
│   ├─┬ jest-config@29.7.0
│   │ ├── @types/node@17.0.18 deduped
│   │ ├─┬ jest-circus@29.7.0
│   │ │ └── @types/node@17.0.18 deduped
│   │ └─┬ jest-environment-node@29.7.0
│   │   └── @types/node@17.0.18 deduped
│   ├─┬ jest-haste-map@29.7.0
│   │ ├─┬ @types/graceful-fs@4.1.9
│   │ │ └── @types/node@17.0.18 deduped
│   │ └── @types/node@17.0.18 deduped
│   ├─┬ jest-runner@29.7.0
│   │ └── @types/node@17.0.18 deduped
│   ├─┬ jest-runtime@29.7.0
│   │ └── @types/node@17.0.18 deduped
│   └─┬ jest-watcher@29.7.0
│     └── @types/node@17.0.18 deduped
└─┬ uniforms-bridge-simple-schema-2@4.0.0-alpha.6 -> ./packages/uniforms-bridge-simple-schema-2
  └─┬ @types/simpl-schema@1.12.7
    └─┬ @types/meteor@2.6.3
      ├─┬ @types/connect@3.4.35
      │ └── @types/node@17.0.18 deduped
      └─┬ mongodb@4.6.0
        └─┬ mongodb-connection-string-url@2.5.2
          └─┬ @types/whatwg-url@8.2.1
            └── @types/node@17.0.18 deduped
```
</details>

<details>
<summary>2. `AbortSignal` colliding declarations</summary>

```
../../node_modules/@types/node/globals.d.ts:72:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; any(signals: AbortSignal[]): AbortSignal; timeout(milliseconds: number): AbortSignal; }', but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.
uniforms:build:esm:
uniforms:build:esm: 72 declare var AbortSignal: {
uniforms:build:esm:                ~~~~~~~~~~~
uniforms:build:esm:
uniforms:build:esm:   ../../node_modules/typescript/lib/lib.dom.d.ts:2360:13
uniforms:build:esm:     2360 declare var AbortSignal: {
uniforms:build:esm:                      ~~~~~~~~~~~
uniforms:build:esm:     'AbortSignal' was also declared here.
uniforms:build:esm:
uniforms:build:esm:
uniforms:build:esm: Found 1 error.
uniforms:build:esm:
```
</details>

<details>
<summary>3. After installing `@types/node@18`, the `Model_1` doesn't exist</summary>

```
../uniforms/cjs/QuickForm.d.ts:14:32 - error TS2552: Cannot find name 'Model_1'. Did you mean 'Model'?
uniforms-bridge-simple-schema-2:build:esm:
uniforms-bridge-simple-schema-2:build:esm: 14             id?: BaseFormProps<Model_1>["id"];
uniforms-bridge-simple-schema-2:build:esm:                                   ~~~~~~~
uniforms-bridge-simple-schema-2:build:esm:
uniforms-bridge-simple-schema-2:build:esm: ../uniforms/cjs/QuickForm.d.ts:16:39 - error TS2552: Cannot find name 'Model_1'. Did you mean 'Model'?
```
</details>

<details>
<summary>4. After changing `id` and `noValidate` types to explicit types instead of referencing</summary>

```
../../node_modules/antd/lib/select/index.d.ts:14:69 - error TS2344: Type 'VT' does not satisfy the constraint 'DefaultValueType'.
uniforms-antd:build:cjs:   Type 'VT' is not assignable to type 'RawValueType[]'.
uniforms-antd:build:cjs:
uniforms-antd:build:cjs: 14 export interface InternalSelectProps<VT> extends Omit<RcSelectProps<VT>, 'mode'> {
uniforms-antd:build:cjs:                                                                        ~~
uniforms-antd:build:cjs:
uniforms-antd:build:cjs:   ../../node_modules/antd/lib/select/index.d.ts:14:38
uniforms-antd:build:cjs:     14 export interface InternalSelectProps<VT> extends Omit<RcSelectProps<VT>, 'mode'> {
uniforms-antd:build:cjs:                                             ~~
uniforms-antd:build:cjs:     This type parameter might need an `extends RawValueType[]` constraint.
uniforms-antd:build:cjs:   ../../node_modules/antd/lib/select/index.d.ts:14:38
uniforms-antd:build:cjs:     14 export interface InternalSelectProps<VT> extends Omit<RcSelectProps<VT>, 'mode'> {
uniforms-antd:build:cjs:                                             ~~
uniforms-antd:build:cjs:     This type parameter might need an `extends DefaultValueType` constraint.
uniforms-antd:build:cjs:
uniforms-antd:build:cjs:
uniforms-antd:build:cjs: Found 1 error.
uniforms-antd:build:cjs:
```
</details>

## Notes
TBH, I'm not confident about this one, but the build passes now.
Fixes #1369.