### PR TITLE
Updated supported version of React in AntD theme

### DIFF
--- a/packages/uniforms-antd/package.json
+++ b/packages/uniforms-antd/package.json
@@ -33,7 +33,7 @@
   ],
   "peerDependencies": {
     "antd": "^5.0.0",
-    "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
+    "react": "^18.0.0 || ^17.0.0 || ^16.9.0",
     "uniforms": "4.0.0-beta.2"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
         specifier: ^4.0.0
         version: 4.17.21
       react:
-        specifier: ^18.0.0 || ^17.0.0 || ^16.8.0
+        specifier: ^18.0.0 || ^17.0.0 || ^16.9.0
         version: 18.3.1
       tslib:
         specifier: 2.8.0


### PR DESCRIPTION
Minimum supported React version in AntD is `16.9.0` ([link](https://github.com/ant-design/ant-design/blob/3f8943e2744f41f6c1434225b8f72d2813b1b722/package.json#L104)). In this pull request, I updated `peerDependencies` to change `16.8.0` to `16.9.0`. 