### PR TITLE
Empty string if text field is empty instead of undefined

### DIFF
--- a/packages/uniforms-antd/src/LongTextField.tsx
+++ b/packages/uniforms-antd/src/LongTextField.tsx
@@ -17,11 +17,7 @@ function LongText({ rows = 5, ...props }: LongTextFieldProps) {
     <TextArea
       disabled={props.disabled}
       name={props.name}
-      onChange={event =>
-        props.onChange(
-          event.target.value === '' ? undefined : event.target.value,
-        )
-      }
+      onChange={event => props.onChange(event.target.value)}
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-antd/src/TextField.tsx
+++ b/packages/uniforms-antd/src/TextField.tsx
@@ -16,11 +16,7 @@ function Text(props: TextFieldProps) {
     <Input
       disabled={props.disabled}
       name={props.name}
-      onChange={event =>
-        props.onChange(
-          event.target.value === '' ? undefined : event.target.value,
-        )
-      }
+      onChange={event => props.onChange(event.target.value)}
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-bootstrap4/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap4/src/LongTextField.tsx
@@ -21,11 +21,7 @@ function LongText(props: LongTextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event =>
-        props.onChange(
-          event.target.value === '' ? undefined : event.target.value,
-        )
-      }
+      onChange={event => props.onChange(event.target.value)}
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-bootstrap4/src/TextField.tsx
+++ b/packages/uniforms-bootstrap4/src/TextField.tsx
@@ -23,11 +23,7 @@ function Text(props: TextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event =>
-        props.onChange(
-          event.target.value === '' ? undefined : event.target.value,
-        )
-      }
+      onChange={event => props.onChange(event.target.value)}
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={props.inputRef}

--- a/packages/uniforms-bootstrap5/src/LongTextField.tsx
+++ b/packages/uniforms-bootstrap5/src/LongTextField.tsx
@@ -22,11 +22,7 @@ function LongText(props: LongTextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event =>
-        props.onChange(
-          event.target.value === '' ? undefined : event.target.value,
-        )
-      }
+      onChange={event => props.onChange(event.target.value)}
       placeholder={props.placeholder}
       minLength={props.minLength}
       maxLength={props.maxLength}

--- a/packages/uniforms-bootstrap5/src/TextField.tsx
+++ b/packages/uniforms-bootstrap5/src/TextField.tsx
@@ -23,11 +23,7 @@ function Text(props: TextFieldProps) {
       disabled={props.disabled}
       id={props.id}
       name={props.name}
-      onChange={event =>
-        props.onChange(
-          event.target.value === '' ? undefined : event.target.value,
-        )
-      }
+      onChange={event => props.onChange(event.target.value)}
       placeholder={props.placeholder}
       minLength={props.minLength}
       maxLength={props.maxLength}

--- a/packages/uniforms-mui/src/LongTextField.tsx
+++ b/packages/uniforms-mui/src/LongTextField.tsx
@@ -31,10 +31,7 @@ const LongText = ({
       margin="dense"
       multiline
       name={name}
-      onChange={event =>
-        disabled ||
-        onChange(event.target.value === '' ? undefined : event.target.value)
-      }
+      onChange={event => disabled || onChange(event.target.value)}
       placeholder={placeholder}
       ref={inputRef}
       type={type}

--- a/packages/uniforms-mui/src/TextField.tsx
+++ b/packages/uniforms-mui/src/TextField.tsx
@@ -32,10 +32,7 @@ function Text({
       label={label}
       margin="dense"
       name={name}
-      onChange={event =>
-        disabled ||
-        onChange(event.target.value === '' ? undefined : event.target.value)
-      }
+      onChange={event => disabled || onChange(event.target.value)}
       placeholder={placeholder}
       ref={inputRef}
       type={type}

--- a/packages/uniforms-semantic/src/LongTextField.tsx
+++ b/packages/uniforms-semantic/src/LongTextField.tsx
@@ -36,9 +36,7 @@ function LongText({
         disabled={disabled}
         id={id}
         name={name}
-        onChange={event =>
-          onChange(event.target.value === '' ? undefined : event.target.value)
-        }
+        onChange={event => onChange(event.target.value)}
         placeholder={placeholder}
         readOnly={readOnly}
         ref={inputRef}

--- a/packages/uniforms-semantic/src/TextField.tsx
+++ b/packages/uniforms-semantic/src/TextField.tsx
@@ -57,9 +57,7 @@ function Text({
           disabled={disabled}
           id={id}
           name={name}
-          onChange={event =>
-            onChange(event.target.value === '' ? undefined : event.target.value)
-          }
+          onChange={event => onChange(event.target.value)}
           placeholder={placeholder}
           readOnly={readOnly}
           ref={inputRef}

--- a/packages/uniforms-unstyled/src/LongTextField.tsx
+++ b/packages/uniforms-unstyled/src/LongTextField.tsx
@@ -27,9 +27,7 @@ function LongText({
         disabled={disabled}
         id={id}
         name={name}
-        onChange={event =>
-          onChange(event.target.value === '' ? undefined : event.target.value)
-        }
+        onChange={event => onChange(event.target.value)}
         placeholder={placeholder}
         readOnly={readOnly}
         ref={inputRef}

--- a/packages/uniforms-unstyled/src/TextField.tsx
+++ b/packages/uniforms-unstyled/src/TextField.tsx
@@ -30,9 +30,7 @@ function Text({
         disabled={disabled}
         id={id}
         name={name}
-        onChange={event =>
-          onChange(event.target.value === '' ? undefined : event.target.value)
-        }
+        onChange={event => onChange(event.target.value)}
         placeholder={placeholder}
         readOnly={readOnly}
         ref={inputRef}

--- a/packages/uniforms/__suites__/LongTextField.tsx
+++ b/packages/uniforms/__suites__/LongTextField.tsx
@@ -110,7 +110,7 @@ export function testLongTextField(
       schema: z.object({ x: z.string() }),
     });
     await userEvent.type(screen.getByRole('textbox'), '{Backspace}');
-    expect(onChange).toHaveBeenLastCalledWith('x', undefined);
+    expect(onChange).toHaveBeenLastCalledWith('x', '');
   });
 
   test('<LongTextField> - renders a label', () => {

--- a/packages/uniforms/__suites__/TextField.tsx
+++ b/packages/uniforms/__suites__/TextField.tsx
@@ -148,7 +148,7 @@ export function testTextField(
       schema: z.object({ x: z.string() }),
     });
     await userEvent.type(screen.getByRole('textbox'), '{Backspace}');
-    expect(onChange).toHaveBeenLastCalledWith('x', undefined);
+    expect(onChange).toHaveBeenLastCalledWith('x', '');
   });
 
   test('<TextField> - renders a label', () => {


### PR DESCRIPTION
- reverted change introduced during alpha/beta of uniforms v4
- we should also consider removing `undefined` from `NumField` and other fields