### PR TITLE
Fix `tslib` issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v4.0.0-beta.2](https://github.com/vazco/uniforms/tree/v4.0.0-beta.2) (2024-10-29)
+
+- **Fixed:** Fixed `tslib` issue [\#1378](https://github.com/vazco/uniforms/pull/1378)
+
 ## [v4.0.0-beta.1](https://github.com/vazco/uniforms/tree/v4.0.0-beta.1) (2024-10-29)
 
 - **Breaking:** Update React to v18 & AntD to v5 [\#1376](https://github.com/vazco/uniforms/pull/1376)

--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -40,7 +40,8 @@
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
     "lodash": "^4.0.0",
-    "warning": "^4.0.0"
+    "warning": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@ant-design/icons": "^5.0.0",
@@ -51,7 +52,6 @@
     "dayjs": "^1.11.13",
     "simpl-schema": "1.13.1",
     "rc-input-number": "^9.2.0",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*",
     "zod": "^3.0.0"

--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-antd",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "antd": "^5.0.0",
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-bootstrap4/package.json
+++ b/packages/uniforms-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bootstrap4",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -29,7 +29,7 @@
   ],
   "peerDependencies": {
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-bootstrap4/package.json
+++ b/packages/uniforms-bootstrap4/package.json
@@ -35,13 +35,13 @@
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
     "lodash": "^4.0.0",
-    "warning": "^4.0.0"
+    "warning": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "@types/react": "18.3.12",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*",
     "zod": "^3.0.0"

--- a/packages/uniforms-bootstrap5/package.json
+++ b/packages/uniforms-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bootstrap5",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -29,7 +29,7 @@
   ],
   "peerDependencies": {
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-bootstrap5/package.json
+++ b/packages/uniforms-bootstrap5/package.json
@@ -35,13 +35,13 @@
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
     "lodash": "^4.0.0",
-    "warning": "^4.0.0"
+    "warning": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "@types/react": "18.3.12",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*",
     "zod": "^3.0.0"

--- a/packages/uniforms-bridge-json-schema/package.json
+++ b/packages/uniforms-bridge-json-schema/package.json
@@ -37,12 +37,12 @@
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*"
   },

--- a/packages/uniforms-bridge-json-schema/package.json
+++ b/packages/uniforms-bridge-json-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bridge-json-schema",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -33,7 +33,7 @@
     "src/*.tsx"
   ],
   "peerDependencies": {
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {
     "invariant": "^2.0.0",

--- a/packages/uniforms-bridge-simple-schema-2/package.json
+++ b/packages/uniforms-bridge-simple-schema-2/package.json
@@ -34,7 +34,8 @@
   ],
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "peerDependencies": {
     "simpl-schema": "^1.0.0 || ^0.0.4",
@@ -45,7 +46,6 @@
     "@types/lodash": "4.17.5",
     "@types/react": "18.3.12",
     "@types/simpl-schema": "1.12.7",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*"
   },

--- a/packages/uniforms-bridge-simple-schema-2/package.json
+++ b/packages/uniforms-bridge-simple-schema-2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bridge-simple-schema-2",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "simpl-schema": "^1.0.0 || ^0.0.4",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",

--- a/packages/uniforms-bridge-zod/package.json
+++ b/packages/uniforms-bridge-zod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-bridge-zod",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "zod": "^3.0.0",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",

--- a/packages/uniforms-bridge-zod/package.json
+++ b/packages/uniforms-bridge-zod/package.json
@@ -34,7 +34,8 @@
   ],
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "peerDependencies": {
     "zod": "^3.0.0",
@@ -43,7 +44,6 @@
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*"
   },

--- a/packages/uniforms-mui/package.json
+++ b/packages/uniforms-mui/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@emotion/react": "11.7.1",
@@ -44,7 +45,6 @@
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "@types/react": "18.3.12",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*",
     "zod": "^3.0.0"

--- a/packages/uniforms-mui/package.json
+++ b/packages/uniforms-mui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-mui",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@mui/material": "^5.0.0",
     "react": "^18.0.0 || ^17.0.0",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {
     "invariant": "^2.0.0",

--- a/packages/uniforms-semantic/package.json
+++ b/packages/uniforms-semantic/package.json
@@ -34,13 +34,13 @@
   "dependencies": {
     "classnames": "^2.0.0",
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "@types/react": "18.3.12",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*",
     "zod": "^3.0.0"

--- a/packages/uniforms-semantic/package.json
+++ b/packages/uniforms-semantic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-semantic",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -29,7 +29,7 @@
   ],
   "peerDependencies": {
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {
     "classnames": "^2.0.0",

--- a/packages/uniforms-unstyled/package.json
+++ b/packages/uniforms-unstyled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-unstyled",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
@@ -28,7 +28,7 @@
   ],
   "peerDependencies": {
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "uniforms": "4.0.0-beta.1"
+    "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {
     "invariant": "^2.0.0",

--- a/packages/uniforms-unstyled/package.json
+++ b/packages/uniforms-unstyled/package.json
@@ -32,13 +32,13 @@
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.5",
     "@types/react": "18.3.12",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "uniforms": "workspace:*"
   },

--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",

--- a/packages/uniforms/package.json
+++ b/packages/uniforms/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "invariant": "^2.0.0",
-    "lodash": "^4.0.0"
+    "lodash": "^4.0.0",
+    "tslib": "2.8.0"
   },
   "devDependencies": {
     "@types/invariant": "2.2.37",
@@ -47,7 +48,6 @@
     "@types/simpl-schema": "1.12.8",
     "moment": "2.30.1",
     "simpl-schema": "1.13.1",
-    "tslib": "2.2.0",
     "typescript": "5.5.4",
     "zod": "^3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -96,9 +99,6 @@ importers:
       simpl-schema:
         specifier: 1.13.1
         version: 1.13.1
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -123,6 +123,9 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
       warning:
         specifier: ^4.0.0
         version: 4.0.3
@@ -151,9 +154,6 @@ importers:
       simpl-schema:
         specifier: 1.13.1
         version: 1.13.1
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -178,6 +178,9 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
       warning:
         specifier: ^4.0.0
         version: 4.0.3
@@ -191,9 +194,6 @@ importers:
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -218,6 +218,9 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
       warning:
         specifier: ^4.0.0
         version: 4.0.3
@@ -231,9 +234,6 @@ importers:
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -252,6 +252,9 @@ importers:
       lodash:
         specifier: ^4.0.0
         version: 4.17.21
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -259,9 +262,6 @@ importers:
       '@types/lodash':
         specifier: 4.17.5
         version: 4.17.5
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -280,6 +280,9 @@ importers:
       simpl-schema:
         specifier: ^1.0.0 || ^0.0.4
         version: 1.13.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -293,9 +296,6 @@ importers:
       '@types/simpl-schema':
         specifier: 1.12.7
         version: 1.12.7(@aws-sdk/client-sso-oidc@3.679.0(@aws-sdk/client-sts@3.679.0))
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -311,6 +311,9 @@ importers:
       lodash:
         specifier: ^4.0.0
         version: 4.17.21
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -321,9 +324,6 @@ importers:
       '@types/lodash':
         specifier: 4.17.5
         version: 4.17.5
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -345,6 +345,9 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0
         version: 18.3.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
     devDependencies:
       '@emotion/react':
         specifier: 11.7.1
@@ -361,9 +364,6 @@ importers:
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -388,6 +388,9 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -398,9 +401,6 @@ importers:
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -422,6 +422,9 @@ importers:
       react:
         specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
         version: 18.3.1
+      tslib:
+        specifier: 2.8.0
+        version: 2.8.0
     devDependencies:
       '@types/invariant':
         specifier: 2.2.37
@@ -432,9 +435,6 @@ importers:
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
-      tslib:
-        specifier: 2.2.0
-        version: 2.2.0
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -5110,9 +5110,6 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
-
-  tslib@2.2.0:
-    resolution: {integrity: sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==}
 
   tslib@2.8.0:
     resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
@@ -11140,7 +11137,7 @@ snapshots:
 
   rxjs@7.8.1:
     dependencies:
-      tslib: 2.2.0
+      tslib: 2.8.0
 
   safe-array-concat@1.1.2:
     dependencies:
@@ -11567,8 +11564,6 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
-
-  tslib@2.2.0: {}
 
   tslib@2.8.0: {}
 


### PR DESCRIPTION
During a major monorepo refactoring, `tslib` was moved to `devDependencies`, but it should be in the `dependencies`. It causes issue after installing new `4.0.0-beta.1` version. 

```sh
✘ [ERROR] Could not resolve "tslib"
  node_modules/uniforms-unstyled/esm/RadioField.js:1:23:
    1 │ import { __rest } from "tslib";
```

### Changes
- Updated changelog
- Updated uniforms versions to `4.0.0-beta.2`
- Moved `tslib` to `dependencies`
- Updated `tslib` to `2.8.0`