### PR TITLE
Update packages & changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [v4.0.0-beta.1](https://github.com/vazco/uniforms/tree/v4.0.0-beta.1) (2024-10-29)
+
+- **Breaking:** Update React to v18 & AntD to v5 [\#1376](https://github.com/vazco/uniforms/pull/1376)
+- **Fixed:** Removed setting initial value for enum types. [\#1354](https://github.com/vazco/uniforms/pull/1354)
+
+## [v4.0.0-alpha.6](https://github.com/vazco/uniforms/tree/v4.0.0-alpha.6) (2024-07-26)
+
+- **Breaking** Initialize model with default values [\#1343](https://github.com/vazco/uniforms/pull/1343)
+- **Breaking** Deprecate `uniforms-bootstrap3` package [\#1341](https://github.com/vazco/uniforms/pull/1341)
+- **Breaking** Deprecate `uniforms-bootstrap3` package [\#1338](https://github.com/vazco/uniforms/pull/1338)
+- **Breaking** Deprecate `uniforms-bridge-simple-schema` package [\#1323](https://github.com/vazco/uniforms/pull/1323)
+- **Breaking** Deprecate `uniforms-bridge-graphql` package [\#1322](https://github.com/vazco/uniforms/pull/1322)
+- **Added:** Extend `onChangeModel` - add details about what changed. [\#1363](https://github.com/vazco/uniforms/pull/1363)
+- **Added:** Blank `TextField` and `LongTextField` [\#1356](https://github.com/vazco/uniforms/pull/1356)
+- **Added** Passing props with Zod bridge [\#1321](https://github.com/vazco/uniforms/pull/1321)
+- **Added** Improve Zod messages [\#1320](https://github.com/vazco/uniforms/pull/1320)
+- **Added** Support for Zod `.refine` and `.superRefine` [\#1319](https://github.com/vazco/uniforms/pull/1319)
+- **Fixed** Update `BaseForm` types [\#1325](https://github.com/vazco/uniforms/pull/1325)
+- **Fixed** Compatibility with StrictMode [\#1324](https://github.com/vazco/uniforms/pull/1324)
+- **Fixed:** Optional array fields (Zod bridge) [\#1352](https://github.com/vazco/uniforms/pull/1352)
+
 ## [v4.0.0-alpha.5](https://github.com/vazco/uniforms/tree/v4.0.0-alpha.5) (2023-06-23)
 
 - **Breaking:** Unified the way of handling `label` and `placeholder`. [\#973](https://github.com/vazco/uniforms/issues/973)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - **Breaking** Initialize model with default values [\#1343](https://github.com/vazco/uniforms/pull/1343)
 - **Breaking** Deprecate `uniforms-bootstrap3` package [\#1341](https://github.com/vazco/uniforms/pull/1341)
-- **Breaking** Deprecate `uniforms-bootstrap3` package [\#1338](https://github.com/vazco/uniforms/pull/1338)
+- **Breaking** Deprecate `uniforms-material` package [\#1338](https://github.com/vazco/uniforms/pull/1338)
 - **Breaking** Deprecate `uniforms-bridge-simple-schema` package [\#1323](https://github.com/vazco/uniforms/pull/1323)
 - **Breaking** Deprecate `uniforms-bridge-graphql` package [\#1322](https://github.com/vazco/uniforms/pull/1322)
 - **Added:** Extend `onChangeModel` - add details about what changed. [\#1363](https://github.com/vazco/uniforms/pull/1363)

--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-antd",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -33,13 +33,13 @@
   ],
   "peerDependencies": {
     "antd": "^5.0.0",
-    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
+    "uniforms": "4.0.0-beta.1"
   },
   "dependencies": {
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
     "lodash": "^4.0.0",
-    "uniforms": "^4.0.0-alpha.6",
     "warning": "^4.0.0"
   },
   "devDependencies": {
@@ -53,6 +53,7 @@
     "rc-input-number": "^9.2.0",
     "tslib": "2.2.0",
     "typescript": "5.5.4",
+    "uniforms": "workspace:*",
     "zod": "^3.0.0"
   },
   "scripts": {

--- a/packages/uniforms-bootstrap4/package.json
+++ b/packages/uniforms-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bootstrap4",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -28,13 +28,13 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
+    "uniforms": "4.0.0-beta.1"
   },
   "dependencies": {
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
     "lodash": "^4.0.0",
-    "uniforms": "^4.0.0-alpha.6",
     "warning": "^4.0.0"
   },
   "devDependencies": {
@@ -43,6 +43,7 @@
     "@types/react": "18.3.12",
     "tslib": "2.2.0",
     "typescript": "5.5.4",
+    "uniforms": "workspace:*",
     "zod": "^3.0.0"
   },
   "scripts": {

--- a/packages/uniforms-bootstrap5/package.json
+++ b/packages/uniforms-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bootstrap5",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -28,13 +28,13 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
+    "uniforms": "4.0.0-beta.1"
   },
   "dependencies": {
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
     "lodash": "^4.0.0",
-    "uniforms": "^4.0.0-alpha.6",
     "warning": "^4.0.0"
   },
   "devDependencies": {
@@ -43,6 +43,7 @@
     "@types/react": "18.3.12",
     "tslib": "2.2.0",
     "typescript": "5.5.4",
+    "uniforms": "workspace:*",
     "zod": "^3.0.0"
   },
   "scripts": {

--- a/packages/uniforms-bridge-json-schema/package.json
+++ b/packages/uniforms-bridge-json-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bridge-json-schema",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -32,16 +32,19 @@
     "src/*.ts",
     "src/*.tsx"
   ],
+  "peerDependencies": {
+    "uniforms": "4.0.0-beta.1"
+  },
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0",
-    "uniforms": "4.0.0-alpha.6"
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "tslib": "2.2.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "uniforms": "workspace:*"
   },
   "scripts": {
     "build:cjs": "tsc --build tsconfig.cjs.json",

--- a/packages/uniforms-bridge-simple-schema-2/package.json
+++ b/packages/uniforms-bridge-simple-schema-2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bridge-simple-schema-2",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -34,11 +34,11 @@
   ],
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0",
-    "uniforms": "4.0.0-alpha.6"
+    "lodash": "^4.0.0"
   },
   "peerDependencies": {
-    "simpl-schema": "^1.0.0 || ^0.0.4"
+    "simpl-schema": "^1.0.0 || ^0.0.4",
+    "uniforms": "4.0.0-beta.1"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
@@ -46,7 +46,8 @@
     "@types/react": "18.3.12",
     "@types/simpl-schema": "1.12.7",
     "tslib": "2.2.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "uniforms": "workspace:*"
   },
   "scripts": {
     "build:cjs": "tsc --build tsconfig.cjs.json",

--- a/packages/uniforms-bridge-zod/package.json
+++ b/packages/uniforms-bridge-zod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bridge-zod",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -34,17 +34,18 @@
   ],
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0",
-    "uniforms": "4.0.0-alpha.6"
+    "lodash": "^4.0.0"
   },
   "peerDependencies": {
-    "zod": "^3.0.0"
+    "zod": "^3.0.0",
+    "uniforms": "4.0.0-beta.1"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "tslib": "2.2.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "uniforms": "workspace:*"
   },
   "scripts": {
     "build:cjs": "tsc --build tsconfig.cjs.json",

--- a/packages/uniforms-mui/package.json
+++ b/packages/uniforms-mui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-mui",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -31,12 +31,12 @@
   ],
   "peerDependencies": {
     "@mui/material": "^5.0.0",
-    "react": "^18.0.0 || ^17.0.0"
+    "react": "^18.0.0 || ^17.0.0",
+    "uniforms": "4.0.0-beta.1"
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0",
-    "uniforms": "4.0.0-alpha.6"
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "@emotion/react": "11.7.1",
@@ -46,6 +46,7 @@
     "@types/react": "18.3.12",
     "tslib": "2.2.0",
     "typescript": "5.5.4",
+    "uniforms": "workspace:*",
     "zod": "^3.0.0"
   },
   "scripts": {

--- a/packages/uniforms-semantic/package.json
+++ b/packages/uniforms-semantic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-semantic",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -28,13 +28,13 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
+    "uniforms": "4.0.0-beta.1"
   },
   "dependencies": {
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0",
-    "uniforms": "4.0.0-alpha.6"
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
@@ -42,6 +42,7 @@
     "@types/react": "18.3.12",
     "tslib": "2.2.0",
     "typescript": "5.5.4",
+    "uniforms": "workspace:*",
     "zod": "^3.0.0"
   },
   "scripts": {

--- a/packages/uniforms-unstyled/package.json
+++ b/packages/uniforms-unstyled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-unstyled",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -27,19 +27,20 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "react": "^18.0.0 || ^17.0.0 || ^16.8.0"
+    "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
+    "uniforms": "4.0.0-beta.1"
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0",
-    "uniforms": "4.0.0-alpha.6"
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "@types/react": "18.3.12",
     "tslib": "2.2.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "uniforms": "workspace:*"
   },
   "scripts": {
     "build:cjs": "tsc --build tsconfig.cjs.json",

--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-beta.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
-      uniforms:
-        specifier: ^4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
       warning:
         specifier: ^4.0.0
         version: 4.0.3
@@ -160,6 +157,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -178,9 +178,6 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
-      uniforms:
-        specifier: ^4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
       warning:
         specifier: ^4.0.0
         version: 4.0.3
@@ -200,6 +197,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -218,9 +218,6 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
-      uniforms:
-        specifier: ^4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
       warning:
         specifier: ^4.0.0
         version: 4.0.3
@@ -240,6 +237,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -252,9 +252,6 @@ importers:
       lodash:
         specifier: ^4.0.0
         version: 4.17.21
-      uniforms:
-        specifier: 4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -268,6 +265,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
 
   packages/uniforms-bridge-simple-schema-2:
     dependencies:
@@ -280,9 +280,6 @@ importers:
       simpl-schema:
         specifier: ^1.0.0 || ^0.0.4
         version: 1.13.1
-      uniforms:
-        specifier: 4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -302,6 +299,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
 
   packages/uniforms-bridge-zod:
     dependencies:
@@ -311,9 +311,6 @@ importers:
       lodash:
         specifier: ^4.0.0
         version: 4.17.21
-      uniforms:
-        specifier: 4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -330,6 +327,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
 
   packages/uniforms-mui:
     dependencies:
@@ -345,9 +345,6 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0
         version: 18.3.1
-      uniforms:
-        specifier: 4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
     devDependencies:
       '@emotion/react':
         specifier: 11.7.1
@@ -370,6 +367,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -388,9 +388,6 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
-      uniforms:
-        specifier: 4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -407,6 +404,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -422,9 +422,6 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
-      uniforms:
-        specifier: 4.0.0-alpha.6
-        version: 4.0.0-alpha.6(react@18.3.1)
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -441,6 +438,9 @@ importers:
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      uniforms:
+        specifier: workspace:*
+        version: link:../uniforms
 
   reproductions:
     dependencies:
@@ -5212,11 +5212,6 @@ packages:
   unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
 
-  uniforms@4.0.0-alpha.6:
-    resolution: {integrity: sha512-j6OeGfw1h1HUztB/C1LMI5GENVFCqLXdBpr3P2ZtbpWHErAEVFjr7MQz4FSKwbW47mXbr6dKRPGVmtk7OkkRNQ==}
-    peerDependencies:
-      react: ^18.0.0 || ^17.0.0 || ^16.8.0
-
   unist-util-find-all-after@3.0.2:
     resolution: {integrity: sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==}
 
@@ -6648,15 +6643,13 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)':
+  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.13)
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/logger': 2.12.0
       '@parcel/utils': 2.12.0
       lmdb: 2.8.5
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@parcel/codeframe@2.12.0':
     dependencies:
@@ -6716,7 +6709,7 @@ snapshots:
   '@parcel/core@2.12.0(@swc/helpers@0.5.13)':
     dependencies:
       '@mischnic/json-sourcemap': 0.1.1
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/diagnostic': 2.12.0
       '@parcel/events': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
@@ -6729,7 +6722,7 @@ snapshots:
       '@parcel/source-map': 2.1.1
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       abortcontroller-polyfill: 1.7.5
       base-x: 3.0.10
       browserslist: 4.24.2
@@ -6757,7 +6750,7 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
       '@parcel/watcher': 2.4.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -6831,7 +6824,7 @@ snapshots:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/rust': 2.12.0
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
 
   '@parcel/optimizer-svgo@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))':
     dependencies:
@@ -6863,7 +6856,7 @@ snapshots:
       '@parcel/node-resolver-core': 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@swc/core': 1.7.40(@swc/helpers@0.5.13)
       semver: 7.6.3
     transitivePeerDependencies:
@@ -7052,7 +7045,7 @@ snapshots:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.13)
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       nullthrows: 1.1.1
 
   '@parcel/transformer-js@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))':
@@ -7063,7 +7056,7 @@ snapshots:
       '@parcel/rust': 2.12.0
       '@parcel/source-map': 2.1.1
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@swc/helpers': 0.5.13
       browserslist: 4.24.2
       nullthrows: 1.1.1
@@ -7131,12 +7124,12 @@ snapshots:
 
   '@parcel/types@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)':
     dependencies:
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/diagnostic': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/source-map': 2.1.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       utility-types: 3.11.0
     transitivePeerDependencies:
       - '@parcel/core'
@@ -7209,7 +7202,7 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
 
-  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)':
+  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.13)
       '@parcel/diagnostic': 2.12.0
@@ -7218,8 +7211,6 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
       nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@pkgr/core@0.1.1': {}
 
@@ -11680,13 +11671,6 @@ snapshots:
       is-plain-obj: 2.1.0
       trough: 1.0.5
       vfile: 4.2.1
-
-  uniforms@4.0.0-alpha.6(react@18.3.1):
-    dependencies:
-      invariant: 2.2.4
-      lodash: 4.17.21
-      react: 18.3.1
-      tslib: 2.2.0
 
   unist-util-find-all-after@3.0.2:
     dependencies:


### PR DESCRIPTION
- Updated uniforms packages to `4.0.0-beta.1`
- Moved `uniforms` from `dependencies` to `peerDependencies`. Added also workspace version to `devDependencies` for pnpm
- Updated changelog with latest changes
- Updated changelog with missing `4.0.0-alpha.6` version changes